### PR TITLE
Validate P4 ids in p4runtime DeviceMgr

### DIFF
--- a/include/PI/p4info.h
+++ b/include/PI/p4info.h
@@ -75,6 +75,9 @@ const char *pi_p4info_any_name_from_id(const pi_p4info_t *p4info,
 pi_p4_id_t pi_p4info_any_id_from_name(const pi_p4info_t *p4info,
                                       pi_res_type_id_t type, const char *name);
 
+//! Returns true iff the id is valid.
+bool pi_p4info_is_valid_id(const pi_p4info_t *p4info, pi_p4_id_t id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/p4info/p4info_struct.c
+++ b/src/p4info/p4info_struct.c
@@ -128,6 +128,15 @@ pi_p4_id_t pi_p4info_any_id_from_name(const pi_p4info_t *p4info,
   return p4info_name_map_get(&res->name_map, name);
 }
 
+bool pi_p4info_is_valid_id(const pi_p4info_t *p4info, pi_p4_id_t id) {
+  const pi_p4info_res_t *res = &p4info->resources[PI_GET_TYPE_ID(id)];
+  if (!res->is_init) return false;
+  PWord_t PValue;
+  Word_t index = id & 0xFFFFFF;
+  JLG(PValue, res->id_map, index);
+  return (PValue != NULL);
+}
+
 pi_status_t pi_p4info_add_alias(pi_p4info_t *p4info, pi_p4_id_t id,
                                 const char *alias) {
   pi_p4info_res_t *res = &p4info->resources[PI_GET_TYPE_ID(id)];


### PR DESCRIPTION
We return an INVALID_ARGUMENT error code if the id is not correct.