### PR TITLE
Add support for writing meter configs in DeviceMgr

### DIFF
--- a/frontends_extra/cpp/PI/frontends/cpp/tables.h
+++ b/frontends_extra/cpp/PI/frontends/cpp/tables.h
@@ -56,6 +56,9 @@ class MatchKeyReader {
 
 class MatchKey {
   friend class MatchTable;
+  friend struct MatchKeyHash;
+  friend struct MatchKeyEq;
+
  public:
   MatchKey(const pi_p4info_t *p4info, pi_p4_id_t table_id);
   ~MatchKey();
@@ -94,6 +97,11 @@ class MatchKey {
   error_code_t set_valid(pi_p4_id_t f_id, bool key);
   error_code_t get_valid(pi_p4_id_t f_id, bool *key) const;
 
+  MatchKey(const MatchKey &other);
+  MatchKey &operator=(const MatchKey &other);
+  MatchKey(MatchKey &&other) = default;
+  MatchKey &operator=(MatchKey &&other) = default;
+
  private:
   template <typename T>
   error_code_t format(pi_p4_id_t f_id, T v, size_t offset, size_t *written);
@@ -111,6 +119,18 @@ class MatchKey {
   std::vector<char> _data;
   pi_match_key_t *match_key;
   MatchKeyReader reader;
+};
+
+// MatchKeyHash and MatchKeyEq can be used to store MatchKey objects into an
+// unordered_map. They take into account the table id and the match key data
+// (including the priority).
+
+struct MatchKeyHash {
+  size_t operator()(const MatchKey &mk) const;
+};
+
+struct MatchKeyEq {
+  bool operator()(const MatchKey &mk1, const MatchKey &mk2) const;
 };
 
 class ActionDataReader {

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -14,6 +14,8 @@ libpifeproto_la_SOURCES = \
 src/device_mgr.cpp \
 src/action_prof_mgr.h \
 src/action_prof_mgr.cpp \
+src/table_info_store.h \
+src/table_info_store.cpp \
 src/common.h
 
 libpifeproto_la_LIBADD = \

--- a/proto/frontend/src/table_info_store.cpp
+++ b/proto/frontend/src/table_info_store.cpp
@@ -1,0 +1,103 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/frontends/cpp/tables.h>
+#include <PI/pi.h>
+
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <unordered_map>
+
+#include "table_info_store.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+using MatchKey = TableInfoStore::MatchKey;
+using Data = TableInfoStore::Data;
+
+class TableInfoStoreOne {
+ public:
+  void add_entry(const MatchKey &mk, const Data &data) {
+    Lock lock(mutex);
+    data_map.emplace(mk, data);
+  }
+
+  void remove_entry(const MatchKey &mk) {
+    Lock lock(mutex);
+    data_map.erase(mk);
+  }
+
+  Data get_entry(const MatchKey &mk) {
+    auto it = data_map.find(mk);
+    return (it == data_map.end()) ? Data() : it->second;
+  }
+
+ private:
+  using Mutex = std::mutex;
+  using Lock = std::lock_guard<Mutex>;
+
+  mutable Mutex mutex{};
+  std::unordered_map<MatchKey, Data, pi::MatchKeyHash, pi::MatchKeyEq>
+  data_map{};
+};
+
+TableInfoStore::TableInfoStore() = default;
+TableInfoStore::~TableInfoStore() = default;
+
+void
+TableInfoStore::add_table(pi_p4_id_t t_id) {
+  tables.emplace(
+      t_id, std::unique_ptr<TableInfoStoreOne>(new TableInfoStoreOne()));
+}
+
+void
+TableInfoStore::add_entry(pi_p4_id_t t_id, const MatchKey &mk,
+                          const Data &data) {
+  auto &table = tables.at(t_id);
+  table->add_entry(mk, data);
+}
+
+void
+TableInfoStore::remove_entry(pi_p4_id_t t_id, const MatchKey &mk) {
+  auto &table = tables.at(t_id);
+  table->remove_entry(mk);
+}
+
+Data
+TableInfoStore::get_entry(pi_p4_id_t t_id, const MatchKey &mk) const {
+  auto &table = tables.at(t_id);
+  return table->get_entry(mk);
+}
+
+void
+TableInfoStore::reset() {
+  tables.clear();
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi

--- a/proto/frontend/src/table_info_store.h
+++ b/proto/frontend/src/table_info_store.h
@@ -1,0 +1,84 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SRC_TABLE_INFO_STORE_H_
+#define SRC_TABLE_INFO_STORE_H_
+
+#include <PI/frontends/cpp/tables.h>
+#include <PI/pi.h>
+
+#include <memory>
+#include <unordered_map>
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+class TableInfoStoreOne;
+
+class TableInfoStore {
+ public:
+  // instead of storing proto data (RepeatedPtrField<p4::MatchKey>), we store
+  // the PI match key representation. Using protobuf data as a key can become
+  // somewhat nighmarish; in particular the order of match fields in the match
+  // key should be able to change without impacting the hash or equality
+  // operator.
+  using MatchKey = pi::MatchKey;
+
+  // wish I could use boost::variant for these
+  struct Data {
+    Data() : none(true), handle(0) { }
+    explicit Data(pi_entry_handle_t handle) : none(false), handle(handle) { }
+
+    const bool none;
+    const pi_entry_handle_t handle;
+    // TODO(antonin): add support for controller metadata?
+  };
+
+  TableInfoStore();
+
+  ~TableInfoStore();
+
+  void add_table(pi_p4_id_t t_id);
+
+  void add_entry(pi_p4_id_t t_id, const MatchKey &mk, const Data &data);
+
+  void remove_entry(pi_p4_id_t t_id, const MatchKey &mk);
+
+  // we assume that Data is going to remain very small and that it makes sense
+  // to return it by value (for the sake of thread-safety)
+  Data get_entry(pi_p4_id_t t_id, const MatchKey &mk) const;
+
+  void reset();
+
+ private:
+  // TableInfoStoreOne includes a mutex, so we need a pointer
+  std::unordered_map<pi_p4_id_t, std::unique_ptr<TableInfoStoreOne> > tables;
+};
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi
+
+#endif  // SRC_TABLE_INFO_STORE_H_


### PR DESCRIPTION
The tricky case was direct meters, for which we need to be able to map
the match key to the correct entry handle; unless we want to start
adding PI C APIs which can work from the match key, like we did for
delete and modify (table entries). It doesn't seem like such a bad
solution to keep some limited per-entry state in DeviceMgr (may be
needed to support the controller_metadata cookie anyaway). To store this
state, the TableInfoStore was introduced.