### PR TITLE
Fix pi_omit handling in bmv2 json reader

### DIFF
--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -315,7 +315,7 @@ static bool exclude_header(cJSON *header) {
   const cJSON *item = cJSON_GetObjectItem(header, "pi_omit");
   if (!item) return false;
   if (item->valueint) return true;
-  return true;
+  return false;
 }
 
 static size_t header_count_fields(cJSON *header_type) {

--- a/tests/test_bmv2_json_reader.c
+++ b/tests/test_bmv2_json_reader.c
@@ -204,7 +204,9 @@ TEST(IdAssignment, PiOmit) {
   TEST_ASSERT_EQUAL_UINT(PI_INVALID_ID,
                          pi_p4info_field_id_from_name(p4info, "scalars.f1"));
   TEST_ASSERT_NOT_EQUAL(PI_INVALID_ID,
-                        pi_p4info_field_id_from_name(p4info, "reg.f1"));
+                        pi_p4info_field_id_from_name(p4info, "reg1.f1"));
+  TEST_ASSERT_NOT_EQUAL(PI_INVALID_ID,
+                        pi_p4info_field_id_from_name(p4info, "reg2.f1"));
   TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info));
   free(config);
 }

--- a/tests/testdata/pi_omit.json
+++ b/tests/testdata/pi_omit.json
@@ -34,10 +34,17 @@
             "pi_omit": true
         },
         {
-            "name": "reg",
+            "name": "reg1",
             "id": 1,
             "header_type": "reg_t",
             "metadata": true
+        },
+        {
+            "name": "reg2",
+            "id": 2,
+            "header_type": "reg_t",
+            "metadata": true,
+            "pi_omit": false
         }
     ],
     "meter_arrays": [],


### PR DESCRIPTION
There was a typo and the case where pi_omit is set to false was not
handled properly.