### PR TITLE
Add sanity-checking for protobuf 'bytes' fields

### DIFF
--- a/src/p4info/tables.c
+++ b/src/p4info/tables.c
@@ -371,7 +371,9 @@ size_t pi_p4info_table_match_field_offset(const pi_p4info_t *p4info,
 size_t pi_p4info_table_match_field_bitwidth(const pi_p4info_t *p4info,
                                             pi_p4_id_t table_id,
                                             pi_p4_id_t mf_id) {
+  size_t invalid = (size_t)-1;
   size_t index = pi_p4info_table_match_field_index(p4info, table_id, mf_id);
+  if (invalid == index) return invalid;
   _table_data_t *table = get_table(p4info, table_id);
   _match_field_data_t *data = &get_match_field_data(table)[index];
   return data->info.bitwidth;

--- a/tests/testdata/unittest.json
+++ b/tests/testdata/unittest.json
@@ -81,6 +81,14 @@
                     64
                 ],
                 [
+                    "field12",
+                    12
+                ],
+                [
+                    "field4",
+                    4
+                ],
+                [
                     "_padding",
                     4
                 ]
@@ -157,37 +165,8 @@
     ],
     "actions": [
         {
-            "name": "actionB",
-            "id": 0,
-            "runtime_data": [
-                {
-                    "name": "param",
-                    "bitwidth": 8
-                }
-            ],
-            "primitives": [
-                {
-                    "op": "modify_field",
-                    "parameters": [
-                        {
-                            "type": "field",
-                            "value": [
-                                "header_test",
-                                "field8"
-                            ]
-                        },
-                        {
-                            "type": "runtime_data",
-                            "value": 0
-                        }
-                    ]
-                }
-            ],
-            "pragmas": []
-        },
-        {
             "name": "actionA",
-            "id": 1,
+            "id": 0,
             "runtime_data": [
                 {
                     "name": "param",
@@ -203,6 +182,35 @@
                             "value": [
                                 "header_test",
                                 "field48"
+                            ]
+                        },
+                        {
+                            "type": "runtime_data",
+                            "value": 0
+                        }
+                    ]
+                }
+            ],
+            "pragmas": []
+        },
+        {
+            "name": "actionB",
+            "id": 1,
+            "runtime_data": [
+                {
+                    "name": "param",
+                    "bitwidth": 8
+                }
+            ],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "header_test",
+                                "field8"
                             ]
                         },
                         {
@@ -400,6 +408,36 @@
                             "target": [
                                 "header_test",
                                 "field32"
+                            ],
+                            "mask": null
+                        }
+                    ],
+                    "actions": [
+                        "actionA",
+                        "actionB"
+                    ],
+                    "next_tables": {
+                        "actionA": "ExactOneNonAligned",
+                        "actionB": "ExactOneNonAligned"
+                    },
+                    "base_default_next": "ExactOneNonAligned",
+                    "pragmas": []
+                },
+                {
+                    "name": "ExactOneNonAligned",
+                    "id": 6,
+                    "match_type": "exact",
+                    "type": "simple",
+                    "max_size": 512,
+                    "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
+                    "key": [
+                        {
+                            "match_type": "exact",
+                            "target": [
+                                "header_test",
+                                "field12"
                             ],
                             "mask": null
                         }

--- a/tests/testdata/unittest.p4
+++ b/tests/testdata/unittest.p4
@@ -22,6 +22,8 @@ header_type header_test_t {
         field32 : 32;
         field48 : 48;
         field64 : 64;
+        field12 : 12;
+        field4 : 4;
     }
 }
 
@@ -136,6 +138,16 @@ field_list_calculation SelectorHash {
     output_width : 16;
 }
 
+table ExactOneNonAligned {
+    reads {
+        header_test.field12 : exact;
+    }
+    actions {
+        actionA; actionB;
+    }
+    size: 512;
+}
+
 control ingress {
     apply(ExactOne);
     apply(LpmOne);
@@ -143,6 +155,7 @@ control ingress {
     apply(RangeOne);
     apply(MixMany);
     apply(IndirectWS);
+    apply(ExactOneNonAligned);
 }
 
 control egress { }


### PR DESCRIPTION
For match fields and action parameter values sent through P4Runtime, we
now check that:
 * the bytestring has the correct length (i.e. the number of bytes match
 the width of the P4 type)
 * for non byte-aligned field, the leading bits have been cleared
 (i.e. for a 12-bit field, the 4 leading bits of the first byte need to
 be cleared).

We also check that match keys have the appropriate number of match
fields and that they match the P4 table declaration. Same thing for
action parameters.

If one of these checks is violated, we return an INVALID_ARGUMENT
status.

These checks are now performed in DeviceMgr. Some of them may be
redundant with checks performed at lower levels of the implementation;
we can clean this up later if there is a performance concern.