### PR TITLE
Add libtool-bin to PI deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV PI_DEPS automake \
             libboost-dev \
             libboost-system-dev \
             libtool \
+            libtool-bin \
             pkg-config \
             python2.7 \
             libjudy-dev \


### PR DESCRIPTION
This is needed to run the CLI tests; I believe it is now needed because
of the base image being upgraded to Ubuntu 16.04.