### PR TITLE
Compile googlemock for testing.

### DIFF
--- a/third_party/gtest.am
+++ b/third_party/gtest.am
@@ -1,4 +1,4 @@
-check_LTLIBRARIES = libgtest.la
+check_LTLIBRARIES = libgtest.la libgmock.la
 
 libgtest_la_CPPFLAGS = \
 -I$(srcdir)/googletest/googletest/include \
@@ -43,3 +43,39 @@ googletest/googletest/src/gtest-internal-inl.h
 libgtest_la_SOURCES = \
 googletest/googletest/src/gtest-all.cc \
 googletest/googletest/include/gtest/gtest.h
+
+
+libgmock_la_CPPFLAGS = \
+$(libgtest_la_CPPFLAGS) \
+-I$(srcdir)/googletest/googlemock/include \
+-I$(srcdir)/googletest/googlemock
+
+EXTRA_DIST += \
+googletest/googlemock/include/gmock/gmock-cardinalities.h \
+googletest/googlemock/include/gmock/gmock-generated-function-mockers.h \
+googletest/googlemock/include/gmock/gmock-matchers.h \
+googletest/googlemock/include/gmock/gmock-more-matchers.h \
+googletest/googlemock/include/gmock/gmock-generated-nice-strict.h \
+googletest/googlemock/include/gmock/internal/custom/gmock-matchers.h \
+googletest/googlemock/include/gmock/internal/custom/gmock-generated-actions.h \
+googletest/googlemock/include/gmock/internal/custom/gmock-port.h \
+googletest/googlemock/include/gmock/internal/gmock-port.h \
+googletest/googlemock/include/gmock/internal/gmock-generated-internal-utils.h \
+googletest/googlemock/include/gmock/internal/gmock-internal-utils.h \
+googletest/googlemock/include/gmock/gmock-generated-actions.h \
+googletest/googlemock/include/gmock/gmock-more-actions.h \
+googletest/googlemock/include/gmock/gmock-actions.h \
+googletest/googlemock/include/gmock/gmock-generated-matchers.h \
+googletest/googlemock/include/gmock/gmock-spec-builders.h
+
+EXTRA_DIST += \
+googletest/googlemock/src/gmock-spec-builders.cc \
+googletest/googlemock/src/gmock-internal-utils.cc \
+googletest/googlemock/src/gmock-matchers.cc \
+googletest/googlemock/src/gmock-cardinalities.cc \
+googletest/googlemock/src/gmock_main.cc \
+googletest/googlemock/src/gmock.cc
+
+libgmock_la_SOURCES = \
+googletest/googlemock/src/gmock-all.cc \
+googletest/googlemock/include/gmock/gmock.h


### PR DESCRIPTION
googlemock is needed (in addition to googletest) for the pi.proto unit
tests I have in mind.