### PR TITLE
Update p4runtime.proto

### DIFF
--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -77,7 +77,7 @@ message TableWriteResponse {
 message TableReadRequest {
   uint64 device_id = 1;
   // Read all if empty.
-  repeated int32 table_ids = 2;
+  repeated uint32 table_ids = 2;
 }
 
 message TableReadResponse {
@@ -105,7 +105,7 @@ message TableUpdate {
 //   function when it is called.
 
 message TableEntry {
-  int32 table_id = 1;
+  uint32 table_id = 1;
   repeated FieldMatch match = 2;
   TableAction action = 3;
   int32 priority = 4;              // ignored unless match => TCAM
@@ -114,7 +114,7 @@ message TableEntry {
 
 // field_match_type ::= exact | ternary | lpm | range | valid
 message FieldMatch {
-  int32 field_id = 1;
+  uint32 field_id = 1;
 
   message Exact {
     bytes value = 1;
@@ -154,9 +154,9 @@ message TableAction {
 }
 
 message Action {
-  int32 action_id = 1;
+  uint32 action_id = 1;
   message Param {
-    int32 param_id = 2;
+    uint32 param_id = 2;
     bytes value = 3;
   }
   repeated Param params = 4;
@@ -177,7 +177,7 @@ message ActionProfileWriteResponse {
 message ActionProfileReadRequest {
   uint64 device_id = 1;
   // Read all if empty.
-  repeated int32 action_profile_ids = 2;
+  repeated uint32 action_profile_ids = 2;
 }
 
 message ActionProfileReadResponse {
@@ -208,8 +208,8 @@ message ActionProfileEntry {
 message ActionProfileMember {
   uint32 member_id = 1;
   Action action = 2;
-  uint32 weight = 3;  // For WCMP
-  uint32 watch = 4;   // For fast-failover, this is TBD
+  int32 weight = 3;  // For WCMP
+  uint32 watch = 4;  // For fast-failover, this is TBD
 }
 
 message ActionProfileGroup {
@@ -222,7 +222,7 @@ message ActionProfileGroup {
   }
   Type type = 2;
   repeated uint32 member_id = 3;
-  uint32 max_size = 4;
+  int32 max_size = 4;
 }
 
 //------------------------------------------------------------------------------
@@ -247,7 +247,7 @@ message CounterReadRequest {
 }
 
 message CounterEntry {
-  int32 counter_id = 1;
+  uint32 counter_id = 1;
   repeated CounterCell cells = 2;
   // TODO timestamp?
 }
@@ -296,7 +296,7 @@ message MeterReadRequest {
 }
 
 message MeterEntry {
-  int32 meter_id = 1;
+  uint32 meter_id = 1;
   repeated MeterCell cells = 2;
   // TODO timestamp?
 }


### PR DESCRIPTION
Use consistent integer-types for various fields.

GUIDANCE
https://google.github.io/styleguide/cppguide.html#Integer_Types
You should not use the unsigned integer types such as uint32, unless there is a valid reason such as representing a bit pattern rather than a number, or you need defined overflow modulo 2^N. In particular, do not use unsigned types to say a number will never be negative.

Since table/field/action/etc. IDs can encode parent/hierarchy info in various bits, I consider them bit patterns, and therefore use uint32.
Other fields such as ‘weight’ and ‘max_size’ are changed to int32.