### PR TITLE
Ignore untracked content in the googletest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest
+        ignore = untracked


### PR DESCRIPTION
During the build process, googletest leaves some untracked files lying around which causes `modified:   third_party/googletest (untracked content)` to appear whenever you run `git status`. It'd be nice to clean up the output of `git status` by ignoring that untracked content.