### PR TITLE
Some build adjustments

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -160,19 +160,24 @@ $(BUILT_SOURCES): proto_files.ts
 	  fi; \
 	fi
 
-# is this the best name for this library, or is this too generic?
-lib_LTLIBRARIES = libpiproto.la
+noinst_LTLIBRARIES = libpiprotobuf.la libpigrpc.la
 
 # generated source should not be distributed
-nodist_libpiproto_la_SOURCES = \
-$(proto_cpp_files) $(proto_grpc_files)
+nodist_libpiprotobuf_la_SOURCES = $(proto_cpp_files)
+nodist_libpigrpc_la_SOURCES = $(proto_grpc_files)
+
+libpiprotobuf_la_LIBADD = $(PROTOBUF_LIBS)
+libpigrpc_la_LIBADD = $(PROTOBUF_LIBS) $(GRPC_LIBS)
+
+# is this the best name for this library, or is this too generic?
+lib_LTLIBRARIES = libpiproto.la
 
 libpiproto_la_SOURCES = \
 src/util.cpp
 
+libpiproto_la_LIBADD = libpiprotobuf.la libpigrpc.la
+
 nobase_include_HEADERS = \
 PI/proto/util.h
-
-libpiproto_la_LIBADD = $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 CLEANFILES = $(BUILT_SOURCES) proto_files.ts

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -28,7 +28,7 @@ AC_SUBST([PROTOBUF_LIBS])
 
 dnl we need >= 1.3.0 so that binary error details (libgrpc++_error_details) are
 dnl available
-PKG_CHECK_MODULES([GRPC], [grpc >= 1.3.0 grpc++ >= 1.3.0])
+PKG_CHECK_MODULES([GRPC], [grpc++ >= 1.3.0 grpc >= 3.0.0])
 AC_SUBST([GRPC_CFLAGS])
 AC_SUBST([GRPC_LIBS])
 

--- a/proto/p4info/Makefile.am
+++ b/proto/p4info/Makefile.am
@@ -20,6 +20,6 @@ convert_p4info.cpp
 
 pi_convert_p4info_LDADD = \
 $(builddir)/libpiconvertproto.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpip4info.la \
 $(PROTOBUF_LIBS)


### PR DESCRIPTION
Fixed grpc version requirement in proto/configure.ac
Split libpiproto into 2 separate noinst libtool libraries (one for
generated protobuf files, one for generated grpc files). These 2
separate libraries are then merged into a single libpiproto which is
installed. This way the pi_convert_p4info binary has no dependency on
the grpc libraries.