### PR TITLE
Validate P4 action ids in p4runtime DeviceMgr

### DIFF
--- a/include/PI/p4info/act_profs.h
+++ b/include/PI/p4info/act_profs.h
@@ -47,6 +47,10 @@ const pi_p4_id_t *pi_p4info_act_prof_get_actions(const pi_p4info_t *p4info,
                                                  pi_p4_id_t act_prof_id,
                                                  size_t *num_actions);
 
+bool pi_p4info_act_prof_is_action_of(const pi_p4info_t *p4info,
+                                     pi_p4_id_t act_prof_id,
+                                     pi_p4_id_t action_id);
+
 size_t pi_p4info_act_prof_max_size(const pi_p4info_t *p4info,
                                    pi_p4_id_t act_prof_id);
 

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -16,7 +16,10 @@ src/action_prof_mgr.h \
 src/action_prof_mgr.cpp \
 src/table_info_store.h \
 src/table_info_store.cpp \
-src/common.h
+src/action_helpers.h \
+src/action_helpers.cpp \
+src/common.h \
+src/common.cpp
 
 libpifeproto_la_LIBADD = \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \

--- a/proto/frontend/src/action_helpers.h
+++ b/proto/frontend/src/action_helpers.h
@@ -18,15 +18,18 @@
  *
  */
 
-#ifndef SRC_COMMON_H_
-#define SRC_COMMON_H_
+#ifndef SRC_ACTION_HELPERS_H_
+#define SRC_ACTION_HELPERS_H_
 
 #include <PI/pi.h>
 
-#include <string>
-
-#include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
+
+namespace p4 {
+
+class Action;
+
+}  // namespace p4
 
 namespace pi {
 
@@ -34,39 +37,9 @@ namespace fe {
 
 namespace proto {
 
-using Code = ::google::rpc::Code;
 using Status = ::google::rpc::Status;
 
-namespace common {
-
-struct SessionTemp {
-  explicit SessionTemp(bool batch = false)
-      : batch(batch) {
-    pi_session_init(&sess);
-    if (batch) pi_batch_begin(sess);
-  }
-
-  ~SessionTemp() {
-    if (batch) pi_batch_end(sess, false  /* hw_sync */);
-    pi_session_cleanup(sess);
-  }
-
-  pi_session_handle_t get() const { return sess; }
-
-  pi_session_handle_t sess;
-  bool batch;
-};
-
-Code check_proto_bytestring(const std::string &str, size_t nbits);
-
-inline Status make_invalid_p4_id_status() {
-  Status status;
-  status.set_code(Code::INVALID_ARGUMENT);
-  status.set_message("Invalid P4 id");
-  return status;
-}
-
-}  // namespace common
+Status validate_action_data(pi_p4info_t *p4info, const p4::Action &action);
 
 }  // namespace proto
 
@@ -74,4 +47,4 @@ inline Status make_invalid_p4_id_status() {
 
 }  // namespace pi
 
-#endif  // SRC_COMMON_H_
+#endif  // SRC_ACTION_HELPERS_H_

--- a/proto/frontend/src/action_prof_mgr.h
+++ b/proto/frontend/src/action_prof_mgr.h
@@ -150,6 +150,9 @@ class ActionProfMgr {
   const Id *retrieve_group_id(pi_indirect_handle_t h);
 
  private:
+  bool check_p4_action_id(pi_p4_id_t p4_id) const;
+
+  Status validate_action(const p4::Action &action);
   pi::ActionData construct_action_data(const p4::Action &action);
 
   // using RepeatedMembers = decltype(

--- a/src/p4info/act_profs.c
+++ b/src/p4info/act_profs.c
@@ -150,6 +150,16 @@ const pi_p4_id_t *pi_p4info_act_prof_get_actions(const pi_p4info_t *p4info,
   return pi_p4info_table_get_actions(p4info, one_t_id, num_actions);
 }
 
+bool pi_p4info_act_prof_is_action_of(const pi_p4info_t *p4info,
+                                     pi_p4_id_t act_prof_id,
+                                     pi_p4_id_t action_id) {
+  _act_prof_data_t *act_prof = get_act_prof(p4info, act_prof_id);
+  if (act_prof->num_tables == 0) return false;
+  pi_p4_id_t one_t_id = act_prof->table_ids[0];
+  // we assume all tables sharing the action profile have the same actions
+  return pi_p4info_table_is_action_of(p4info, one_t_id, action_id);
+}
+
 size_t pi_p4info_act_prof_max_size(const pi_p4info_t *p4info,
                                    pi_p4_id_t act_prof_id) {
   _act_prof_data_t *act_prof = get_act_prof(p4info, act_prof_id);

--- a/tests/testdata/unittest.json
+++ b/tests/testdata/unittest.json
@@ -165,8 +165,37 @@
     ],
     "actions": [
         {
-            "name": "actionA",
+            "name": "actionB",
             "id": 0,
+            "runtime_data": [
+                {
+                    "name": "param",
+                    "bitwidth": 8
+                }
+            ],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "header_test",
+                                "field8"
+                            ]
+                        },
+                        {
+                            "type": "runtime_data",
+                            "value": 0
+                        }
+                    ]
+                }
+            ],
+            "pragmas": []
+        },
+        {
+            "name": "actionA",
+            "id": 1,
             "runtime_data": [
                 {
                     "name": "param",
@@ -194,32 +223,10 @@
             "pragmas": []
         },
         {
-            "name": "actionB",
-            "id": 1,
-            "runtime_data": [
-                {
-                    "name": "param",
-                    "bitwidth": 8
-                }
-            ],
-            "primitives": [
-                {
-                    "op": "modify_field",
-                    "parameters": [
-                        {
-                            "type": "field",
-                            "value": [
-                                "header_test",
-                                "field8"
-                            ]
-                        },
-                        {
-                            "type": "runtime_data",
-                            "value": 0
-                        }
-                    ]
-                }
-            ],
+            "name": "actionC",
+            "id": 2,
+            "runtime_data": [],
+            "primitives": [],
             "pragmas": []
         }
     ],
@@ -384,10 +391,12 @@
                         }
                     ],
                     "actions": [
-                        "actionA"
+                        "actionA",
+                        "actionC"
                     ],
                     "next_tables": {
-                        "actionA": "IndirectWS"
+                        "actionA": "IndirectWS",
+                        "actionC": "IndirectWS"
                     },
                     "base_default_next": "IndirectWS",
                     "pragmas": []

--- a/tests/testdata/unittest.p4
+++ b/tests/testdata/unittest.p4
@@ -41,6 +41,8 @@ action actionB(param) {
     modify_field(header_test.field8, param);
 }
 
+action actionC() { }
+
 table ExactOne {
     reads {
         header_test.field32 : exact;
@@ -100,7 +102,7 @@ table MixMany {
         header_test : valid;
     }
     actions {
-        actionA;
+        actionA; actionC;
     }
     size: 512;
 }


### PR DESCRIPTION
Make sure that the action id is valid and that it indeed belongs to the
table / action profile.

We return an INVALID_ARGUMENT error code if the id is not correct.