### PR TITLE
Proposal to support extern types in p4runtime

### DIFF
--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -21,14 +21,12 @@ import "google/protobuf/any.proto";
 package p4.config;
 
 message P4Info {
-  repeated Table tables = 1;
-  repeated Action actions = 2;
-  repeated ActionProfile action_profiles = 3;
-  repeated Counter counters = 4;
-  repeated Meter meters = 5;
-
-  // for extern?
-  repeated google.protobuf.Any externs = 100;
+  repeated Extern externs = 1;
+  repeated Table tables = 2;
+  repeated Action actions = 3;
+  repeated ActionProfile action_profiles = 4;
+  repeated Counter counters = 5;
+  repeated Meter meters = 6;
 }
 
 message Preamble {
@@ -53,6 +51,23 @@ message Preamble {
   // application should be able to indiscriminately use the name or the alias.
   string alias = 3;
   repeated string annotations = 4;
+}
+
+// used to group all extern instances of the same type in one message
+message Extern {
+  // the extern_type_id is assigned during compilation. It is likely that this
+  // id will in fact come from a P4 annotation to the extern declaration and
+  // that each vendor will receive a prefix to avoid collisions.
+  uint32 extern_type_id = 1;
+  string extern_type_name = 2;
+  repeated ExternInstance instances = 3;
+}
+
+message ExternInstance {
+  Preamble preamble = 1;
+  // specific to the extern type, declared in a separate vendor-specific proto
+  // file
+  google.protobuf.Any info = 2;
 }
 
 // TODO(antonin): define inside the Table message?

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -14,6 +14,7 @@
 
 syntax = "proto3";
 
+import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
 import "p4/config/p4info.proto";
 
@@ -114,12 +115,22 @@ message Update {
 
 message Entity {
   oneof entity {
-    TableEntry table_entry = 1;
-    ActionProfileMember action_profile_member = 2;
-    ActionProfileGroup action_profile_group = 3;
-    MeterEntry meter_entry = 4;
-    CounterEntry counter_entry = 5;
+    ExternEntry extern_entry = 1;
+    TableEntry table_entry = 2;
+    ActionProfileMember action_profile_member = 3;
+    ActionProfileGroup action_profile_group = 4;
+    MeterEntry meter_entry = 5;
+    CounterEntry counter_entry = 6;
   }
+}
+
+message ExternEntry {
+  // the extern_type_id is assigned during compilation. It is likely that this
+  // id will in fact come from a P4 annotation to the extern declaration and
+  // that each vendor will receive a prefix to avoid collisions.
+  uint32 extern_type_id = 1;
+  uint32 extern_id = 2;  // id of the instance
+  google.protobuf.Any entry = 3;
 }
 
 // From Section 11 of P4_14 spec:


### PR DESCRIPTION
Proposed changes to p4info.proto and p4runtime.proto. We leverage
google.protobuf.Any to pack / unpack extern-specific data in both
cases. Guidelines to choose packages / appropriate URLs for
extern-specific protobuf messages are TBD.