### PR TITLE
More build adjustments

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -160,22 +160,21 @@ $(BUILT_SOURCES): proto_files.ts
 	  fi; \
 	fi
 
-noinst_LTLIBRARIES = libpiprotobuf.la libpigrpc.la
+# confusing names...
+# libpiprotobuf = only protobuf files
+# libpiproto = protobuf + grpc
+lib_LTLIBRARIES = libpiprotobuf.la libpiproto.la
 
 # generated source should not be distributed
 nodist_libpiprotobuf_la_SOURCES = $(proto_cpp_files)
-nodist_libpigrpc_la_SOURCES = $(proto_grpc_files)
+nodist_libpiproto_la_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
+
+libpiprotobuf_la_SOURCES = src/util.cpp
+
+libpiproto_la_SOURCES = src/util.cpp
 
 libpiprotobuf_la_LIBADD = $(PROTOBUF_LIBS)
-libpigrpc_la_LIBADD = $(PROTOBUF_LIBS) $(GRPC_LIBS)
-
-# is this the best name for this library, or is this too generic?
-lib_LTLIBRARIES = libpiproto.la
-
-libpiproto_la_SOURCES = \
-src/util.cpp
-
-libpiproto_la_LIBADD = libpiprotobuf.la libpigrpc.la
+libpiproto_la_LIBADD = $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 nobase_include_HEADERS = \
 PI/proto/util.h

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -21,7 +21,7 @@ src/common.h
 libpifeproto_la_LIBADD = \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \
 $(top_builddir)/p4info/libpiconvertproto.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpip4info.la
 
 nobase_include_HEADERS = \

--- a/proto/server/Makefile.am
+++ b/proto/server/Makefile.am
@@ -16,5 +16,6 @@ nobase_include_HEADERS = PI/proto/pi_server.h
 libpigrpcserver_la_LIBADD = \
 $(top_builddir)/frontend/libpifeproto.la \
 $(top_builddir)/libpiproto.la \
-$(PROTOBUF_LIBS) $(GRPC_LIBS) \
--lgrpc++_error_details
+$(PROTOBUF_LIBS) $(GRPC_LIBS)
+# causes issue with libpiproto as it includes a version of google.rpc.Status
+# -lgrpc++_error_details

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -24,7 +24,7 @@ test_p4info_convert_SOURCES = $(common_source) test_p4info_convert.cpp
 
 test_p4info_convert_LDADD = \
 $(top_builddir)/p4info/libpiconvertproto.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpip4info.la \
 $(common_libs)
 
@@ -39,7 +39,7 @@ test_proto_fe_LDADD = \
 $(top_builddir)/p4info/libpiconvertproto.la \
 $(top_builddir)/frontend/libpifeproto.la \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpiall.la \
 $(top_builddir)/../src/libpip4info.la \
 $(common_libs)


### PR DESCRIPTION
Fix issues of this type when staring binaries:
```
[libprotobuf ERROR google/protobuf/descriptor_database.cc:109] Symbol name "google.rpc.Status" conflicts with the existing symbol "google.rpc.Status".
[libprotobuf FATAL google/protobuf/descriptor.cc:1164] CHECK failed: generated_database_->Add(encoded_file_descriptor, size): 
terminate called after throwing an instance of 'google::protobuf::FatalException'
  what():  CHECK failed: generated_database_->Add(encoded_file_descriptor, size): 
Aborted (core dumped)
```