### PR TITLE
Add table / act-prof size to p4info

### DIFF
--- a/include/PI/p4info/act_profs.h
+++ b/include/PI/p4info/act_profs.h
@@ -47,6 +47,9 @@ const pi_p4_id_t *pi_p4info_act_prof_get_actions(const pi_p4info_t *p4info,
                                                  pi_p4_id_t act_prof_id,
                                                  size_t *num_actions);
 
+size_t pi_p4info_act_prof_max_size(const pi_p4info_t *p4info,
+                                   pi_p4_id_t act_prof_id);
+
 pi_p4_id_t pi_p4info_act_prof_begin(const pi_p4info_t *p4info);
 pi_p4_id_t pi_p4info_act_prof_next(const pi_p4info_t *p4info, pi_p4_id_t id);
 pi_p4_id_t pi_p4info_act_prof_end(const pi_p4info_t *p4info);

--- a/include/PI/p4info/tables.h
+++ b/include/PI/p4info/tables.h
@@ -101,6 +101,8 @@ const pi_p4_id_t *pi_p4info_table_get_direct_resources(
     const pi_p4info_t *p4info, pi_p4_id_t table_id,
     size_t *num_direct_resources);
 
+size_t pi_p4info_table_max_size(const pi_p4info_t *p4info, pi_p4_id_t table_id);
+
 pi_p4_id_t pi_p4info_table_begin(const pi_p4info_t *p4info);
 pi_p4_id_t pi_p4info_table_next(const pi_p4info_t *p4info, pi_p4_id_t id);
 pi_p4_id_t pi_p4info_table_end(const pi_p4info_t *p4info);

--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -504,9 +504,11 @@ static pi_status_t read_act_profs(reader_state_t *state, cJSON *root,
     const char *name = item->valuestring;
     pi_p4_id_t pi_id = request_id(state, act_prof, PI_ACT_PROF_ID);
     bool with_selector = cJSON_HasObjectItem(act_prof, "selector");
+    item = cJSON_GetObjectItem(act_prof, "max_size");
+    if (!item) return PI_STATUS_CONFIG_READER_ERROR;
+    size_t max_size = item->valueint;
     PI_LOG_DEBUG("Adding action profile '%s'\n", name);
-    // TODO(antonin): store size as well
-    pi_p4info_act_prof_add(p4info, pi_id, name, with_selector);
+    pi_p4info_act_prof_add(p4info, pi_id, name, with_selector, max_size);
   }
 
   vector_destroy(act_profs_vec);
@@ -539,8 +541,13 @@ static pi_status_t read_tables(reader_state_t *state, cJSON *root,
     if (!json_actions) return PI_STATUS_CONFIG_READER_ERROR;
     size_t num_actions = cJSON_GetArraySize(json_actions);
 
+    item = cJSON_GetObjectItem(table, "max_size");
+    if (!item) return PI_STATUS_CONFIG_READER_ERROR;
+    size_t max_size = item->valueint;
+
     PI_LOG_DEBUG("Adding table '%s'\n", name);
-    pi_p4info_table_add(p4info, pi_id, name, num_match_fields, num_actions);
+    pi_p4info_table_add(p4info, pi_id, name, num_match_fields, num_actions,
+                        max_size);
 
     import_pragmas(table, p4info, pi_id);
 

--- a/src/config_readers/native_json_reader.c
+++ b/src/config_readers/native_json_reader.c
@@ -131,8 +131,12 @@ static pi_status_t read_tables(cJSON *root, pi_p4info_t *p4info) {
     cJSON *actions = cJSON_GetObjectItem(table, "actions");
     if (!actions) return PI_STATUS_CONFIG_READER_ERROR;
     size_t num_actions = cJSON_GetArraySize(actions);
+    item = cJSON_GetObjectItem(table, "max_size");
+    if (!item) return PI_STATUS_CONFIG_READER_ERROR;
+    size_t max_size = item->valueint;
 
-    pi_p4info_table_add(p4info, pi_id, name, num_match_fields, num_actions);
+    pi_p4info_table_add(p4info, pi_id, name, num_match_fields, num_actions,
+                        max_size);
 
     import_annotations(table, p4info, pi_id);
 
@@ -200,8 +204,11 @@ static pi_status_t read_act_profs(cJSON *root, pi_p4info_t *p4info) {
     if (!item) return PI_STATUS_CONFIG_READER_ERROR;
     assert(item->type == cJSON_True || item->type == cJSON_False);
     bool with_selector = (item->type == cJSON_True);
+    item = cJSON_GetObjectItem(act_prof, "max_size");
+    if (!item) return PI_STATUS_CONFIG_READER_ERROR;
+    size_t max_size = item->valueint;
 
-    pi_p4info_act_prof_add(p4info, pi_id, name, with_selector);
+    pi_p4info_act_prof_add(p4info, pi_id, name, with_selector, max_size);
 
     import_annotations(act_prof, p4info, pi_id);
 

--- a/src/p4info/act_profs.c
+++ b/src/p4info/act_profs.c
@@ -39,6 +39,7 @@ typedef struct _act_prof_data_s {
   // TODO(antonin): remove restriction on amount of table references?
   pi_p4_id_t table_ids[MAX_TABLES];
   bool with_selector;
+  size_t max_size;
 } _act_prof_data_t;
 
 static _act_prof_data_t *get_act_prof(const pi_p4info_t *p4info,
@@ -78,6 +79,8 @@ void pi_p4info_act_prof_serialize(cJSON *root, const pi_p4info_t *p4info) {
 
     cJSON_AddBoolToObject(aObject, "with_selector", act_prof->with_selector);
 
+    cJSON_AddNumberToObject(aObject, "max_size", act_prof->max_size);
+
     p4info_common_serialize(aObject, &act_prof->common);
 
     cJSON_AddItemToArray(aArray, aObject);
@@ -92,12 +95,14 @@ void pi_p4info_act_prof_init(pi_p4info_t *p4info, size_t num_act_profs) {
 }
 
 void pi_p4info_act_prof_add(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
-                            const char *name, bool with_selector) {
+                            const char *name, bool with_selector,
+                            size_t max_size) {
   _act_prof_data_t *act_prof = p4info_add_res(p4info, act_prof_id, name);
   act_prof->name = strdup(name);
   act_prof->act_prof_id = act_prof_id;
   act_prof->num_tables = 0;
   act_prof->with_selector = with_selector;
+  act_prof->max_size = max_size;
 }
 
 void pi_p4info_act_prof_add_table(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
@@ -143,6 +148,12 @@ const pi_p4_id_t *pi_p4info_act_prof_get_actions(const pi_p4info_t *p4info,
   if (act_prof->num_tables == 0) return NULL;
   pi_p4_id_t one_t_id = act_prof->table_ids[0];
   return pi_p4info_table_get_actions(p4info, one_t_id, num_actions);
+}
+
+size_t pi_p4info_act_prof_max_size(const pi_p4info_t *p4info,
+                                   pi_p4_id_t act_prof_id) {
+  _act_prof_data_t *act_prof = get_act_prof(p4info, act_prof_id);
+  return act_prof->max_size;
 }
 
 pi_p4_id_t pi_p4info_act_prof_begin(const pi_p4info_t *p4info) {

--- a/src/p4info/act_profs_int.h
+++ b/src/p4info/act_profs_int.h
@@ -32,7 +32,8 @@ void pi_p4info_act_prof_init(pi_p4info_t *p4info, size_t num_act_profs);
 void pi_p4info_act_prof_free(pi_p4info_t *p4info);
 
 void pi_p4info_act_prof_add(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
-                            const char *name, bool with_selector);
+                            const char *name, bool with_selector,
+                            size_t max_size);
 
 void pi_p4info_act_prof_add_table(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
                                   pi_p4_id_t table_id);

--- a/src/p4info/tables.c
+++ b/src/p4info/tables.c
@@ -70,6 +70,7 @@ typedef struct _table_data_s {
     pi_p4_id_t direct[INLINE_DIRECT_RES];
     pi_p4_id_t *indirect;
   } direct_resources;
+  size_t max_size;
 } _table_data_t;
 
 static _table_data_t *get_table(const pi_p4info_t *p4info,
@@ -170,6 +171,8 @@ void pi_p4info_table_serialize(cJSON *root, const pi_p4info_t *p4info) {
     }
     cJSON_AddItemToObject(tObject, "direct_resources", directresArray);
 
+    cJSON_AddNumberToObject(tObject, "max_size", table->max_size);
+
     p4info_common_serialize(tObject, &table->common);
 
     cJSON_AddItemToArray(tArray, tObject);
@@ -184,7 +187,7 @@ void pi_p4info_table_init(pi_p4info_t *p4info, size_t num_tables) {
 
 void pi_p4info_table_add(pi_p4info_t *p4info, pi_p4_id_t table_id,
                          const char *name, size_t num_match_fields,
-                         size_t num_actions) {
+                         size_t num_actions, size_t max_size) {
   _table_data_t *table = p4info_add_res(p4info, table_id, name);
   table->name = strdup(name);
   table->table_id = table_id;
@@ -204,6 +207,7 @@ void pi_p4info_table_add(pi_p4info_t *p4info, pi_p4_id_t table_id,
   table->implementation = PI_INVALID_ID;
   table->num_direct_resources = 0;
   table->match_fields_added = 0;
+  table->max_size = max_size;
 }
 
 void pi_p4info_table_add_match_field(pi_p4info_t *p4info, pi_p4_id_t table_id,
@@ -387,6 +391,12 @@ const pi_p4_id_t *pi_p4info_table_get_direct_resources(
   _table_data_t *table = get_table(p4info, table_id);
   *num_direct_resources = table->num_direct_resources;
   return get_direct_resources(table);
+}
+
+size_t pi_p4info_table_max_size(const pi_p4info_t *p4info,
+                                pi_p4_id_t table_id) {
+  _table_data_t *table = get_table(p4info, table_id);
+  return table->max_size;
 }
 
 pi_p4_id_t pi_p4info_table_begin(const pi_p4info_t *p4info) {

--- a/src/p4info/tables_int.h
+++ b/src/p4info/tables_int.h
@@ -31,7 +31,7 @@ void pi_p4info_table_init(pi_p4info_t *p4info, size_t num_tables);
 
 void pi_p4info_table_add(pi_p4info_t *p4info, pi_p4_id_t table_id,
                          const char *name, size_t num_match_fields,
-                         size_t num_actions);
+                         size_t num_actions, size_t max_size);
 
 void pi_p4info_table_add_match_field(pi_p4info_t *p4info, pi_p4_id_t table_id,
                                      pi_p4_id_t field_id, const char *name,

--- a/tests/frontends/generic/test.c
+++ b/tests/frontends/generic/test.c
@@ -30,6 +30,8 @@
 
 #include <stdlib.h>
 
+#define DEFAULT_TABLE_SIZE 1024
+
 static pi_p4info_t *p4info;
 static size_t num_fields;
 static size_t num_actions;
@@ -62,7 +64,7 @@ static void p4info_init(size_t bitwidth, pi_p4info_match_type_t match_type) {
   pid = pi_make_action_param_id(aid, 0);
   pi_p4info_action_add_param(p4info, aid, pid, "p0_0", bitwidth);
   tid = pi_make_table_id(0);
-  pi_p4info_table_add(p4info, tid, "t0", 1, 1);
+  pi_p4info_table_add(p4info, tid, "t0", 1, 1, DEFAULT_TABLE_SIZE);
   pi_p4info_table_add_match_field(p4info, tid, fid, "f0", match_type, bitwidth);
   pi_p4info_table_add_action(p4info, tid, aid);
 

--- a/tests/test_p4info.c
+++ b/tests/test_p4info.c
@@ -32,6 +32,8 @@
 #include <Judy.h>
 #include <string.h>
 
+#define DEFAULT_TABLE_SIZE 1024
+
 static pi_p4info_t *p4info;
 
 TEST_GROUP(P4Info);
@@ -390,7 +392,8 @@ TEST(P4Info, TablesStress) {
     tdata[i].num_match_fields = rand() % (max_match_fields + 1);
     tdata[i].num_actions = rand() % (max_actions + 1);
     pi_p4info_table_add(p4info, tdata[i].id, tdata[i].name,
-                        tdata[i].num_match_fields, tdata[i].num_actions);
+                        tdata[i].num_match_fields, tdata[i].num_actions,
+                        DEFAULT_TABLE_SIZE);
     gen_rand_ids(tdata[i].match_fields, num_fields, tdata[i].num_match_fields);
     for (size_t j = 0; j < tdata[i].num_match_fields; j++) {
       pi_p4_id_t id = tdata[i].match_fields[j];
@@ -503,7 +506,8 @@ TEST(P4Info, TablesIterator) {
   char name[16];
   for (size_t i = 0; i < num_tables; i++) {
     snprintf(name, sizeof(name), "a%zu", i);
-    pi_p4info_table_add(p4info, pi_make_table_id(i), name, 0, 1);
+    pi_p4info_table_add(p4info, pi_make_table_id(i), name, 0, 1,
+                        DEFAULT_TABLE_SIZE);
   }
 
   size_t cnt = 0;


### PR DESCRIPTION
There was a desire to have it in p4info.proto; it therefore needs to be
in p4info for the various conversions to be possible.