### PR TITLE
Add options with-cli and with-internal-rpc

### DIFF
--- a/CLI/Makefile.am
+++ b/CLI/Makefile.am
@@ -38,8 +38,7 @@ libpicli.la \
 $(top_builddir)/src/libpi.la \
 $(top_builddir)/src/libpifegeneric.la \
 $(top_builddir)/src/libpip4info.la \
-$(top_builddir)/lib/libpitoolkit.la \
--lnanomsg
+$(top_builddir)/lib/libpitoolkit.la
 
 pi_CLI_dummy_LDADD = $(common_libs) \
 $(top_builddir)/targets/dummy/libpi_dummy.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,15 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
+if WITH_CLI
+MAYBE_CLI = CLI
+endif
+
 if WITH_PROTO
 MAYBE_PROTO = proto
 endif
 
 # examples need to come after generators!
-SUBDIRS = third_party lib include src generators targets CLI examples bin \
-tests $(MAYBE_PROTO) frontends_extra
+SUBDIRS = third_party lib include src generators targets $(MAYBE_CLI) examples \
+bin tests $(MAYBE_PROTO) frontends_extra
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-bmv2 --with-fe-cpp

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -12,6 +12,7 @@ $(top_builddir)/src/libpip4info.la
 
 # This is the rpc server for bmv2
 if WITH_BMV2
+if WITH_INTERNAL_RPC
 bin_PROGRAMS += pi_rpc_server
 
 pi_rpc_server_SOURCES = rpc_server.c
@@ -20,9 +21,9 @@ pi_rpc_server_LDADD = \
 $(top_builddir)/src/libpi.la \
 $(top_builddir)/src/libpip4info.la \
 $(top_builddir)/targets/bmv2/libpi_bmv2.la \
--lnanomsg \
 -lthrift -lruntimestubs -lsimpleswitch_thrift
 
 # Dummy C++ source to cause C++ linking.
 nodist_EXTRA_pi_rpc_server_SOURCES = dummy.cxx
+endif
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,19 @@ AM_CONDITIONAL([WITH_FE_CPP], [test "$want_fe_cpp" = yes])
 
 AM_CONDITIONAL([WITH_PROTO], [test "$with_proto" = yes])
 
+AC_ARG_WITH([internal-rpc],
+    AS_HELP_STRING([--with-internal-rpc],
+                   [Build internal rpc (nanomsg) code @<:@default=yes@:>@]),
+    [with_internal_rpc="$withval"], [with_internal_rpc=yes])
+
+AM_CONDITIONAL([WITH_INTERNAL_RPC], [test "$with_internal_rpc" = yes])
+
+AC_ARG_WITH([cli],
+    AS_HELP_STRING([--with-cli], [Build PI C CLI @<:@default=yes@:>@]),
+    [with_cli="$withval"], [with_cli=yes])
+
+AM_CONDITIONAL([WITH_CLI], [test "$with_cli" = yes])
+
 LT_INIT
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -70,8 +83,11 @@ AS_IF([test "$want_bmv2" = yes], [
                    we won't run the tests requiring simple_switch])], [
       simple_switch_found=yes])
 ])
-AM_CONDITIONAL([WITH_SIMPLE_SWITCH], [test "$simple_switch_found" = "yes"])
-AM_CONDITIONAL([WITH_CLI_TESTS], [test "$simple_switch_found" = "yes"])
+AM_CONDITIONAL([WITH_SIMPLE_SWITCH], [test "$simple_switch_found" = yes])
+AM_CONDITIONAL([WITH_CLI_TESTS],
+               [test "$with_cli" = yes\
+                && test "$simple_switch_found" = yes\
+                && test "$with_internal_rpc" = yes])
 
 AC_CHECK_HEADERS([stdlib.h string.h assert.h stdio.h stdint.h stdbool.h\
                   stddef.h time.h ctype.h unistd.h arpa/inet.h\
@@ -107,7 +123,14 @@ AC_PREPROC_IFELSE(
 # Check for libjudy
 AC_CHECK_LIB([Judy], [Judy1Next], [], [AC_MSG_ERROR([Missing libJudy])])
 
-AC_CHECK_LIB([readline], [readline], [], [AC_MSG_ERROR([Missing readline lib])])
+AM_COND_IF([WITH_CLI], [
+  AC_CHECK_LIB([readline], [readline], [],
+               [AC_MSG_ERROR([Missing readline lib])])
+])
+
+AM_COND_IF([WITH_INTERNAL_RPC], [
+  AC_CHECK_LIB([nanomsg], [nn_errno], [], [AC_MSG_ERROR([Missing libnanomsg])])
+])
 
 AC_TYPE_UINT8_T
 AC_TYPE_UINT16_T
@@ -167,3 +190,5 @@ AS_ECHO("  simple_switch found ........................ : $simple_switch_found")
 ])
 AS_ECHO("Compile C++ frontend ......................... : $want_fe_cpp")
 AS_ECHO("Compile pi.proto and associated frontend ..... : $with_proto")
+AS_ECHO("Compile internal RPC ......................... : $with_internal_rpc")
+AS_ECHO("Compile PI C CLI ............................. : $with_cli")

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -10,8 +10,7 @@ LDADD = \
 $(top_builddir)/src/libpi.la \
 $(top_builddir)/src/libpifegeneric.la \
 $(top_builddir)/src/libpip4info.la \
-$(top_builddir)/targets/dummy/libpi_dummy.la \
--lnanomsg
+$(top_builddir)/targets/dummy/libpi_dummy.la
 
 noinst_PROGRAMS = example_1 example_2
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,16 +42,19 @@ pi_act_prof.c \
 pi_counter.c \
 pi_meter.c \
 pi_learn.c \
-pi_value.c \
+pi_value.c
+
+if WITH_INTERNAL_RPC
+libpi_la_SOURCES += \
 pi_rpc_server.c \
 pi_notifications_pub.h \
 pi_notifications_pub.c
+endif
 
 libpi_la_LIBADD = \
 libpip4info.la \
 libpiutils.la \
-$(top_builddir)/lib/libpitoolkit.la \
--lnanomsg
+$(top_builddir)/lib/libpitoolkit.la
 
 libpiutils_la_SOURCES = \
 utils/logging.h \
@@ -70,8 +73,7 @@ $(libpifegeneric_la_SOURCES)
 libpiall_la_LIBADD = \
 $(top_builddir)/third_party/cJSON/libpicjson.la \
 libpiutils.la \
-$(top_builddir)/lib/libpitoolkit.la \
--lnanomsg
+$(top_builddir)/lib/libpitoolkit.la
 
 # order important because libpi requires libpip4info
 lib_LTLIBRARIES = libpip4info.la libpi.la libpifegeneric.la libpiall.la

--- a/targets/Makefile.am
+++ b/targets/Makefile.am
@@ -4,4 +4,8 @@ if WITH_BMV2
 MAYBE_BMV2 = bmv2
 endif
 
-SUBDIRS = dummy rpc $(MAYBE_BMV2)
+if WITH_INTERNAL_RPC
+MAYBE_RPC = rpc
+endif
+
+SUBDIRS = dummy $(MAYBE_RPC) $(MAYBE_BMV2)

--- a/targets/rpc/Makefile.am
+++ b/targets/rpc/Makefile.am
@@ -15,7 +15,6 @@ notifications.c
 
 libpi_rpc_la_LIBADD = \
 $(top_builddir)/src/libpip4info.la \
--lnanomsg \
 $(PTHREAD_CFLAGS)
 
 lib_LTLIBRARIES = libpi_rpc.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -53,8 +53,7 @@ $(top_builddir)/targets/dummy/libpi_dummy.la \
 $(top_builddir)/src/libpip4info.la \
 $(top_builddir)/third_party/unity/libunity.la \
 $(top_builddir)/third_party/cJSON/libpicjson.la \
-$(top_builddir)/lib/libpitoolkit.la \
--lnanomsg
+$(top_builddir)/lib/libpitoolkit.la
 
 check_PROGRAMS = \
 test_bmv2_json_reader \


### PR DESCRIPTION
Added these to configure. They enable conditional compilation of the CLI
and the internal nanomsg rpc system. By default these are enable but by
using --with-<option>=no, they can be disabled.
