### PR TITLE
Rename PI gRPC service to P4Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ See [examples] (examples/) for how to use the PI.
 - libjudy-dev
 - libreadline-dev
 
-## Building pi.proto
+## Building p4runtime.proto
 
-To include `pi.proto` in the build, please run `configure` with `--with-proto`.
+To include `p4runtime.proto` in the build, please run `configure` with
+`--with-proto`.
 
 ## PI CLI
 

--- a/configure.ac
+++ b/configure.ac
@@ -32,11 +32,12 @@ AC_ARG_WITH([fe_cpp],
     [want_fe_cpp=yes], [])
 
 AC_ARG_WITH([proto],
-    AS_HELP_STRING([--with-proto], [Compile pi.proto and associated frontend]),
+    AS_HELP_STRING([--with-proto],
+                   [Compile p4runtime.proto and associated frontend]),
     [with_proto="$withval"], [with_proto=no])
 
 AS_IF([test "$with_proto" = yes && test "$want_fe_cpp" = no], [
-    AC_MSG_NOTICE([C++ frontend needed for pi.proto, turning it on])
+    AC_MSG_NOTICE([C++ frontend needed for p4runtime.proto, turning it on])
     want_fe_cpp=yes
 ])
 
@@ -216,6 +217,6 @@ AS_IF([test "$want_bmv2" = yes], [
 AS_ECHO("  simple_switch found ........................ : $simple_switch_found")
 ])
 AS_ECHO("Compile C++ frontend ......................... : $want_fe_cpp")
-AS_ECHO("Compile pi.proto and associated frontend ..... : $with_proto")
+AS_ECHO("Compile p4runtime.proto and associated fe .... : $with_proto")
 AS_ECHO("Compile internal RPC ......................... : $with_internal_rpc")
 AS_ECHO("Compile PI C CLI ............................. : $with_cli")

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -18,7 +18,7 @@ PROTOFLAGS = -I$(abs_srcdir)
 
 # Absolute paths are needed here for 'make distcheck' to work properly
 protos = \
-$(abs_srcdir)/p4/pi.proto \
+$(abs_srcdir)/p4/p4runtime.proto \
 $(abs_srcdir)/p4/config/p4info.proto \
 $(abs_srcdir)/google/rpc/status.proto \
 $(abs_srcdir)/google/rpc/code.proto \
@@ -27,7 +27,7 @@ $(abs_srcdir)/p4/tmp/device.proto
 # Somehow, using an absolute path above prevents me from using EXTRA_DIST =
 # $(protos)
 EXTRA_DIST = \
-p4/pi.proto \
+p4/p4runtime.proto \
 p4/config/p4info.proto \
 google/rpc/status.proto \
 google/rpc/code.proto \

--- a/proto/demo_grpc/simple_router_mgr.cpp
+++ b/proto/demo_grpc/simple_router_mgr.cpp
@@ -175,7 +175,8 @@ class StreamChannelSyncClient {
  public:
   StreamChannelSyncClient(SimpleRouterMgr *simple_router_mgr,
                           std::shared_ptr<Channel> channel)
-      : simple_router_mgr(simple_router_mgr), stub_(p4::PI::NewStub(channel)) {
+      : simple_router_mgr(simple_router_mgr),
+        stub_(p4::P4Runtime::NewStub(channel)) {
     stream = stub_->StreamChannel(&context);
   }
 
@@ -209,7 +210,7 @@ class StreamChannelSyncClient {
 
  private:
   SimpleRouterMgr *simple_router_mgr{nullptr};
-  std::unique_ptr<p4::PI::Stub> stub_;
+  std::unique_ptr<p4::P4Runtime::Stub> stub_;
   std::thread recv_thread;
   ClientContext context;
   std::unique_ptr<ClientReaderWriter<p4::StreamMessageRequest,
@@ -221,7 +222,7 @@ SimpleRouterMgr::SimpleRouterMgr(int dev_id, pi_p4info_t *p4info,
                                  std::shared_ptr<Channel> channel)
     : dev_id(dev_id), p4info(p4info), io_service(io_service),
       device_stub_(p4::tmp::Device::NewStub(channel)),
-      pi_stub_(p4::PI::NewStub(channel)),
+      pi_stub_(p4::P4Runtime::NewStub(channel)),
       packet_io_client(new StreamChannelSyncClient(this, channel)) {
 }
 

--- a/proto/demo_grpc/simple_router_mgr.h
+++ b/proto/demo_grpc/simple_router_mgr.h
@@ -162,6 +162,6 @@ class SimpleRouterMgr {
   pi_p4info_t *p4info{nullptr};
   boost::asio::io_service &io_service;
   std::unique_ptr<p4::tmp::Device::Stub> device_stub_;
-  std::unique_ptr<p4::PI::Stub> pi_stub_;
+  std::unique_ptr<p4::P4Runtime::Stub> pi_stub_;
   std::unique_ptr<StreamChannelSyncClient> packet_io_client;
 };

--- a/proto/demo_grpc/test_client.cpp
+++ b/proto/demo_grpc/test_client.cpp
@@ -117,7 +117,7 @@ class DeviceClient {
 class StreamChannelSync {
  public:
   StreamChannelSync(std::shared_ptr<Channel> channel)
-      : stub_(p4::PI::NewStub(channel)) {
+      : stub_(p4::P4Runtime::NewStub(channel)) {
     stream = stub_->StreamChannel(&context);
   }
 
@@ -145,27 +145,27 @@ class StreamChannelSync {
   }
 
  private:
-  std::unique_ptr<p4::PI::Stub> stub_;
+  std::unique_ptr<p4::P4Runtime::Stub> stub_;
   std::thread recv_thread;
   ClientContext context;
   std::unique_ptr<ClientReaderWriter<p4::StreamMessageRequest,
                                      p4::StreamMessageResponse> > stream;
 };
 
-class PIAsyncClient {
+class P4RuntimeAsyncClient {
  public:
-  PIAsyncClient(std::shared_ptr<Channel> channel)
-      : stub_(p4::PI::NewStub(channel)) {}
+  P4RuntimeAsyncClient(std::shared_ptr<Channel> channel)
+      : stub_(p4::P4Runtime::NewStub(channel)) {}
 
   void sub_packet_in() {
-    recv_thread = std::thread(&PIAsyncClient::AsyncRecvPacketIn, this);
+    recv_thread = std::thread(&P4RuntimeAsyncClient::AsyncRecvPacketIn, this);
   }
 
  private:
   // struct for keeping state and data information
   class AsyncRecvPacketInState {
    public:
-    AsyncRecvPacketInState(p4::PI::Stub *stub_, CompletionQueue *cq)
+    AsyncRecvPacketInState(p4::P4Runtime::Stub *stub_, CompletionQueue *cq)
         : state(State::CREATE) {
       stream = stub_->AsyncStreamChannel(&context, cq,
                                          static_cast<void *>(this));
@@ -244,7 +244,7 @@ class PIAsyncClient {
     }
   }
 
-  std::unique_ptr<p4::PI::Stub> stub_;
+  std::unique_ptr<p4::P4Runtime::Stub> stub_;
   CompletionQueue cq_;
   std::thread recv_thread;
 };
@@ -259,7 +259,7 @@ int main(int argc, char** argv) {
   std::cout << "1. Status received: " << rc << std::endl;
   // rc = client.route_add_test();
   // std::cout << "2. Status received: " << rc << std::endl;
-  // PIAsyncClient async_client(channel);
+  // P4RuntimeAsyncClient async_client(channel);
   // async_client.sub_packet_in();
   StreamChannelSync packet_io_client(channel);
   packet_io_client.send_init(0);

--- a/proto/demo_grpc/test_perf.cpp
+++ b/proto/demo_grpc/test_perf.cpp
@@ -118,10 +118,10 @@ class DeviceClient {
   std::unique_ptr<p4::tmp::Device::Stub> stub_;
 };
 
-class PIClient {
+class P4RuntimeClient {
  public:
-  PIClient(std::shared_ptr<Channel> channel)
-      : stub_(p4::PI::NewStub(channel)) { }
+  P4RuntimeClient(std::shared_ptr<Channel> channel)
+      : stub_(p4::P4Runtime::NewStub(channel)) { }
 
   int table_write(const p4::TableWriteRequest &request) {
     p4::TableWriteResponse rep;
@@ -132,7 +132,7 @@ class PIClient {
   }
 
  private:
-  std::unique_ptr<p4::PI::Stub> stub_;
+  std::unique_ptr<p4::P4Runtime::Stub> stub_;
 };
 
 namespace {
@@ -156,7 +156,7 @@ std::string uint_to_string<uint32_t>(uint32_t i) {
 class StreamChannelSync {
  public:
   StreamChannelSync(std::shared_ptr<Channel> channel)
-      : stub_(p4::PI::NewStub(channel)) {
+      : stub_(p4::P4Runtime::NewStub(channel)) {
     stream = stub_->StreamChannel(&context);
   }
 
@@ -193,7 +193,7 @@ class StreamChannelSync {
 
  private:
   std::atomic<bool> stop_f{false};
-  std::unique_ptr<p4::PI::Stub> stub_;
+  std::unique_ptr<p4::P4Runtime::Stub> stub_;
   std::thread recv_thread;
   ClientContext context;
   std::unique_ptr<ClientReaderWriter<p4::StreamMessageRequest,
@@ -232,7 +232,7 @@ class Tester {
     auto add_entries = [this, t_id, a_id, batch_size](size_t iters) {
       using google::protobuf::Arena;
       for (size_t i = 0; i < iters; i++) {
-        // when arenas are enabled in pi.proto
+        // when arenas are enabled in p4runtime.proto
         // Arena arena;
         // p4::TableWriteRequest *request =
         //     Arena::CreateMessage<p4::TableWriteRequest>(&arena);
@@ -318,7 +318,7 @@ class Tester {
   int device_id;
   const pi_p4info_t *p4info;
   DeviceClient device_client;
-  PIClient pi_client;
+  P4RuntimeClient pi_client;
   StreamChannelSync packet_recv;
 };
 

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -447,7 +447,7 @@ class DeviceMgrImp {
 
   // this function to avoid code duplication
   // we can probably simplify this code if the action_profile_id is moved up in
-  // pi.proto
+  // p4runtime.proto
   template <typename FMember, typename FGroup>
   Status action_profile_common(const p4::ActionProfileEntry &entry,
                                FMember fmember, FGroup fgroup) {

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -22,7 +22,7 @@ import "google/rpc/status.proto";
 
 package p4;
 
-service PI {
+service P4Runtime {
   // Modifies the P4 tables containing 'TableEntry's.
   rpc TableWrite(TableWriteRequest) returns (TableWriteResponse) {
   }


### PR DESCRIPTION
We only renamed the service and updated the demo code accordingly. The
proto file was also renamed from pi.proto to p4runtime.proto.

For now, the rest of the code still refers to PI. We may also want to
rename the repository from PI to p4Runtime / p4-runtime in the future,
but for now it seems that the gRPC service was the priority.