### PR TITLE
Update func_counter.c

### DIFF
--- a/targets/dummy/func_counter.c
+++ b/targets/dummy/func_counter.c
@@ -69,6 +69,6 @@ void func_counter_destroy() {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic warning "-Wsign-compare"
   JLFA(bytes_freed, func_counter.array);
-#pragma GCC diagnostic pop  (void)bytes_freed;
+#pragma GCC diagnostic pop
   (void)bytes_freed;
 }


### PR DESCRIPTION
@antonin - found another sign-compare issue with Judy macros.
