### PR TITLE
Add support for valid match type in DeviceMgr

### DIFF
--- a/frontends_extra/cpp/PI/frontends/cpp/tables.h
+++ b/frontends_extra/cpp/PI/frontends/cpp/tables.h
@@ -45,6 +45,8 @@ class MatchKeyReader {
   error_code_t get_ternary(pi_p4_id_t f_id, std::string *key,
                            std::string *mask) const;
 
+  error_code_t get_valid(pi_p4_id_t f_id, bool *key) const;
+
   int get_priority() const;
 
  private:
@@ -88,6 +90,9 @@ class MatchKey {
 
   error_code_t get_ternary(pi_p4_id_t f_id, std::string *key,
                            std::string *mask) const;
+
+  error_code_t set_valid(pi_p4_id_t f_id, bool key);
+  error_code_t get_valid(pi_p4_id_t f_id, bool *key) const;
 
  private:
   template <typename T>

--- a/frontends_extra/cpp/src/tables.cpp
+++ b/frontends_extra/cpp/src/tables.cpp
@@ -139,6 +139,15 @@ MatchKeyReader::get_ternary(pi_p4_id_t f_id, std::string *key,
   return rc;
 }
 
+error_code_t
+MatchKeyReader::get_valid(pi_p4_id_t f_id, bool *key) const {
+  size_t offset = pi_p4info_table_match_field_offset(
+      match_key->p4info, match_key->table_id, f_id);
+  auto src = match_key->data + offset;
+  *key = (*src != 0);
+  return 0;
+}
+
 int
 MatchKeyReader::get_priority() const {
   return match_key->priority;
@@ -329,6 +338,19 @@ error_code_t
 MatchKey::get_ternary(pi_p4_id_t f_id, std::string *key,
                       std::string *mask) const {
   return reader.get_ternary(f_id, key, mask);
+}
+
+error_code_t
+MatchKey::set_valid(pi_p4_id_t f_id, bool key) {
+  size_t offset = pi_p4info_table_match_field_offset(p4info, table_id, f_id);
+  auto dst = match_key->data + offset;
+  *dst = key ? 1 : 0;
+  return 0;
+}
+
+error_code_t
+MatchKey::get_valid(pi_p4_id_t f_id, bool *key) const {
+  return reader.get_valid(f_id, key);
 }
 
 ActionDataReader::ActionDataReader(const pi_action_data_t *action_data)

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -183,6 +183,13 @@ class DeviceMgrImp {
       mf->set_field_id(finfo.field_id);
       switch (finfo.match_type) {
         case PI_P4INFO_MATCH_TYPE_VALID:
+          {
+            auto valid = mf->mutable_valid();
+            bool value;
+            mk_reader.get_valid(finfo.field_id, &value);
+            valid->set_value(value);
+          }
+          break;
         case PI_P4INFO_MATCH_TYPE_EXACT:
           {
             auto exact = mf->mutable_exact();
@@ -494,8 +501,10 @@ class DeviceMgrImp {
                                  mf.ternary().mask().data(),
                                  mf.ternary().value().size());
           break;
-        case p4::FieldMatch::kRange:
         case p4::FieldMatch::kValid:
+          match_key->set_valid(mf.field_id(), mf.valid().value());
+          break;
+        case p4::FieldMatch::kRange:
           return Code::UNIMPLEMENTED;
         default:
           return Code::INVALID_ARGUMENT;


### PR DESCRIPTION
Even though the valid match type goes away in P4_16, this is the easiest
way of handling valid in P4_14.