### PR TITLE
Config gnmi proto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = third_party/googletest
 	url = https://github.com/google/googletest
         ignore = untracked
+[submodule "proto/openconfig/reference"]
+	path = proto/openconfig/reference
+	url = https://github.com/openconfig/reference.git

--- a/proto/.gitignore
+++ b/proto/.gitignore
@@ -1,3 +1,4 @@
 cpp_out
 grpc_out
 proto_files.ts
+gnmi/gnmi.proto

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -9,7 +9,7 @@ endif
 
 SUBDIRS = . p4info frontend server $(MAYBE_PROTO_DEMO) tests
 
-PROTOFLAGS = -I$(abs_srcdir)
+PROTOFLAGS = -I$(abs_srcdir) -I$(abs_builddir)
 
 # This makefile relies on the symbolic link that we create google ->
 # googleapis/google. Without it, we run into some issues with `protoc`. An
@@ -31,7 +31,8 @@ p4/p4runtime.proto \
 p4/config/p4info.proto \
 google/rpc/status.proto \
 google/rpc/code.proto \
-p4/tmp/p4config.proto
+p4/tmp/p4config.proto \
+openconfig/reference/rpc/gnmi/gnmi.proto
 
 proto_cpp_files = \
 cpp_out/p4/p4runtime.pb.cc \
@@ -43,7 +44,9 @@ cpp_out/google/rpc/status.pb.h \
 cpp_out/google/rpc/code.pb.cc \
 cpp_out/google/rpc/code.pb.h \
 cpp_out/p4/tmp/p4config.pb.cc \
-cpp_out/p4/tmp/p4config.pb.h
+cpp_out/p4/tmp/p4config.pb.h \
+cpp_out/gnmi/gnmi.pb.cc \
+cpp_out/gnmi/gnmi.pb.h
 
 proto_grpc_files = \
 grpc_out/p4/p4runtime.grpc.pb.cc \
@@ -55,7 +58,9 @@ grpc_out/google/rpc/status.grpc.pb.h \
 grpc_out/google/rpc/code.grpc.pb.cc \
 grpc_out/google/rpc/code.grpc.pb.h \
 grpc_out/p4/tmp/p4config.grpc.pb.cc \
-grpc_out/p4/tmp/p4config.grpc.pb.h
+grpc_out/p4/tmp/p4config.grpc.pb.h \
+grpc_out/gnmi/gnmi.grpc.pb.cc \
+grpc_out/gnmi/gnmi.grpc.pb.h
 
 includep4dir = $(includedir)/p4/
 nodist_includep4_HEADERS = \
@@ -78,6 +83,11 @@ cpp_out/google/rpc/status.pb.h \
 cpp_out/google/rpc/code.pb.h \
 grpc_out/google/rpc/status.grpc.pb.h \
 grpc_out/google/rpc/code.grpc.pb.h
+
+includegnmidir = $(includedir)/gnmi/
+nodist_includegnmi_HEADERS = \
+cpp_out/gnmi/gnmi.pb.h \
+grpc_out/gnmi/gnmi.grpc.pb.h
 
 AM_CPPFLAGS = -Icpp_out -Igrpc_out \
 -I$(top_srcdir)/../include
@@ -111,18 +121,30 @@ py_out/google/rpc/code_pb2.py \
 py_out/google/rpc/status_pb2.py \
 py_out/google/rpc/__init__.py
 
+gnmipydir = $(pythondir)/gnmi
+nodist_gnmipy_PYTHON = \
+py_out/gnmi/__init__.py \
+py_out/gnmi/gnmi_pb2.py
+
 BUILT_SOURCES += \
 $(nodist_p4py_PYTHON) \
 $(nodist_p4configpy_PYTHON) \
 $(nodist_p4tmppy_PYTHON) \
 $(nodist_googlepy_PYTHON) \
-$(nodist_googlerpcpy_PYTHON)
+$(nodist_googlerpcpy_PYTHON) \
+$(nodist_gnmipy_PYTHON)
 endif
+
+$(abs_builddir)/gnmi/gnmi.proto : $(abs_srcdir)/openconfig/reference/rpc/gnmi/gnmi.proto
+	@mkdir -p $(builddir)/gnmi
+	$(SED) 's;github.com/golang/protobuf/ptypes/any/any.proto;google/protobuf/any.proto;g' $^ > gnmi.proto.tmp
+	$(SED) 's;github.com/google/protobuf/src/google/protobuf/descriptor.proto;google/protobuf/descriptor.proto;g' gnmi.proto.tmp > $@
+	@rm gnmi.proto.tmp
 
 # See http://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
 
 # Is there any issue with running protoc only once, instead of once per proto?
-proto_files.ts: $(protos)
+proto_files.ts: $(protos) $(abs_builddir)/gnmi/gnmi.proto
 	@rm -f proto_files.tmp
 	@touch proto_files.tmp
 	@mkdir -p $(builddir)/cpp_out
@@ -137,7 +159,7 @@ if HAVE_GRPC_PY_PLUGIN
 # an old version of the Python plugin.
 	$(PROTOC) $^ --python_out $(builddir)/py_out $(PROTOFLAGS) --grpc_out $(builddir)/py_out --plugin=protoc-gen-grpc=$(GRPC_PY_PLUGIN)
 	@touch $(builddir)/py_out/p4/__init__.py $(builddir)/py_out/p4/config/__init__.py $(builddir)/py_out/p4/tmp/__init__.py
-	@touch $(builddir)/py_out/google/__init__.py $(builddir)/py_out/google/rpc/__init__.py
+	@touch $(builddir)/py_out/google/__init__.py $(builddir)/py_out/google/rpc/__init__.py $(builddir)/py_out/gnmi/__init__.py
 endif
 	@mv -f proto_files.tmp $@
 
@@ -179,4 +201,4 @@ libpiproto_la_LIBADD = $(PROTOBUF_LIBS) $(GRPC_LIBS)
 nobase_include_HEADERS = \
 PI/proto/util.h
 
-CLEANFILES = $(BUILT_SOURCES) proto_files.ts
+CLEANFILES = $(BUILT_SOURCES) proto_files.ts gnmi/gnmi.proto

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -87,6 +87,8 @@ case "${host_os}" in
         ;;
 esac
 
+AC_PROG_SED
+
 # Generate makefiles
 AC_CONFIG_FILES([Makefile
                  p4info/Makefile

--- a/proto/demo_grpc/Makefile.am
+++ b/proto/demo_grpc/Makefile.am
@@ -12,7 +12,7 @@ AM_CXXFLAGS = -Wall -Werror
 
 noinst_PROGRAMS = controller pi_server_dummy test_perf
 
-pi_server_dummy_SOURCES = pi_server_main.cpp
+pi_server_dummy_SOURCES = pi_server_main.cpp gnmi_mgr_dummy.cpp
 
 test_perf_SOURCES = test_perf.cpp
 
@@ -26,12 +26,13 @@ app.cpp
 COMMON_SERVER_LIBS = \
 $(top_builddir)/server/libpigrpcserver.la \
 $(top_builddir)/frontend/libpifeproto.la \
+$(top_builddir)/libpiproto.la \
 $(top_builddir)/../src/libpiall.la
 
 if WITH_BMV2
 bin_PROGRAMS = pi_grpc_server
 
-pi_grpc_server_SOURCES = pi_server_main.cpp
+pi_grpc_server_SOURCES = pi_server_main.cpp gnmi_mgr_dummy.cpp
 
 pi_grpc_server_LDADD = \
 $(COMMON_SERVER_LIBS) \

--- a/proto/demo_grpc/gnmi_mgr_dummy.cpp
+++ b/proto/demo_grpc/gnmi_mgr_dummy.cpp
@@ -1,0 +1,72 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/frontends/proto/gnmi_mgr.h>
+
+#include "google/rpc/code.pb.h"
+
+using Status = ::google::rpc::Status;
+using Code = ::google::rpc::Code;
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+class GnmiMgrImp {
+ public:
+  Status config_get(const gnmi::GetRequest &request,
+                    gnmi::GetResponse *response) const {
+    Status status;
+    status.set_code(Code::UNIMPLEMENTED);
+    return status;
+  }
+
+  Status config_set(const gnmi::SetRequest &request,
+                    gnmi::SetResponse *response) {
+    Status status;
+    status.set_code(Code::UNIMPLEMENTED);
+    return status;
+  }
+};
+
+GnmiMgr::GnmiMgr()
+    : pimp(new GnmiMgrImp()) { }
+
+GnmiMgr::~GnmiMgr() = default;
+
+Status
+GnmiMgr::config_get(const gnmi::GetRequest &request,
+                          gnmi::GetResponse *response) const {
+  return pimp->config_get(request, response);
+}
+
+Status
+GnmiMgr::config_set(const gnmi::SetRequest &request,
+                          gnmi::SetResponse *response) {
+  return pimp->config_set(request, response);
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -30,6 +30,7 @@ $(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpip4info.la
 
 nobase_include_HEADERS = \
-PI/frontends/proto/device_mgr.h
+PI/frontends/proto/device_mgr.h \
+PI/frontends/proto/gnmi_mgr.h
 
 lib_LTLIBRARIES = libpifeproto.la

--- a/proto/frontend/PI/frontends/proto/gnmi_mgr.h
+++ b/proto/frontend/PI/frontends/proto/gnmi_mgr.h
@@ -1,0 +1,62 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef PI_FRONTENDS_PROTO_GNMI_MGR_H_
+#define PI_FRONTENDS_PROTO_GNMI_MGR_H_
+
+#include <memory>
+
+#include "gnmi/gnmi.pb.h"
+#include "google/rpc/status.pb.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+// forward declaration for PIMPL class
+class GnmiMgrImp;
+
+class GnmiMgr {
+ public:
+  using Status = ::google::rpc::Status;
+
+  GnmiMgr();
+  ~GnmiMgr();
+
+  Status config_get(const gnmi::GetRequest &request,
+                    gnmi::GetResponse *response) const;
+
+  Status config_set(const gnmi::SetRequest &request,
+                    gnmi::SetResponse *response);
+
+ private:
+  // PIMPL design
+  std::unique_ptr<GnmiMgrImp> pimp;
+};
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi
+
+#endif  // PI_FRONTENDS_PROTO_GNMI_MGR_H_


### PR DESCRIPTION
The first commit adds gnmi as a git dependency for this repository and adds the infra required to compile it.

The second is an attempt at an interface to process gnmi Get and Set requests. Nothing permanent, mostly a POC.