### PR TITLE
added max_size parameter to PI grp_create

### DIFF
--- a/include/PI/pi_act_prof.h
+++ b/include/PI/pi_act_prof.h
@@ -36,6 +36,7 @@ pi_status_t pi_act_prof_mbr_modify(pi_session_handle_t session_handle,
 pi_status_t pi_act_prof_grp_create(pi_session_handle_t session_handle,
                                    pi_dev_tgt_t dev_tgt,
                                    pi_p4_id_t act_prof_id,
+                                   size_t max_size,
                                    pi_indirect_handle_t *grp_handle);
 
 pi_status_t pi_act_prof_grp_delete(pi_session_handle_t session_handle,

--- a/include/PI/target/pi_act_prof_imp.h
+++ b/include/PI/target/pi_act_prof_imp.h
@@ -36,6 +36,7 @@ pi_status_t _pi_act_prof_mbr_modify(pi_session_handle_t session_handle,
 pi_status_t _pi_act_prof_grp_create(pi_session_handle_t session_handle,
                                     pi_dev_tgt_t dev_tgt,
                                     pi_p4_id_t act_prof_id,
+                                    size_t max_size,
                                     pi_indirect_handle_t *grp_handle);
 
 pi_status_t _pi_act_prof_grp_delete(pi_session_handle_t session_handle,

--- a/src/pi_act_prof.c
+++ b/src/pi_act_prof.c
@@ -45,9 +45,10 @@ pi_status_t pi_act_prof_mbr_modify(pi_session_handle_t session_handle,
 pi_status_t pi_act_prof_grp_create(pi_session_handle_t session_handle,
                                    pi_dev_tgt_t dev_tgt,
                                    pi_p4_id_t act_prof_id,
+                                   size_t max_size,
                                    pi_indirect_handle_t *grp_handle) {
   return _pi_act_prof_grp_create(session_handle, dev_tgt, act_prof_id,
-                                 grp_handle);
+                                 max_size, grp_handle);
 }
 
 pi_status_t pi_act_prof_grp_delete(pi_session_handle_t session_handle,

--- a/targets/bmv2/pi_act_prof_imp.cpp
+++ b/targets/bmv2/pi_act_prof_imp.cpp
@@ -137,8 +137,10 @@ pi_status_t _pi_act_prof_mbr_modify(pi_session_handle_t session_handle,
 pi_status_t _pi_act_prof_grp_create(pi_session_handle_t session_handle,
                                     pi_dev_tgt_t dev_tgt,
                                     pi_p4_id_t act_prof_id,
+                                    size_t max_size,
                                     pi_indirect_handle_t *grp_handle) {
   (void) session_handle;
+  (void) max_size;  // no bound needed / supported in bmv2
 
   pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(d_info->assigned);

--- a/targets/dummy/pi_act_prof_imp.c
+++ b/targets/dummy/pi_act_prof_imp.c
@@ -51,8 +51,10 @@ pi_status_t _pi_act_prof_mbr_modify(pi_session_handle_t session_handle,
 pi_status_t _pi_act_prof_grp_create(pi_session_handle_t session_handle,
                                     pi_dev_tgt_t dev_tgt,
                                     pi_p4_id_t act_prof_id,
+                                    size_t max_size,
                                     pi_indirect_handle_t *grp_handle) {
-  (void) session_handle; (void) dev_tgt; (void) act_prof_id; (void) grp_handle;
+  (void) session_handle; (void) dev_tgt; (void) act_prof_id; (void) max_size;
+  (void) grp_handle;
   printf("%s\n", __func__);
   return PI_STATUS_SUCCESS;
 }

--- a/targets/rpc/pi_act_prof_imp.c
+++ b/targets/rpc/pi_act_prof_imp.c
@@ -87,8 +87,10 @@ pi_status_t _pi_act_prof_mbr_modify(pi_session_handle_t session_handle,
 pi_status_t _pi_act_prof_grp_create(pi_session_handle_t session_handle,
                                     pi_dev_tgt_t dev_tgt,
                                     pi_p4_id_t act_prof_id,
+                                    size_t max_size,
                                     pi_indirect_handle_t *grp_handle) {
-  (void) session_handle; (void) dev_tgt; (void) act_prof_id; (void) grp_handle;
+  (void) session_handle; (void) dev_tgt; (void) act_prof_id; (void) max_size;
+  (void) grp_handle;
   printf("%s\n", __func__);
   return PI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
- this seems like a reasonable thing to add and may be needed by some targets
- we could imagine standardizing that `0` means "as big as you can"
- maybe we will introduce a properties parameter instead, similar to what we have for match tables
