### PR TITLE
Add batch support to the PI C API

### DIFF
--- a/include/PI/pi.h
+++ b/include/PI/pi.h
@@ -81,6 +81,14 @@ pi_status_t pi_session_init(pi_session_handle_t *session_handle);
 //! Terminate a client session.
 pi_status_t pi_session_cleanup(pi_session_handle_t session_handle);
 
+//! Start a batch of operations for the session. For a given session, there can
+//! only be one ongoing batch operation.
+pi_status_t pi_batch_begin(pi_session_handle_t session_handle);
+
+//! End the ongoing batch for the session. If \p hw_sync is true, the call will
+//! block until all the operations have been committed to hardware.
+pi_status_t pi_batch_end(pi_session_handle_t session_handle, bool hw_sync);
+
 //! PI cleanup function.
 pi_status_t pi_destroy();
 

--- a/include/PI/target/pi_imp.h
+++ b/include/PI/target/pi_imp.h
@@ -45,6 +45,10 @@ pi_status_t _pi_session_init(pi_session_handle_t *session_handle);
 
 pi_status_t _pi_session_cleanup(pi_session_handle_t session_handle);
 
+pi_status_t _pi_batch_begin(pi_session_handle_t session_handle);
+
+pi_status_t _pi_batch_end(pi_session_handle_t session_handle, bool hw_sync);
+
 pi_status_t _pi_destroy();
 
 pi_status_t _pi_packetout_send(pi_dev_id_t dev_id, const char *pkt,

--- a/targets/bmv2/pi_imp.cpp
+++ b/targets/bmv2/pi_imp.cpp
@@ -157,6 +157,17 @@ pi_status_t _pi_session_cleanup(pi_session_handle_t session_handle) {
   return PI_STATUS_SUCCESS;
 }
 
+pi_status_t _pi_batch_begin(pi_session_handle_t session_handle) {
+  (void) session_handle;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_batch_end(pi_session_handle_t session_handle, bool hw_sync) {
+  (void) session_handle;
+  (void) hw_sync;
+  return PI_STATUS_SUCCESS;
+}
+
 pi_status_t _pi_packetout_send(pi_dev_id_t dev_id, const char *pkt,
                                size_t size) {
   if (cpu_send_recv->send_pkt(dev_id, pkt, size) != 0)

--- a/targets/dummy/pi_imp.c
+++ b/targets/dummy/pi_imp.c
@@ -95,6 +95,19 @@ pi_status_t _pi_session_cleanup(pi_session_handle_t session_handle) {
   return PI_STATUS_SUCCESS;
 }
 
+pi_status_t _pi_batch_begin(pi_session_handle_t session_handle) {
+  (void)session_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_batch_end(pi_session_handle_t session_handle, bool hw_sync) {
+  (void)session_handle;
+  (void)hw_sync;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
 pi_status_t _pi_packetout_send(pi_dev_id_t dev_id, const char *pkt,
                                size_t size) {
   (void)dev_id;


### PR DESCRIPTION
For bmv2 batch_start and batch_end are no-ops, but some hardware targets
may be able to leverage these functions.