### PR TITLE
Update p4runtime.proto

### DIFF
--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -251,8 +251,10 @@ Code
 ActionProfMgr::group_update_members(pi::ActProf &ap,
                                     const p4::ActionProfileGroup &group) {
   Code code;
-  std::vector<Id> new_membership(group.member_id().begin(),
-                                 group.member_id().end());
+  std::vector<Id> new_membership(group.members().size());
+  std::transform(
+      group.members().begin(), group.members().end(), new_membership.begin(),
+      [](const p4::ActionProfileGroup::Member &m) { return m.member_id(); });
   std::sort(new_membership.begin(), new_membership.end());
   auto group_id = group.group_id();
   auto &membership = group_members.at(group_id);

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -394,7 +394,8 @@ class DeviceMgrImp {
           code = Code::UNKNOWN;
           break;
         }
-        group->add_member_id(*member_id);
+        auto member = group->add_members();
+        member->set_member_id(*member_id);
       }
     }
 

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -236,8 +236,6 @@ message ActionProfileEntry {
 message ActionProfileMember {
   uint32 member_id = 1;
   Action action = 2;
-  int32 weight = 3;  // For WCMP
-  uint32 watch = 4;  // For fast-failover, this is TBD
 }
 
 message ActionProfileGroup {
@@ -249,7 +247,13 @@ message ActionProfileGroup {
     FAST_FAILOVER = 2;
   }
   Type type = 2;
-  repeated uint32 member_id = 3;
+  message Member {
+    uint32 member_id = 1;
+    int32 weight = 2;  // For WCMP
+    uint32 watch = 3;  // For fast-failover, this is TBD
+  }
+  repeated Member members = 3;
+  // Maximum size of the group (to help provision resources on the target).
   int32 max_size = 4;
 }
 


### PR DESCRIPTION
Move "weight" and "watch" from being part of ActionProfileMember definition to ActionProfileGroup attributes for using that member.
A weight makes sense in the context of adding a member to a group, not when creating a member.