### PR TITLE
Silence compiler warnings locally for Judy macros

### DIFF
--- a/CLI/main.c
+++ b/CLI/main.c
@@ -178,7 +178,12 @@ static void init_cmd_map() {
 
 static void cleanup() {
   Word_t bytes;
+  // there is code in Judy headers that raises a warning with some compiler
+  // versions
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wsign-compare"
   JSLFA(bytes, J_cmd_name_map);
+#pragma GCC diagnostic pop
 
   if (is_device_selected) pi_remove_device(dev_tgt.dev_id);
 

--- a/CLI/p4_config_repo.c
+++ b/CLI/p4_config_repo.c
@@ -60,5 +60,10 @@ void p4_config_cleanup() {
     JLN(p4info_ptr, repo, index);
   }
   Word_t cnt;
+  // there is code in Judy headers that raises a warning with some compiler
+  // versions
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wsign-compare"
   JLFA(cnt, repo);
+#pragma GCC diagnostic pop
 }

--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -167,7 +167,12 @@ static pi_status_t read_fields(cJSON *root, pi_p4info_t *p4info) {
   }
 
   Word_t Rc_word;
+  // there is code in Judy headers that raises a warning with some compiler
+  // versions
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wsign-compare"
   JSLFA(Rc_word, header_type_map);
+#pragma GCC diagnostic pop
 
   return PI_STATUS_SUCCESS;
 }

--- a/src/p4info/p4info_name_map.c
+++ b/src/p4info/p4info_name_map.c
@@ -38,5 +38,10 @@ pi_p4_id_t p4info_name_map_get(const p4info_name_map_t *map, const char *name) {
 
 void p4info_name_map_destroy(p4info_name_map_t *map) {
   Word_t Rc_word;
+  // there is code in Judy headers that raises a warning with some compiler
+  // versions
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wsign-compare"
   JSLFA(Rc_word, *map);
+#pragma GCC diagnostic pop
 }

--- a/tests/test_p4info.c
+++ b/tests/test_p4info.c
@@ -352,7 +352,10 @@ void gen_rand_ids(pi_p4_id_t *ids, pi_p4_id_t max, size_t num) {
     ids[i] = v;
   }
   Word_t Rc_word;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wsign-compare"
   J1FA(Rc_word, set);
+#pragma GCC diagnostic pop
 }
 
 TEST(P4Info, TablesStress) {


### PR DESCRIPTION
Some compilers complain (Wsign-compare) for some of libJudy macros:
J1FA, JLFA, JSLFA. I had to take care of all invocations of these
macros. May have to abstract away Judy to clean this up later on.
