### PR TITLE
Tentative support for error_details in grpc::Status

### DIFF
--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -26,7 +26,9 @@ dnl readable
 AC_SUBST([PROTOBUF_CFLAGS])
 AC_SUBST([PROTOBUF_LIBS])
 
-PKG_CHECK_MODULES([GRPC], [grpc >= 1.0.0 grpc++ >= 1.0.0])
+dnl we need >= 1.3.0 so that binary error details (libgrpc++_error_details) are
+dnl available
+PKG_CHECK_MODULES([GRPC], [grpc >= 1.3.0 grpc++ >= 1.3.0])
 AC_SUBST([GRPC_CFLAGS])
 AC_SUBST([GRPC_LIBS])
 

--- a/proto/server/Makefile.am
+++ b/proto/server/Makefile.am
@@ -16,4 +16,5 @@ nobase_include_HEADERS = PI/proto/pi_server.h
 libpigrpcserver_la_LIBADD = \
 $(top_builddir)/frontend/libpifeproto.la \
 $(top_builddir)/libpiproto.la \
-$(PROTOBUF_LIBS) $(GRPC_LIBS)
+$(PROTOBUF_LIBS) $(GRPC_LIBS) \
+-lgrpc++_error_details


### PR DESCRIPTION
Since version 1.3.0, gRPC supports returning error details along with
the grpc::Status. This commit modifies the gRPC server implementation
for P4Runtime to leverage this feature. DeviceMgr methods return a
google::rpc::Status object which is converted to a grpc::Status object
using the grpc::SetErrorDetails helper function which ships with
gRPC. On the client side, the grpc::ExtractErrorDetails method can be
used to retrieve the error details.

Note that the google::rpc::Status proto contains a `repeated
google.protobuf.Any` field which will be used to carry
P4Runtime-specific error codes for each batch request, in addition to
the generic gRPC error code.

Because of the new dependency on error details, the configure.ac file
was updated to require a version >= 1.3.0 for gRPC.