### PR TITLE
Resolve resource name hash collisions without corrupting the resulting id

### DIFF
--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -170,14 +170,18 @@ static uint32_t jenkins_one_at_a_time_hash(const uint8_t *key, size_t length) {
   return hash;
 }
 
+static uint32_t hash_to_id(uint32_t hash, pi_res_type_id_t type_id) {
+  return (type_id << 24) | (hash & 0xffff);
+}
+
 static pi_p4_id_t generate_id_from_name(reader_state_t *state, cJSON *object,
                                         pi_res_type_id_t type_id) {
   const cJSON *item = cJSON_GetObjectItem(object, "name");
   const char *name = item->valuestring;
   pi_p4_id_t hash =
       jenkins_one_at_a_time_hash((const uint8_t *)name, strlen(name));
-  pi_p4_id_t id = (type_id << 24) | (hash & 0xffff);
-  while (is_id_reserved(state, id)) id++;
+  while (is_id_reserved(state, hash_to_id(hash, type_id))) hash++;
+  pi_p4_id_t id = hash_to_id(hash, type_id);
   reserve_id(state, id);
   allocate_id(state, id);
   return id;

--- a/tests/testdata/id_collision.json
+++ b/tests/testdata/id_collision.json
@@ -1,0 +1,13 @@
+{
+    "header_types": [],
+    "headers": [],
+    "meter_arrays": [],
+    "actions": [
+      { "name": "ae0ea", "id": 0, "runtime_data": [], "primitives": [], "pragmas": [] },
+      { "name": "bb6df", "id": 1, "runtime_data": [], "primitives": [], "pragmas": [] }
+    ],
+    "pipelines": [],
+    "learn_lists": [],
+    "counter_arrays": [],
+    "register_arrays": []
+}


### PR DESCRIPTION
When two resource names hash to the same value, we currently resolve the collision in a way that can spill bits over into parts of the id that aren't supposed to depend on the resource name. The problem is that when we're searching for an unused id, we perform that search by increment the *id* over and over again, when we should actually be incrementing the *hash* and recomputing the id. Doing the latter ensures that we produce an id of the form we expect.

This patch fixes the problem and introduces a test for our hash collisions behavior. I've also fixed the problem on the `p4c` side in my yet-to-be-merged PI-generating code.