### PR TITLE
Add support for table entry modify in DeviceMgr

### DIFF
--- a/frontends_extra/cpp/PI/frontends/cpp/tables.h
+++ b/frontends_extra/cpp/PI/frontends/cpp/tables.h
@@ -262,6 +262,11 @@ class MatchTable {
   pi_status_t entry_delete(pi_entry_handle_t entry_handle);
   pi_status_t entry_delete_wkey(const MatchKey &match_key);
 
+  pi_status_t entry_modify(pi_entry_handle_t entry_handle,
+                           const ActionEntry &action_entry);
+  pi_status_t entry_modify_wkey(const MatchKey &match_key,
+                                const ActionEntry &action_entry);
+
   pi_status_t default_entry_set(const ActionEntry &action_entry);
 
   // these overloads are mostly for backward-compatibility, try not to use in

--- a/frontends_extra/cpp/src/tables.cpp
+++ b/frontends_extra/cpp/src/tables.cpp
@@ -582,6 +582,22 @@ MatchTable::entry_delete_wkey(const MatchKey &match_key) {
 }
 
 pi_status_t
+MatchTable::entry_modify(pi_entry_handle_t entry_handle,
+                         const ActionEntry &action_entry) {
+  auto entry = build_table_entry(action_entry);
+  return pi_table_entry_modify(sess, dev_tgt.dev_id, table_id, entry_handle,
+                               &entry);
+}
+
+pi_status_t
+MatchTable::entry_modify_wkey(const MatchKey &match_key,
+                              const ActionEntry &action_entry) {
+  auto entry = build_table_entry(action_entry);
+  return pi_table_entry_modify_wkey(sess, dev_tgt.dev_id, table_id,
+                                    match_key.get(), &entry);
+}
+
+pi_status_t
 MatchTable::default_entry_set(const ActionEntry &action_entry) {
   auto entry = build_table_entry(action_entry);
   return pi_table_default_action_set(sess, dev_tgt, table_id, &entry);


### PR DESCRIPTION
This required some minor additions to the PI C++ frontend.
Also some small cleanup in the DeviceMgr unit tests; in particular
DummySwitchMock no longer inherits from DummySwitch which was error
prone and non needed, given that we use composition to delegate to the
fake switch.