### PR TITLE
Temporary fix for demo build

### DIFF
--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -38,17 +38,16 @@ AS_IF([test "x$GRPC_CPP_PLUGIN" = x], [
 want_bmv2=no
 AC_ARG_WITH([bmv2],
     AS_HELP_STRING([--with-bmv2], [Build for bmv2 target]),
-    [want_bmv2=yes], [])
+    [want_bmv2="$withval"], [])
 
-with_proto_demo=no
-AS_IF([test "$want_bmv2" = yes], [
-    with_proto_demo=yes
-    AC_CHECK_LIB([microhttpd], [MHD_start_daemon], [], [
-        AC_MSG_WARN([microhttpd library not found, will not compile demo])
-        with_proto_demo=no
-    ])
-    # TODO(antonin): demo also uses boost_system
+AM_CONDITIONAL([WITH_BMV2], [test "$want_bmv2" = yes])
+
+with_proto_demo=yes
+AC_CHECK_LIB([microhttpd], [MHD_start_daemon], [], [
+    AC_MSG_WARN([microhttpd library not found, will not compile demo])
+    with_proto_demo=no
 ])
+# TODO(antonin): demo also uses boost_system
 
 AM_CONDITIONAL([WITH_PROTO_DEMO], [test "$with_proto_demo" = yes])
 

--- a/proto/demo_grpc/Makefile.am
+++ b/proto/demo_grpc/Makefile.am
@@ -9,10 +9,7 @@ AM_CPPFLAGS = \
 
 AM_CXXFLAGS = -Wall -Werror
 
-bin_PROGRAMS = pi_grpc_server
 noinst_PROGRAMS = test_client controller pi_server_dummy test_perf
-
-pi_grpc_server_SOURCES = pi_server_main.cpp
 
 pi_server_dummy_SOURCES = pi_server_main.cpp
 
@@ -44,6 +41,11 @@ $(PROTOBUF_LIBS) $(GRPC_LIBS)
 libpigrpcserver_la_LIBADD = \
 $(COMMON_SERVER_LIBS)
 
+if WITH_BMV2
+bin_PROGRAMS = pi_grpc_server
+
+pi_grpc_server_SOURCES = pi_server_main.cpp
+
 # COMMON_SERVER_LIBS need to be repeated here for some reason, this seems to be
 # specific to the libtool version packaged with Ubuntu (see
 # http://stackoverflow.com/questions/11802727/libtool-doesnt-provide-library-dependencies-to-link). Also
@@ -54,6 +56,7 @@ $(COMMON_SERVER_LIBS) \
 libpigrpcserver.la \
 $(top_builddir)/../targets/bmv2/libpi_bmv2.la \
 -lthrift -lruntimestubs -lsimpleswitch_thrift
+endif  # WITH_BMV2
 
 pi_server_dummy_LDADD = \
 $(COMMON_SERVER_LIBS) \


### PR DESCRIPTION
We build the gRPC server library even when compiling without bmv2. In
the future, this library should probably be moved out of the demo
folder.