### PR TITLE
Temporary fix for action profile ids

### DIFF
--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -571,7 +571,10 @@ static pi_status_t read_tables(reader_state_t *state, cJSON *root,
       with_selector = true;
     }
     if (act_prof_name) {
-      pi_p4_id_t pi_act_prof_id = request_id(state, table, PI_ACT_PROF_ID);
+      // action profiles are not first class citizens in the bmv2 JSON yet, so
+      // we use the same PI id as the table for now
+      // pi_p4_id_t pi_act_prof_id = request_id(state, table, PI_ACT_PROF_ID);
+      pi_p4_id_t pi_act_prof_id = (PI_ACT_PROF_ID << 24) | (pi_id & 0xffffff);
       PI_LOG_DEBUG("Adding action profile '%s'\n", act_prof_name);
       pi_p4info_act_prof_add(p4info, pi_act_prof_id, act_prof_name,
                              with_selector);

--- a/tests/test_bmv2_json_reader.c
+++ b/tests/test_bmv2_json_reader.c
@@ -185,6 +185,10 @@ TEST(IdAssignment, Pragmas) {
 
   TEST_ASSERT_EQUAL_UINT((PI_TABLE_ID << 24) | 9,
                          pi_p4info_table_id_from_name(p4info, "t"));
+  TEST_ASSERT_EQUAL_UINT((PI_TABLE_ID << 24) | 10,
+                         pi_p4info_table_id_from_name(p4info, "t2"));
+  TEST_ASSERT_EQUAL_UINT((PI_ACT_PROF_ID << 24) | 10,
+                         pi_p4info_act_prof_id_from_name(p4info, "ap"));
 
   TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info));
   free(config);

--- a/tests/testdata/pragmas.json
+++ b/tests/testdata/pragmas.json
@@ -299,12 +299,34 @@
                         "a"
                     ],
                     "next_tables": {
+                        "a": "t2"
+                    },
+                    "base_default_next": "t2",
+                    "pragmas": [
+                        "id 9",
+                        "my_pragma v1"
+                    ]
+                },
+                {
+                    "name": "t2",
+                    "id": 1,
+                    "match_type": "exact",
+                    "type": "indirect",
+                    "act_prof_name": "ap",
+                    "max_size": 16384,
+                    "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
+                    "key": [],
+                    "actions": [
+                        "a"
+                    ],
+                    "next_tables": {
                         "a": null
                     },
                     "base_default_next": null,
                     "pragmas": [
-                        "id 9",
-                        "my_pragma v1"
+                        "id 10"
                     ]
                 }
             ],

--- a/tests/testdata/pragmas.p4
+++ b/tests/testdata/pragmas.p4
@@ -71,5 +71,15 @@ action a(ap) {
 @pragma id 9
 table t { actions { a; } }
 
+@pragma id 10
+table t2 { action_profile: ap; }
+
+// no support for action profile pragmas yet, so the table (t2) one will be used
+@pragma id 11
+action_profile ap {
+    actions { a; }
+    size : 128;
+}
+
 @pragma my_pragma v1
-control ingress { apply(t); }
+control ingress { apply(t); apply(t2); }


### PR DESCRIPTION
For now we use the id from the table. When action profiles become first
class citizens in the bmv2 JSON and sharing is supported by bmv2, we
will update this code.