### PR TITLE
Fix make dist when configure is run without bmv2

### DIFF
--- a/targets/Makefile.am
+++ b/targets/Makefile.am
@@ -9,3 +9,5 @@ MAYBE_RPC = rpc
 endif
 
 SUBDIRS = dummy $(MAYBE_RPC) $(MAYBE_BMV2)
+
+DIST_SUBDIRS = dummy rpc $(MAYBE_BMV2)


### PR DESCRIPTION
Fixed by setting DIST_SUBDIRS manually in targets/Makefile.am. Note that
because we are setting DIST_SUBDIRS manually in a few places, care must
be taken when creating a distribution.

This should fix issue #88