### PR TITLE
Remove -build/include_alpha from cpplint filter

### DIFF
--- a/proto/frontend/PI/frontends/proto/device_mgr.h
+++ b/proto/frontend/PI/frontends/proto/device_mgr.h
@@ -27,8 +27,8 @@
 #include <vector>
 
 #include "google/rpc/status.pb.h"
-#include "p4/pi.pb.h"
 #include "p4/config/p4info.pb.h"
+#include "p4/pi.pb.h"
 #include "p4/tmp/device.pb.h"
 
 namespace pi {

--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -19,8 +19,8 @@
  */
 
 #include <algorithm>
-#include <unordered_map>
 #include <set>
+#include <unordered_map>
 #include <vector>
 
 #include "google/rpc/code.pb.h"

--- a/proto/frontend/src/action_prof_mgr.h
+++ b/proto/frontend/src/action_prof_mgr.h
@@ -21,13 +21,13 @@
 #ifndef SRC_ACTION_PROF_MGR_H_
 #define SRC_ACTION_PROF_MGR_H_
 
-#include <PI/pi.h>
 #include <PI/frontends/cpp/tables.h>
+#include <PI/pi.h>
 
-#include <unordered_map>
 #include <map>
 #include <mutex>
 #include <set>
+#include <unordered_map>
 #include <vector>
 
 #include "google/rpc/code.pb.h"

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -18,9 +18,9 @@
  *
  */
 
-#include <PI/pi.h>
 #include <PI/frontends/cpp/tables.h>
 #include <PI/frontends/proto/device_mgr.h>
+#include <PI/pi.h>
 
 #include <memory>
 #include <string>
@@ -28,9 +28,9 @@
 
 #include "google/rpc/code.pb.h"
 
-#include "p4info_to_and_from_proto.h"  // for p4info_proto_reader
 #include "action_prof_mgr.h"
 #include "common.h"
+#include "p4info_to_and_from_proto.h"  // for p4info_proto_reader
 
 namespace pi {
 

--- a/proto/p4info/convert_p4info.cpp
+++ b/proto/p4info/convert_p4info.cpp
@@ -22,8 +22,8 @@
 
 #include <unistd.h>
 
-#include <iostream>
 #include <fstream>  // std::ifstream, std::ofstream
+#include <iostream>
 #include <string>
 
 #include "p4info_to_and_from_proto.h"

--- a/proto/p4info/p4info_to_and_from_proto.cpp
+++ b/proto/p4info/p4info_to_and_from_proto.cpp
@@ -20,10 +20,10 @@
 
 #include <PI/p4info.h>
 
-#include <iostream>
 #include <exception>
-#include <unordered_map>
+#include <iostream>
 #include <string>
+#include <unordered_map>
 
 #include "p4info_int.h"
 

--- a/proto/tests/test_p4info_convert.cpp
+++ b/proto/tests/test_p4info_convert.cpp
@@ -26,8 +26,9 @@
 
 #include "PI/p4info.h"
 
-#include "p4info_to_and_from_proto.h"
 #include "p4/config/p4info.pb.h"
+
+#include "p4info_to_and_from_proto.h"
 
 namespace pi {
 namespace proto {

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -22,19 +22,20 @@
 
 #include <gmock/gmock.h>
 
+#include <fstream>  // std::ifstream
+#include <iterator>  // std::distance
 #include <memory>
+#include <mutex>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <mutex>
-#include <string>
-#include <fstream>  // std::ifstream
-#include <cstring>  // std::memcmp
-#include <iterator>  // std::distance
 
-#include "PI/pi.h"
-#include "PI/int/pi_int.h"
+#include <cstring>  // std::memcmp
+
 #include "PI/frontends/proto/device_mgr.h"
+#include "PI/int/pi_int.h"
+#include "PI/pi.h"
 #include "PI/proto/util.h"
 
 #include "p4info_to_and_from_proto.h"

--- a/targets/bmv2/action_helpers.cpp
+++ b/targets/bmv2/action_helpers.cpp
@@ -20,11 +20,11 @@
 
 #include "action_helpers.h"
 
-#include <PI/p4info.h>
 #include <PI/int/pi_int.h>
+#include <PI/p4info.h>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace pibmv2 {
 

--- a/targets/bmv2/conn_mgr.cpp
+++ b/targets/bmv2/conn_mgr.cpp
@@ -18,14 +18,14 @@
  *
  */
 
+#include "conn_mgr.h"
+
 #include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/protocol/TMultiplexedProtocol.h>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TTransportUtils.h>
-#include <thrift/protocol/TMultiplexedProtocol.h>
 
 #include <iostream>
-
-#include "conn_mgr.h"
 
 namespace pibmv2 {
 

--- a/targets/bmv2/cpu_send_recv.cpp
+++ b/targets/bmv2/cpu_send_recv.cpp
@@ -25,9 +25,9 @@
 
 #include <pcap/pcap.h>
 
-#include <thread>
 #include <mutex>
 #include <string>
+#include <thread>
 
 #include <cassert>
 

--- a/targets/bmv2/pi_act_prof_imp.cpp
+++ b/targets/bmv2/pi_act_prof_imp.cpp
@@ -18,17 +18,17 @@
  *
  */
 
-#include <PI/pi.h>
-#include <PI/p4info.h>
 #include <PI/int/pi_int.h>
+#include <PI/p4info.h>
+#include <PI/pi.h>
 
 #include <iostream>
 #include <string>
 #include <vector>
 
-#include "conn_mgr.h"
-#include "common.h"
 #include "action_helpers.h"
+#include "common.h"
+#include "conn_mgr.h"
 
 namespace pibmv2 {
 

--- a/targets/bmv2/pi_counter_imp.cpp
+++ b/targets/bmv2/pi_counter_imp.cpp
@@ -18,16 +18,16 @@
  *
  */
 
-#include <PI/pi.h>
 #include <PI/p4info.h>
+#include <PI/pi.h>
 #include <PI/target/pi_counter_imp.h>
 
 #include <iostream>
 #include <string>
 #include <thread>
 
-#include "conn_mgr.h"
 #include "common.h"
+#include "conn_mgr.h"
 #include "direct_res_spec.h"
 
 namespace pibmv2 {

--- a/targets/bmv2/pi_imp.cpp
+++ b/targets/bmv2/pi_imp.cpp
@@ -23,10 +23,11 @@
 
 #include <iostream>
 #include <string>
+
 #include <cstring>  // for memset
 
-#include "conn_mgr.h"
 #include "common.h"
+#include "conn_mgr.h"
 #include "cpu_send_recv.h"
 
 #define NUM_DEVICES 256

--- a/targets/bmv2/pi_learn_imp.cpp
+++ b/targets/bmv2/pi_learn_imp.cpp
@@ -18,15 +18,14 @@
  *
  */
 
-#include <PI/pi.h>
-#include <PI/p4info.h>
-#include <PI/target/pi_learn_imp.h>
-
 #include <bm/bm_apps/learn.h>
 
-#include <string>
+#include <PI/p4info.h>
+#include <PI/pi.h>
+#include <PI/target/pi_learn_imp.h>
 
 #include <cstdio>
+#include <string>
 
 #include "common.h"
 

--- a/targets/bmv2/pi_meter_imp.cpp
+++ b/targets/bmv2/pi_meter_imp.cpp
@@ -18,16 +18,16 @@
  *
  */
 
-#include <PI/pi.h>
 #include <PI/p4info.h>
+#include <PI/pi.h>
 #include <PI/target/pi_meter_imp.h>
 
 #include <iostream>
 #include <string>
 #include <vector>
 
-#include "conn_mgr.h"
 #include "common.h"
+#include "conn_mgr.h"
 #include "direct_res_spec.h"
 
 namespace pibmv2 {

--- a/targets/bmv2/pi_tables_imp.cpp
+++ b/targets/bmv2/pi_tables_imp.cpp
@@ -18,22 +18,22 @@
  *
  */
 
-#include <PI/pi.h>
-#include <PI/p4info.h>
 #include <PI/int/pi_int.h>
 #include <PI/int/serialize.h>
+#include <PI/p4info.h>
+#include <PI/pi.h>
 
+#include <algorithm>
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
-#include <algorithm>
+#include <vector>
 
 #include <cstring>
 
-#include "conn_mgr.h"
-#include "common.h"
 #include "action_helpers.h"
+#include "common.h"
+#include "conn_mgr.h"
 #include "direct_res_spec.h"
 
 namespace pibmv2 {

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -252,7 +252,7 @@ _LEGACY_ERROR_CATEGORIES = [
 # flag. By default all errors are on, so only add here categories that should be
 # off by default (i.e., categories that must be enabled by the --filter= flags).
 # All entries here should start with a '-' or '+', as in the --filter= flag.
-_DEFAULT_FILTERS = ['-build/include_alpha']
+_DEFAULT_FILTERS = []
 
 # We used to check for high-bit characters, but after much discussion we
 # decided those were OK, as long as they were in UTF-8 and didn't represent


### PR DESCRIPTION
This commit is purely for style. I removed -build/include_alpha from the
default filters of cpplint, so that it checks that headers are included
in alphabetical order.