### PR TITLE
Stop using 0 for params and match fields ids

### DIFF
--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -279,7 +279,7 @@ static pi_status_t read_actions(reader_state_t *state, cJSON *root,
     PI_LOG_DEBUG("Adding action '%s'\n", name);
     pi_p4info_action_add(p4info, pi_id, name, num_params);
 
-    int param_index = 0;
+    int param_index = 1;
     cJSON *param;
     cJSON_ArrayForEach(param, params) {
       item = cJSON_GetObjectItem(param, "name");
@@ -510,7 +510,7 @@ static pi_status_t read_tables(reader_state_t *state, cJSON *root,
     import_pragmas(table, p4info, pi_id);
 
     cJSON *match_field;
-    int match_field_index = 0;
+    int match_field_index = 1;
     cJSON_ArrayForEach(match_field, json_match_key) {
       item = cJSON_GetObjectItem(match_field, "match_type");
       if (!item) return PI_STATUS_CONFIG_READER_ERROR;

--- a/tests/test_bmv2_json_reader.c
+++ b/tests/test_bmv2_json_reader.c
@@ -168,7 +168,7 @@ TEST(IdAssignment, Pragmas) {
   pi_p4_id_t action_id = (PI_ACTION_ID << 24) | 8;
   TEST_ASSERT_EQUAL_UINT(action_id, pi_p4info_action_id_from_name(p4info, "a"));
   TEST_ASSERT_EQUAL_UINT(
-      0, pi_p4info_action_param_id_from_name(p4info, action_id, "ap"));
+      1, pi_p4info_action_param_id_from_name(p4info, action_id, "ap"));
 
   TEST_ASSERT_EQUAL_UINT((PI_TABLE_ID << 24) | 9,
                          pi_p4info_table_id_from_name(p4info, "t"));


### PR DESCRIPTION
It has been decided to stop using 0 in ids for action parameters and
table match fields. This is because in protobuf 3, 0 is the default
value for integers and there is an ambiguity between an id that has been
set to 0 and an id that wasn't set. Additionally this is more
consistent with the way ids used to be allocated (0 was used exclusively
as an invalid id).