### PR TITLE
Add travis regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
   - docker run -w /PI pi make check -j2
-  - ./tools/check_style.sh
+  - docker run -w /PI pi ./tools/check_style.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Config file for automatic testing at travis-ci.org
+
+sudo: required
+
+dist: trusty
+
+language: generic
+
+services:
+  - docker
+
+matrix:
+  include:
+    - env: CXX=g++ CC=gcc
+    - env: CXX=clang++-3.8 CC=clang-3.8
+
+install:
+  - docker build -t pi .
+
+script:
+  - docker run -w /PI pi make check -j2
+  - ./tools/check_style.sh

--- a/CLI/table_dump.c
+++ b/CLI/table_dump.c
@@ -69,6 +69,7 @@ static void print_hexstr(const char *bytes, size_t nbytes) {
   }
 }
 
+// clang-format off
 static void print_match_param_v(pi_p4_id_t f_id, pi_p4info_match_type_t mt,
                                 const pi_match_key_t *match_key) {
   pi_netv_t fv;
@@ -97,6 +98,7 @@ static void print_match_param_v(pi_p4_id_t f_id, pi_p4info_match_type_t mt,
       assert(0);
   }
 }
+// clang-format on
 
 static void print_action_entry(pi_table_entry_t *entry) {
   // TODO(antonin): all types of action entries (indirect)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV PI_DEPS automake \
             build-essential \
             g++ \
             clang-3.8 \
+            clang-format-3.8 \
             libboost-dev \
             libboost-system-dev \
             libtool \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM p4lang/behavioral-model:latest
+MAINTAINER Antonin Bas <antonin@barefootnetworks.com>
+
+# Default to using 2 make jobs, which is a good default for CI. If you're
+# building locally or you know there are more cores available, you may want to
+# override this.
+ARG MAKEFLAGS
+ENV MAKEFLAGS ${MAKEFLAGS:--j2}
+
+ARG CXX
+ENV CXX ${CXX:-g++}
+
+ARG CC
+ENV CC ${CC:-gcc}
+
+ENV PI_DEPS automake \
+            build-essential \
+            g++ \
+            clang-3.8 \
+            libboost-dev \
+            libboost-system-dev \
+            libtool \
+            pkg-config \
+            python2.7 \
+            libjudy-dev \
+            libreadline-dev \
+            libpcap-dev \
+            libmicrohttpd-dev \
+            doxygen \
+            valgrind
+COPY . /PI/
+WORKDIR /PI/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $PI_DEPS && \
+    ./autogen.sh && \
+    ./configure --with-bmv2 --with-proto && \
+    make

--- a/tools/clang_format_check.py
+++ b/tools/clang_format_check.py
@@ -183,7 +183,8 @@ def main():
     parser.add_argument("-e", "--exe",
                         required=False,
                         help="The clang-format executable to use, by default "
-                        "we will try 'clang-format' and 'clang-format-3.6")
+                        "we will try 'clang-format', 'clang-format-3.8' and "
+                        "'clang-format-3.6'")
 
     # Files or directory to check
     parser.add_argument("file", nargs="+", help="Paths to the files that'll "
@@ -207,7 +208,7 @@ def main():
             exit(-1)
         clang_exec = args.exe
     else:
-        for e in ["clang-format", "clang-format-3.6"]:
+        for e in ["clang-format", "clang-format-3.8", "clang-format-3.6"]:
             if check_clang_format_exec(e):
                 clang_exec = e
                 break


### PR DESCRIPTION
We use a docker image which "inherits" from the bmv2 docker image to
avoid having to build / install all dependencies, which is why we are
adding a Dockerfile.

For now, we build with gcc (4.8) and clang 3.8.