### PR TITLE
P4runtime table read

### DIFF
--- a/frontends_extra/cpp/PI/frontends/cpp/tables.h
+++ b/frontends_extra/cpp/PI/frontends/cpp/tables.h
@@ -72,7 +72,8 @@ class MatchKey {
   const pi_p4info_t *p4info;
   pi_p4_id_t table_id;
   size_t nset{0};
-  std::vector<size_t> offsets{};
+  size_t mk_size;
+  std::vector<char> _data;
   pi_match_key_t *match_key;
   std::vector<char> _data{};
 };
@@ -94,9 +95,8 @@ class ActionData {
 
  private:
   template <typename T>
-  error_code_t format(pi_p4_id_t ap_id, T v, size_t offset);
-  error_code_t format(pi_p4_id_t ap_id, const char *ptr, size_t s,
-                      size_t offset);
+  error_code_t format(pi_p4_id_t ap_id, T v);
+  error_code_t format(pi_p4_id_t ap_id, const char *ptr, size_t s);
 
   pi_action_data_t *get() const {
     return action_data;
@@ -108,9 +108,9 @@ class ActionData {
 #endif
   pi_p4_id_t action_id;
   size_t nset{0};
-  std::vector<size_t> offsets{};
+  size_t ad_size;
+  std::vector<char> _data;
   pi_action_data_t *action_data;
-  std::vector<char> _data{};
 };
 
 class ActionEntry {

--- a/include/PI/p4info/actions.h
+++ b/include/PI/p4info/actions.h
@@ -61,6 +61,9 @@ char pi_p4info_action_param_byte0_mask(const pi_p4info_t *p4info,
 size_t pi_p4info_action_param_offset(const pi_p4info_t *p4info,
                                      pi_p4_id_t param_id);
 
+size_t pi_p4info_action_data_size(const pi_p4info_t *p4info,
+                                  pi_p4_id_t action_id);
+
 pi_p4_id_t pi_p4info_action_begin(const pi_p4info_t *p4info);
 pi_p4_id_t pi_p4info_action_next(const pi_p4info_t *p4info, pi_p4_id_t id);
 pi_p4_id_t pi_p4info_action_end(const pi_p4info_t *p4info);

--- a/include/PI/p4info/tables.h
+++ b/include/PI/p4info/tables.h
@@ -71,6 +71,9 @@ size_t pi_p4info_table_match_field_offset(const pi_p4info_t *p4info,
                                           pi_p4_id_t table_id,
                                           pi_p4_id_t field_id);
 
+size_t pi_p4info_table_match_key_size(const pi_p4info_t *p4info,
+                                      pi_p4_id_t table_id);
+
 void pi_p4info_table_match_field_info(const pi_p4info_t *p4info,
                                       pi_p4_id_t table_id, size_t index,
                                       pi_p4info_match_field_info_t *info);

--- a/proto/frontend/PI/frontends/proto/device_mgr.h
+++ b/proto/frontend/PI/frontends/proto/device_mgr.h
@@ -71,6 +71,10 @@ class DeviceMgr {
   Status table_read(p4_id_t table_id,
                     std::vector<p4::TableEntry> *entries) const;
 
+  // this is likely to be temporary, we may not want to hold all the entries in
+  // memory at once; could be replaced by an iterator of some sort
+  Status table_read_all(std::vector<p4::TableEntry> *entries) const;
+
   Status action_profile_write(
       const p4::ActionProfileUpdate &action_profile_update);
 

--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -317,6 +317,18 @@ ActionProfMgr::retrieve_group_handle(const Id &group_id) {
   return group_bimap.retrieve_handle(group_id);
 }
 
+const Id *
+ActionProfMgr::retrieve_member_id(pi_indirect_handle_t h) {
+  Lock lock(mutex);
+  return member_bimap.retrieve_id(h);
+}
+
+const Id *
+ActionProfMgr::retrieve_group_id(pi_indirect_handle_t h) {
+  Lock lock(mutex);
+  return group_bimap.retrieve_id(h);
+}
+
 }  // namespace proto
 
 }  // namespace fe

--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -56,8 +56,9 @@ void
 ActionProfBiMap::remove(const Id &id) {
   auto h_ptr = retrieve_handle(id);
   if (h_ptr != nullptr) {
+    auto h = *h_ptr;  // need to save the value before modifying the map
     bimap.remove_from_1(id);
-    bimap.remove_from_2(*h_ptr);
+    bimap.remove_from_2(h);
   }
 }
 

--- a/proto/frontend/src/action_prof_mgr.h
+++ b/proto/frontend/src/action_prof_mgr.h
@@ -139,6 +139,9 @@ class ActionProfMgr {
   const pi_indirect_handle_t *retrieve_member_handle(const Id &member_id);
   const pi_indirect_handle_t *retrieve_group_handle(const Id &group_id);
 
+  const Id *retrieve_member_id(pi_indirect_handle_t h);
+  const Id *retrieve_group_id(pi_indirect_handle_t h);
+
  private:
   pi::ActionData construct_action_data(const p4::Action &action);
 

--- a/src/p4info/actions.c
+++ b/src/p4info/actions.c
@@ -51,6 +51,7 @@ typedef struct _action_data_s {
     _action_param_data_t direct[INLINE_PARAMS];
     _action_param_data_t *indirect;
   } param_data;
+  size_t action_data_size;
 } _action_data_t;
 
 static size_t get_param_idx(pi_p4_id_t param_id) {
@@ -167,6 +168,7 @@ void pi_p4info_action_add(pi_p4info_t *p4info, pi_p4_id_t action_id,
     action->param_data.indirect =
         calloc(num_params, sizeof(_action_param_data_t));
   }
+  action->action_data_size = 0;
 }
 
 static char get_byte0_mask(size_t bitwidth) {
@@ -192,6 +194,8 @@ void pi_p4info_action_add_param(pi_p4info_t *p4info, pi_p4_id_t action_id,
   size_t param_idx = get_param_idx(param_id);
   pi_p4_id_t *param_ids = get_param_ids(action);
   param_ids[param_idx] = param_id;
+
+  action->action_data_size += (bitwidth + 7) / 8;
 
   size_t offset = param_data->offset;
   _action_param_data_t *params = get_param_data(action);
@@ -265,6 +269,12 @@ size_t pi_p4info_action_param_offset(const pi_p4info_t *p4info,
                                      pi_p4_id_t param_id) {
   _action_data_t *action = get_action_from_param_id(p4info, param_id);
   return get_param_data_at(action, param_id)->offset;
+}
+
+size_t pi_p4info_action_data_size(const pi_p4info_t *p4info,
+                                  pi_p4_id_t action_id) {
+  _action_data_t *action = get_action(p4info, action_id);
+  return action->action_data_size;
 }
 
 pi_p4_id_t pi_p4info_action_begin(const pi_p4info_t *p4info) {

--- a/tests/test_p4info.c
+++ b/tests/test_p4info.c
@@ -295,6 +295,8 @@ TEST(P4Info, ActionsStress) {
                              pi_p4info_action_param_offset(p4info, p_id));
       offset += (j + 7) / 8;
     }
+    TEST_ASSERT_EQUAL_UINT(offset,
+                           pi_p4info_action_data_size(p4info, adata[i].id));
   }
 
   for (size_t i = 0; i < num_actions; i++) {
@@ -463,6 +465,8 @@ TEST(P4Info, TablesStress) {
                                          p4info, tdata[i].id, finfo.field_id));
       offset += get_match_key_size_one_field(match_type, bw);
     }
+    TEST_ASSERT_EQUAL_UINT(offset,
+                           pi_p4info_table_match_key_size(p4info, tdata[i].id));
 
     TEST_ASSERT_EQUAL_UINT(tdata[i].num_actions,
                            pi_p4info_table_num_actions(p4info, tdata[i].id));


### PR DESCRIPTION
Add support for P4Runtime's TableRead

This required adding support for parsing table entries in the C++ PI frontend, which is achieved by MatchKeyReader and ActionDataReader. The DeviceMgr was updated to leverage these and now implements table_read and table_read_all.

Unit tests were added to test entry retrieval. I took advantage of this commit to cleanup the match table unit tests (less code duplication by using gtest value-parametrized tests).