### PR TITLE
When assigning ids from bmv2 json, sort objects

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ AC_CHECK_FUNCS([stat toupper])
 AC_CHECK_FUNCS([strtok strtok_r strchr strstr strtol strtoll])
 AC_CHECK_FUNCS([inet_pton])
 AC_CHECK_FUNCS([strncasecmp])
+AC_CHECK_FUNCS([qsort])
 # TODO: make this portable
 AC_CHECK_FUNC([strnlen], [], [AC_MSG_ERROR([No strnlen implementation found])])
 

--- a/tests/test_bmv2_json_reader.c
+++ b/tests/test_bmv2_json_reader.c
@@ -186,6 +186,7 @@ TEST(IdAssignment, Pragmas) {
   TEST_ASSERT_EQUAL_UINT((PI_TABLE_ID << 24) | 9,
                          pi_p4info_table_id_from_name(p4info, "t"));
 
+  TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info));
   free(config);
 }
 


### PR DESCRIPTION
When the P4 programmer does not provide an ID himself, we use a 16-bit
hash. However in case of hash collision, the order of the objects
matter, which is why we are now sorting them by alphabetical order.