### PR TITLE
Add support for pi_omit attribute in bmv2 JSON

### DIFF
--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -310,6 +310,14 @@ static bool exclude_field(const char *suffix) {
   return false;
 }
 
+// rules to exclude header instances
+static bool exclude_header(cJSON *header) {
+  const cJSON *item = cJSON_GetObjectItem(header, "pi_omit");
+  if (!item) return false;
+  if (item->valueint) return true;
+  return true;
+}
+
 static size_t header_count_fields(cJSON *header_type) {
   size_t num_fields = 0;
   cJSON *fields = cJSON_GetObjectItem(header_type, "fields");
@@ -349,6 +357,7 @@ static pi_status_t read_fields(reader_state_t *state, cJSON *root,
   size_t num_fields = 0u;
   cJSON *header;
   cJSON_ArrayForEach(header, headers) {
+    if (exclude_header(header)) continue;
     item = cJSON_GetObjectItem(header, "header_type");
     if (!item) return PI_STATUS_CONFIG_READER_ERROR;
     const char *header_type_name = item->valuestring;
@@ -364,6 +373,7 @@ static pi_status_t read_fields(reader_state_t *state, cJSON *root,
 
   sort_json_array(headers);
   cJSON_ArrayForEach(header, headers) {
+    if (exclude_header(header)) continue;
     item = cJSON_GetObjectItem(header, "name");
     if (!item) return PI_STATUS_CONFIG_READER_ERROR;
     const char *header_name = item->valuestring;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,7 +69,8 @@ testdata/ecmp.json \
 testdata/stats.json \
 testdata/l2_switch.json \
 testdata/pragmas.json \
-testdata/unittest.json
+testdata/unittest.json \
+testdata/pi_omit.json
 
 # cleaning up the file created by the dummy target (function call counters)
 clean-local:

--- a/tests/test_bmv2_json_reader.c
+++ b/tests/test_bmv2_json_reader.c
@@ -194,7 +194,25 @@ TEST(IdAssignment, Pragmas) {
   free(config);
 }
 
-TEST_GROUP_RUNNER(IdAssignment) { RUN_TEST_CASE(IdAssignment, Pragmas); }
+TEST(IdAssignment, PiOmit) {
+  pi_p4info_t *p4info;
+  char *config = read_json(TESTDATADIR
+                           "/"
+                           "pi_omit.json");
+  TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS,
+                    pi_add_config(config, PI_CONFIG_TYPE_BMV2_JSON, &p4info));
+  TEST_ASSERT_EQUAL_UINT(PI_INVALID_ID,
+                         pi_p4info_field_id_from_name(p4info, "scalars.f1"));
+  TEST_ASSERT_NOT_EQUAL(PI_INVALID_ID,
+                        pi_p4info_field_id_from_name(p4info, "reg.f1"));
+  TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info));
+  free(config);
+}
+
+TEST_GROUP_RUNNER(IdAssignment) {
+  RUN_TEST_CASE(IdAssignment, PiOmit);
+  RUN_TEST_CASE(IdAssignment, Pragmas);
+}
 
 void test_bmv2_json_reader() {
   RUN_TEST_GROUP(SimpleRouter);

--- a/tests/testdata/pi_omit.json
+++ b/tests/testdata/pi_omit.json
@@ -1,0 +1,49 @@
+{
+    "header_types": [
+        {
+            "name": "scalars_t",
+            "id": 0,
+            "fields": [
+                [
+                    "f1",
+                    32
+                ]
+            ],
+            "length_exp": null,
+            "max_length": null
+        },
+        {
+            "name": "reg_t",
+            "id": 1,
+            "fields": [
+                [
+                    "f1",
+                    32
+                ]
+            ],
+            "length_exp": null,
+            "max_length": null
+        }
+    ],
+    "headers": [
+        {
+            "name": "scalars",
+            "id": 0,
+            "header_type": "scalars_t",
+            "metadata": true,
+            "pi_omit": true
+        },
+        {
+            "name": "reg",
+            "id": 1,
+            "header_type": "reg_t",
+            "metadata": true
+        }
+    ],
+    "meter_arrays": [],
+    "actions": [],
+    "pipelines": [],
+    "learn_lists": [],
+    "counter_arrays": [],
+    "register_arrays": []
+}


### PR DESCRIPTION
This attribute is used by the compiler to signal that a header instance
was inserted by the compiler and should be omitted by the PI.