### PR TITLE
Using p4::config::P4Info instead of native PI json

### DIFF
--- a/frontends_extra/cpp/CPPLINT.cfg
+++ b/frontends_extra/cpp/CPPLINT.cfg
@@ -1,4 +1,3 @@
 set noparent
 filter=-build/include_dirname,-build/c++11
 exclude_files=config\.h
-exclude_files=pi_fe_defines_p4\.h

--- a/frontends_extra/cpp/example/CPPLINT.cfg
+++ b/frontends_extra/cpp/example/CPPLINT.cfg
@@ -1,0 +1,1 @@
+exclude_files=pi_fe_defines_p4\.h

--- a/proto/demo_grpc/Makefile.am
+++ b/proto/demo_grpc/Makefile.am
@@ -4,7 +4,8 @@ AM_CPPFLAGS = \
 -I$(top_srcdir)/../include \
 -I$(top_srcdir)/frontend \
 -I$(top_builddir)/cpp_out \
--I$(top_builddir)/grpc_out
+-I$(top_builddir)/grpc_out \
+-I$(top_srcdir)/p4info
 
 AM_CXXFLAGS = -Wall -Werror
 
@@ -32,6 +33,7 @@ $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \
 $(top_builddir)/libpiproto.la \
 $(top_builddir)/../src/libpiall.la \
 $(top_builddir)/../targets/bmv2/libpi_bmv2.la \
+$(top_builddir)/p4info/libpiconvertproto.la \
 -lthrift -lruntimestubs -lsimpleswitch_thrift \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
@@ -41,20 +43,24 @@ $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \
 $(top_builddir)/libpiproto.la \
 $(top_builddir)/../src/libpiall.la \
 $(top_builddir)/../targets/dummy/libpi_dummy.la \
+$(top_builddir)/p4info/libpiconvertproto.la \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 test_client_LDADD = \
 $(top_builddir)/../src/libpip4info.la \
 $(top_builddir)/libpiproto.la \
+$(top_builddir)/p4info/libpiconvertproto.la \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 test_perf_LDADD = \
 $(top_builddir)/../src/libpip4info.la \
 $(top_builddir)/libpiproto.la \
+$(top_builddir)/p4info/libpiconvertproto.la \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 controller_LDADD = \
 $(top_builddir)/../src/libpip4info.la \
 $(top_builddir)/libpiproto.la \
+$(top_builddir)/p4info/libpiconvertproto.la \
 -lmicrohttpd -lboost_system \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)

--- a/proto/demo_grpc/pi_server.cpp
+++ b/proto/demo_grpc/pi_server.cpp
@@ -58,7 +58,7 @@ class DeviceService : public p4::tmp::Device::Service {
     SIMPLELOG << "PI DeviceAssign\n";
     SIMPLELOG << request->DebugString();
     device_mgr = new DeviceMgr(request->device_id());
-    *rep = device_mgr->init(request->native_p4info_json(), request->extras());
+    *rep = device_mgr->init(request->p4info(), request->extras());
     device_mgr->packet_in_register_cb(::packet_in_cb,
                                       static_cast<void *>(packet_in_mgr));
     return Status::OK;
@@ -79,8 +79,7 @@ class DeviceService : public p4::tmp::Device::Service {
                            ::google::rpc::Status *rep) override {
     SIMPLELOG << "PI DeviceUpdateStart\n";
     SIMPLELOG << request->DebugString();
-    *rep = device_mgr->update_start(request->native_p4info_json(),
-                                    request->device_data());
+    *rep = device_mgr->update_start(request->p4info(), request->device_data());
     return Status::OK;
   }
 

--- a/proto/demo_grpc/test_perf.cpp
+++ b/proto/demo_grpc/test_perf.cpp
@@ -15,6 +15,8 @@
 
 #include <grpc++/grpc++.h>
 
+#include "p4info_to_and_from_proto.h"  // for p4info_serialize_to_proto
+
 #include "p4/pi.grpc.pb.h"
 #include "p4/tmp/device.grpc.pb.h"
 
@@ -92,11 +94,12 @@ class DeviceClient {
   int assign_device(int device_id, const pi_p4info_t *p4info) {
     p4::tmp::DeviceAssignRequest request;
     request.set_device_id(device_id);
-    char *p4info_json = pi_serialize_config(p4info, 0);
-    request.set_native_p4info_json(p4info_json);
+    auto p4info_proto = pi::p4info::p4info_serialize_to_proto(p4info);
+    request.set_allocated_p4info(&p4info_proto);
     ::google::rpc::Status rep;
     ClientContext context;
     Status status = stub_->DeviceAssign(&context, request, &rep);
+    request.release_p4info();
     assert(status.ok());
     return rep.code();
   }

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -5,7 +5,8 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 AM_CPPFLAGS = \
 -I$(top_srcdir)/../include \
 -I$(top_builddir)/cpp_out \
--I$(top_srcdir)/../frontends_extra/cpp
+-I$(top_srcdir)/../frontends_extra/cpp \
+-I$(top_srcdir)/p4info
 
 AM_CXXFLAGS = -Wall -Werror
 

--- a/proto/frontend/PI/frontends/proto/device_mgr.h
+++ b/proto/frontend/PI/frontends/proto/device_mgr.h
@@ -23,6 +23,7 @@
 
 #include "google/rpc/status.pb.h"
 #include "p4/pi.pb.h"
+#include "p4/config/p4info.pb.h"
 #include "p4/tmp/device.pb.h"
 #include "p4/tmp/resource.pb.h"
 
@@ -56,10 +57,10 @@ class DeviceMgr {
 
   // 3 temporary methods to manage a device, will be replaced by permanent
   // solution ASAP
-  Status init(const std::string &p4info_json,
+  Status init(const p4::config::P4Info &p4info,
               const p4::tmp::DeviceAssignRequest_Extras &extras);
 
-  Status update_start(const std::string &p4info_json,
+  Status update_start(const p4::config::P4Info &p4info,
                       const std::string &device_data);
 
   Status update_end();

--- a/proto/p4/tmp/device.proto
+++ b/proto/p4/tmp/device.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 import "google/rpc/status.proto";
 
+import "p4/config/p4info.proto";
+
 // This package is temporary. The Device service provides the ability to push a
 // P4 configuration to a device, which is needed for testing, while we come up
 // with a permanent solution.
@@ -38,7 +40,7 @@ message DeviceAssignRequest {
     map<string, string> kv = 1;
   }
   int32 device_id = 1;
-  string native_p4info_json = 2;
+  p4.config.P4Info p4info = 2;
   Extras extras = 3;  // or extension for backend specific args?
 }
 
@@ -48,7 +50,7 @@ message DeviceRemoveRequest {
 
 message DeviceUpdateStartRequest {
   int32 device_id = 1;
-  string native_p4info_json = 2;
+  p4.config.P4Info p4info = 2;
   bytes device_data = 3;  // or use extension?
 }
 

--- a/proto/p4info/p4info_to_and_from_proto.cpp
+++ b/proto/p4info/p4info_to_and_from_proto.cpp
@@ -258,7 +258,7 @@ namespace {
 
 template <typename T>
 void set_preamble(T *obj, pi_p4_id_t id, const char *name,
-                  pi_p4info_t *p4info) {
+                  const pi_p4info_t *p4info) {
   auto pre = obj->mutable_preamble();
   pre->set_id(id);
   pre->set_name(name);
@@ -269,7 +269,7 @@ void set_preamble(T *obj, pi_p4_id_t id, const char *name,
     pre->add_annotations(annotations[i]);
 }
 
-void p4info_serialize_actions(pi_p4info_t *p4info,
+void p4info_serialize_actions(const pi_p4info_t *p4info,
                               p4::config::P4Info *p4info_proto) {
   for (auto id = pi_p4info_action_begin(p4info);
        id != pi_p4info_action_end(p4info);
@@ -289,7 +289,7 @@ void p4info_serialize_actions(pi_p4info_t *p4info,
   }
 }
 
-void p4info_serialize_fields(pi_p4info_t *p4info,
+void p4info_serialize_fields(const pi_p4info_t *p4info,
                              p4::config::P4Info *p4info_proto) {
   for (auto id = pi_p4info_field_begin(p4info);
        id != pi_p4info_field_end(p4info);
@@ -301,7 +301,7 @@ void p4info_serialize_fields(pi_p4info_t *p4info,
   }
 }
 
-void p4info_serialize_field_lists(pi_p4info_t *p4info,
+void p4info_serialize_field_lists(const pi_p4info_t *p4info,
                                   p4::config::P4Info *p4info_proto) {
   for (auto id = pi_p4info_field_list_begin(p4info);
        id != pi_p4info_field_list_end(p4info);
@@ -316,7 +316,7 @@ void p4info_serialize_field_lists(pi_p4info_t *p4info,
   }
 }
 
-void p4info_serialize_tables(pi_p4info_t *p4info,
+void p4info_serialize_tables(const pi_p4info_t *p4info,
                              p4::config::P4Info *p4info_proto) {
   for (auto id = pi_p4info_table_begin(p4info);
        id != pi_p4info_table_end(p4info);
@@ -372,7 +372,7 @@ void p4info_serialize_tables(pi_p4info_t *p4info,
   }
 }
 
-void p4info_serialize_act_profs(pi_p4info_t *p4info,
+void p4info_serialize_act_profs(const pi_p4info_t *p4info,
                                 p4::config::P4Info *p4info_proto) {
   for (auto id = pi_p4info_act_prof_begin(p4info);
        id != pi_p4info_act_prof_end(p4info);
@@ -389,8 +389,8 @@ void p4info_serialize_act_profs(pi_p4info_t *p4info,
   }
 }
 
-void p4info_serialize_counters(pi_p4info_t *p4info,
-                              p4::config::P4Info *p4info_proto) {
+void p4info_serialize_counters(const pi_p4info_t *p4info,
+                               p4::config::P4Info *p4info_proto) {
   for (auto id = pi_p4info_counter_begin(p4info);
        id != pi_p4info_counter_end(p4info);
        id = pi_p4info_counter_next(p4info, id)) {
@@ -416,7 +416,7 @@ void p4info_serialize_counters(pi_p4info_t *p4info,
   }
 }
 
-void p4info_serialize_meters(pi_p4info_t *p4info,
+void p4info_serialize_meters(const pi_p4info_t *p4info,
                              p4::config::P4Info *p4info_proto) {
   for (auto id = pi_p4info_meter_begin(p4info);
        id != pi_p4info_meter_end(p4info);
@@ -455,7 +455,7 @@ void p4info_serialize_meters(pi_p4info_t *p4info,
 
 }  // namespace
 
-p4::config::P4Info p4info_serialize_to_proto(pi_p4info_t *p4info) {
+p4::config::P4Info p4info_serialize_to_proto(const pi_p4info_t *p4info) {
   p4::config::P4Info p4info_proto;
   p4info_serialize_actions(p4info, &p4info_proto);
   p4info_serialize_fields(p4info, &p4info_proto);

--- a/proto/p4info/p4info_to_and_from_proto.h
+++ b/proto/p4info/p4info_to_and_from_proto.h
@@ -29,7 +29,7 @@ namespace pi {
 
 namespace p4info {
 
-p4::config::P4Info p4info_serialize_to_proto(pi_p4info_t *p4info);
+p4::config::P4Info p4info_serialize_to_proto(const pi_p4info_t *p4info);
 
 // returns true if success, false otherwise
 bool p4info_proto_reader(const p4::config::P4Info &p4info_proto,

--- a/src/p4info/p4info_struct.c
+++ b/src/p4info/p4info_struct.c
@@ -35,7 +35,8 @@ void p4info_init_res(pi_p4info_t *p4info, pi_res_type_id_t res_type, size_t num,
 // C1x §6.7.2.1.13: "A pointer to a structure object, suitably converted, points
 // to its initial member ... and vice versa. There may be unnamed padding within
 // as structure object, but not at its beginning."
-p4info_common_t *pi_p4info_get_common(pi_p4info_t *p4info, pi_p4_id_t id) {
+p4info_common_t *pi_p4info_get_common(const pi_p4info_t *p4info,
+                                      pi_p4_id_t id) {
   void *e = p4info_get_at(p4info, id);
   return (p4info_common_t *)e;
 }

--- a/src/p4info_int.h
+++ b/src/p4info_int.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-p4info_common_t *pi_p4info_get_common(pi_p4info_t *p4info, pi_p4_id_t id);
+p4info_common_t *pi_p4info_get_common(const pi_p4info_t *p4info, pi_p4_id_t id);
 
 #ifdef __cplusplus
 }

--- a/src/pi_tables.c
+++ b/src/pi_tables.c
@@ -51,8 +51,7 @@ pi_status_t pi_entry_properties_set(pi_entry_properties_t *properties,
 bool pi_entry_properties_is_set(const pi_entry_properties_t *properties,
                                 pi_entry_property_type_t property_type) {
   if (!properties) return false;
-  if (property_type >= PI_ENTRY_PROPERTY_TYPE_END)
-    return false;
+  if (property_type >= PI_ENTRY_PROPERTY_TYPE_END) return false;
   return properties->valid_properties & (1 << property_type);
 }
 


### PR DESCRIPTION
We are now using it in DeviceMgr (PI proto frontend) as well as for the
experimental protobuf messages which push a new P4 configuration to the
switch (device.proto).