### PR TITLE
Support ControllerPacketMetadata in DeviceMgr

### DIFF
--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -18,6 +18,8 @@ src/table_info_store.h \
 src/table_info_store.cpp \
 src/action_helpers.h \
 src/action_helpers.cpp \
+src/packet_io_mgr.h \
+src/packet_io_mgr.cpp \
 src/common.h \
 src/common.cpp
 

--- a/proto/frontend/PI/frontends/proto/device_mgr.h
+++ b/proto/frontend/PI/frontends/proto/device_mgr.h
@@ -47,7 +47,7 @@ class DeviceMgr {
   // may change when we introduce specific error namespace
   using Status = ::google::rpc::Status;
   using PacketInCb =
-      std::function<void(device_id_t, std::string packet, void *cookie)>;
+      std::function<void(device_id_t, p4::PacketIn *packet, void *cookie)>;
 
   explicit DeviceMgr(device_id_t device_id);
 
@@ -67,10 +67,7 @@ class DeviceMgr {
   Status read(const p4::ReadRequest &request, p4::ReadResponse *response) const;
   Status read_one(const p4::Entity &entity, p4::ReadResponse *response) const;
 
-  // from the perspective of P4, a punted packet is just bytes. Either the
-  // controller is responsible for encapsulating the packet in the appropriate
-  // header, or the gRPC server is.
-  Status packet_out_send(const std::string &packet) const;
+  Status packet_out_send(const p4::PacketOut &packet) const;
 
   void packet_in_register_cb(PacketInCb cb, void *cookie);
 

--- a/proto/frontend/src/packet_io_mgr.cpp
+++ b/proto/frontend/src/packet_io_mgr.cpp
@@ -1,0 +1,317 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "packet_io_mgr.h"
+
+#include <algorithm>  // for std::fill, std::copy
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "google/rpc/code.pb.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+using Code = ::google::rpc::Code;
+
+namespace {
+
+using p4::config::ControllerPacketMetadata;
+
+size_t compute_nbytes(const ControllerPacketMetadata &metadata_hdr) {
+  size_t nbits = 0;
+  for (const auto &metadata : metadata_hdr.metadata())
+    nbits += metadata.bitwidth();
+  return (nbits + 7) / 8;
+}
+
+// generic_extract and generic_deparse taken from the behavioral-model code
+
+void generic_extract(const char *data, int bit_offset, int bitwidth,
+                     char *dst) {
+  int nbytes = (bitwidth + 7) / 8;
+
+  if (bit_offset == 0 && bitwidth % 8 == 0) {
+    memcpy(dst, data, nbytes);
+    return;
+  }
+
+  int dst_offset = (nbytes << 3) - bitwidth;
+  int i;
+
+  // necessary to ensure correct behavior when shifting right (no sign
+  // extension)
+  auto udata = reinterpret_cast<const unsigned char *>(data);
+
+  int offset = bit_offset - dst_offset;
+  if (offset == 0) {
+    memcpy(dst, udata, nbytes);
+    dst[0] &= (0xFF >> dst_offset);
+  } else if (offset > 0) {  // shift left
+    for (i = 0; i < nbytes - 1; i++) {
+      dst[i] = (udata[i] << offset) | (udata[i + 1] >> (8 - offset));
+    }
+    dst[0] &= (0xFF >> dst_offset);
+    dst[i] = udata[i] << offset;
+    if ((bit_offset + bitwidth) > (nbytes << 3)) {
+      dst[i] |= (udata[i + 1] >> (8 - offset));
+    }
+  } else {  // shift right
+    offset = -offset;
+    dst[0] = udata[0] >> offset;
+    dst[0] &= (0xFF >> dst_offset);
+    for (i = 1; i < nbytes; i++) {
+      dst[i] = (udata[i - 1] << (8 - offset)) | (udata[i] >> offset);
+    }
+  }
+}
+
+void generic_deparse(const char *data, int bitwidth, char *dst,
+                     int hdr_offset) {
+  if (bitwidth == 0) return;
+
+  int nbytes = (bitwidth + 7) / 8;
+
+  if (hdr_offset == 0 && bitwidth % 8 == 0) {
+    memcpy(dst, data, nbytes);
+    return;
+  }
+
+  int field_offset = (nbytes << 3) - bitwidth;
+  int hdr_bytes = (hdr_offset + bitwidth + 7) / 8;
+
+  int i;
+
+  // necessary to ensure correct behavior when shifting right (no sign
+  // extension)
+  auto udata = reinterpret_cast<const unsigned char *>(data);
+
+  // zero out bits we are going to write in dst[0]
+  dst[0] &= (~(0xFF >> hdr_offset));
+
+  int offset = field_offset - hdr_offset;
+  if (offset == 0) {
+    std::copy(data + 1, data + hdr_bytes, dst + 1);
+    dst[0] |= udata[0];
+  } else if (offset > 0) {  // shift left
+    // don't know if this is very efficient, we memset the remaining bytes to 0
+    // so we can use |= and preserve what was originally in dst[0]
+    std::fill(&dst[1], &dst[hdr_bytes], 0);
+    for (i = 0; i < hdr_bytes - 1; i++) {
+      dst[i] |= (udata[i] << offset) | (udata[i + 1] >> (8 - offset));
+    }
+    dst[i] |= udata[i] << offset;
+  } else {  // shift right
+    offset = -offset;
+    dst[0] |= (udata[0] >> offset);
+    if (nbytes == 1) {
+      // dst[1] is always valid, otherwise we would not need to shift the field
+      // to the right
+      dst[1] = udata[0] << (8 - offset);
+      return;
+    }
+    for (i = 1; i < hdr_bytes - 1; i++) {
+      dst[i] = (udata[i - 1] << (8 - offset)) | (udata[i] >> offset);
+    }
+    int tail_offset = (hdr_bytes << 3) - (hdr_offset + bitwidth);
+    dst[i] &= ((1 << tail_offset) - 1);
+    dst[i] |= (udata[i - 1] << (8 - offset));
+  }
+}
+
+}  // namespace
+
+class PacketInMutate {
+ public:
+  static constexpr const char name[] = "packet_in";
+
+  explicit PacketInMutate(const ControllerPacketMetadata &metadata_hdr)
+      : metadata_hdr(metadata_hdr) {
+    nbytes = compute_nbytes(metadata_hdr);
+  }
+
+  bool operator ()(const char *pkt, size_t size,
+                   p4::PacketIn *packet_in) const {
+    if (size < nbytes) return false;
+    packet_in->set_payload(pkt + nbytes, size - nbytes);
+    int bit_offset = 0;
+    std::vector<char> buffer(32);
+    for (const auto &metadata_info : metadata_hdr.metadata()) {
+      auto metadata = packet_in->add_metadata();
+      metadata->set_metadata_id(metadata_info.id());
+      auto bitwidth = metadata_info.bitwidth();
+      buffer.resize((bitwidth + 7) / 8);
+      buffer[0] = 0;
+      generic_extract(pkt, bit_offset, bitwidth, buffer.data());
+      bit_offset += (bitwidth % 8);
+      pkt += (bitwidth / 8);
+      metadata->set_value(buffer.data(), buffer.size());
+    }
+    return true;
+  }
+
+ private:
+  ControllerPacketMetadata metadata_hdr;
+  size_t nbytes{0};
+};
+
+constexpr const char PacketInMutate::name[];
+
+namespace {
+
+class Id2Offset {
+ public:
+  struct Offset {
+    int byte_offset;
+    int bit_offset;
+    int bitwidth;
+  };
+
+  explicit Id2Offset(const ControllerPacketMetadata &metadata_hdr) {
+    int nbits = 0;
+    for (const auto &metadata : metadata_hdr.metadata()) {
+      auto id = metadata.id();
+      auto bitwidth = metadata.bitwidth();
+      offsets.emplace(id, Offset{nbits / 8, nbits % 8, bitwidth});
+      nbits += bitwidth;
+    }
+  }
+
+  const Offset &at(uint32_t id) const { return offsets.at(id); }
+
+ private:
+  std::unordered_map<uint32_t, Offset> offsets{};
+};
+
+}  // namespace
+
+class PacketOutMutate {
+ public:
+  static constexpr const char name[] = "packet_out";
+
+  explicit PacketOutMutate(const ControllerPacketMetadata &metadata_hdr)
+      : metadata_hdr(metadata_hdr), id2offset(metadata_hdr) {
+    nbytes = compute_nbytes(metadata_hdr);
+  }
+
+  bool operator ()(const p4::PacketOut &packet_out, std::string *pkt) const {
+    pkt->clear();
+    const auto &payload = packet_out.payload();
+    pkt->reserve(nbytes + payload.size());
+    pkt->append(nbytes, 0);
+    for (const auto &metadata : packet_out.metadata()) {
+      const auto &offset = id2offset.at(metadata.metadata_id());
+      generic_deparse(metadata.value().data(), offset.bitwidth,
+                      &(*pkt)[offset.byte_offset], offset.bit_offset);
+    }
+    pkt->append(payload);
+    return true;
+  }
+
+ private:
+  ControllerPacketMetadata metadata_hdr;
+  size_t nbytes{0};
+  Id2Offset id2offset;
+};
+
+constexpr const char PacketOutMutate::name[];
+
+using Status = PacketIOMgr::Status;
+
+PacketIOMgr::PacketIOMgr(device_id_t device_id)
+    : device_id(device_id), packet_in_mutate(nullptr),
+      packet_out_mutate(nullptr) { }
+
+PacketIOMgr::~PacketIOMgr() = default;
+
+void
+PacketIOMgr::p4_change(const p4::config::P4Info &p4info) {
+  PacketInMutate *packet_in_mutate_new = nullptr;
+  PacketOutMutate *packet_out_mutate_new = nullptr;
+  for (const auto &metadata_hdr : p4info.controller_packet_metadata()) {
+    const auto &name = metadata_hdr.preamble().name();
+    if (name == PacketInMutate::name)
+      packet_in_mutate_new = new PacketInMutate(metadata_hdr);
+    else if (name == PacketOutMutate::name)
+      packet_out_mutate_new = new PacketOutMutate(metadata_hdr);
+  }
+  Lock lock(mutex);
+  packet_in_mutate.reset(packet_in_mutate_new);
+  packet_out_mutate.reset(packet_out_mutate_new);
+}
+
+Status
+PacketIOMgr::packet_out_send(const p4::PacketOut &packet) const {
+    Status status;
+    pi_status_t pi_status = PI_STATUS_SUCCESS;
+    if (packet_out_mutate) {
+      std::string raw_packet;
+      auto success = (*packet_out_mutate)(packet, &raw_packet);
+      if (!success) {
+        status.set_code(Code::UNKNOWN);
+        return status;
+      }
+      pi_status = pi_packetout_send(device_id, raw_packet.data(),
+                                    raw_packet.size());
+    } else {
+      const auto &payload = packet.payload();
+      pi_status = pi_packetout_send(device_id, payload.data(),
+                                    payload.size());
+    }
+    if (pi_status != PI_STATUS_SUCCESS)
+      status.set_code(Code::UNKNOWN);
+    else
+      status.set_code(Code::OK);
+    return status;
+}
+
+void
+PacketIOMgr::packet_in_register_cb(PacketInCb cb, void *cookie) {
+  cb_ = std::move(cb);
+  cookie_ = cookie;
+  pi_packetin_register_cb(device_id, &PacketIOMgr::packet_in_cb,
+                          static_cast<void *>(this));
+}
+
+void
+PacketIOMgr::packet_in_cb(pi_dev_id_t dev_id, const char *pkt, size_t size,
+                          void *cookie) {
+  auto mgr = static_cast<PacketIOMgr *>(cookie);
+  assert(dev_id == mgr->device_id);
+  p4::PacketIn packet_in;
+  if (mgr->packet_in_mutate) {
+    Lock lock(mgr->mutex);
+    auto success = (*mgr->packet_in_mutate)(pkt, size, &packet_in);
+    if (!success) return;
+  } else {
+    packet_in.set_payload(pkt, size);
+  }
+  mgr->cb_(mgr->device_id, &packet_in, mgr->cookie_);
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi

--- a/proto/frontend/src/packet_io_mgr.h
+++ b/proto/frontend/src/packet_io_mgr.h
@@ -1,0 +1,79 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SRC_PACKET_IO_MGR_H_
+#define SRC_PACKET_IO_MGR_H_
+
+#include <PI/frontends/proto/device_mgr.h>
+#include <PI/pi.h>
+
+#include <memory>
+#include <mutex>
+
+#include "google/rpc/status.pb.h"
+#include "p4/config/p4info.pb.h"
+#include "p4/p4runtime.pb.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+class PacketInMutate;
+class PacketOutMutate;
+
+class PacketIOMgr {
+ public:
+  using device_id_t = DeviceMgr::device_id_t;
+  using PacketInCb = DeviceMgr::PacketInCb;
+  using Status = DeviceMgr::Status;
+
+  explicit PacketIOMgr(device_id_t device_id);
+  ~PacketIOMgr();
+
+  void p4_change(const p4::config::P4Info &p4info);
+
+  Status packet_out_send(const p4::PacketOut &packet) const;
+
+  void packet_in_register_cb(PacketInCb cb, void *cookie);
+
+ private:
+  static void packet_in_cb(pi_dev_id_t dev_id, const char *pkt, size_t size,
+                           void *cookie);
+
+  using Mutex = std::mutex;
+  using Lock = std::lock_guard<Mutex>;
+  device_id_t device_id;
+  mutable Mutex mutex{};
+  std::unique_ptr<PacketInMutate> packet_in_mutate;
+  std::unique_ptr<PacketOutMutate> packet_out_mutate;
+
+  PacketInCb cb_;
+  void *cookie_;
+};
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi
+
+#endif  // SRC_PACKET_IO_MGR_H_

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -11,9 +11,10 @@ AM_CPPFLAGS = \
 
 TESTS = \
 test_p4info_convert \
-test_proto_fe
+test_proto_fe \
+test_proto_fe_packet_io
 
-common_source = main.cpp mock_switch.h mock_switch.cpp
+common_source = main.cpp
 
 common_libs = \
 $(top_builddir)/../third_party/libgmock.la \
@@ -28,14 +29,20 @@ $(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpip4info.la \
 $(common_libs)
 
-test_proto_fe_SOURCES = $(common_source) test_proto_fe.cpp
+proto_fe_common_source = $(common_source) mock_switch.h mock_switch.cpp
+
+test_proto_fe_SOURCES = $(proto_fe_common_source) test_proto_fe.cpp
+test_proto_fe_packet_io_SOURCES = $(proto_fe_common_source) \
+test_proto_fe_packet_io.cpp
 
 # this is an awful hack and a big time saver :)
 # thanks to this, I do not need to implement all of the _pi_* functions, only
 # the one I actually need for the tests. To me this is acceptable as I only use
 # this for unit tests
 test_proto_fe_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
-test_proto_fe_LDADD = \
+test_proto_fe_packet_io_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
+
+proto_fe_libs = \
 $(top_builddir)/p4info/libpiconvertproto.la \
 $(top_builddir)/frontend/libpifeproto.la \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \
@@ -44,6 +51,10 @@ $(top_builddir)/../src/libpiall.la \
 $(top_builddir)/../src/libpip4info.la \
 $(common_libs)
 
+test_proto_fe_LDADD = $(proto_fe_libs)
+test_proto_fe_packet_io_LDADD = $(proto_fe_libs)
+
 check_PROGRAMS = \
 test_p4info_convert \
-test_proto_fe
+test_proto_fe \
+test_proto_fe_packet_io

--- a/proto/tests/test_proto_fe_packet_io.cpp
+++ b/proto/tests/test_proto_fe_packet_io.cpp
@@ -1,0 +1,326 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <gmock/gmock.h>
+
+#include <algorithm>  // for std::reverse
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "PI/frontends/proto/device_mgr.h"
+
+#include "google/rpc/code.pb.h"
+
+#include "mock_switch.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+namespace {
+
+using pi::fe::proto::DeviceMgr;
+using Code = ::google::rpc::Code;
+
+using ::testing::_;
+using ::testing::AllArgs;
+using ::testing::StrEq;
+using ::testing::Truly;
+
+class DeviceMgrPacketIOTest : public ::testing::Test {
+ public:
+  DeviceMgrPacketIOTest()
+      : mock(wrapper.sw()), device_id(wrapper.device_id()), mgr(device_id) { }
+
+  static void SetUpTestCase() {
+    DeviceMgr::init(256);
+  }
+
+  static void TearDownTestCase() {
+    DeviceMgr::destroy();
+  }
+
+  void SetUp() override {
+    p4::ForwardingPipelineConfig config;
+    config.set_allocated_p4info(&p4info_proto);
+    auto status = mgr.pipeline_config_set(
+        p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
+        config);
+    ASSERT_EQ(status.code(), Code::OK);
+    config.release_p4info();
+  }
+
+  void TearDown() override { }
+
+  p4::config::P4Info p4info_proto;
+
+  DummySwitchWrapper wrapper{};
+  DummySwitchMock *mock;
+  device_id_t device_id;
+  DeviceMgr mgr;
+};
+
+// Base case for packet-in / packet-out: no special metadata fields
+class DeviceMgrPacketIORegTest : public DeviceMgrPacketIOTest { };
+
+TEST_F(DeviceMgrPacketIORegTest, PacketIn) {
+  p4::PacketIn packet_in;
+  bool received = false;
+  auto cb_fn = [&packet_in, &received](device_id_t, p4::PacketIn *p, void *) {
+    packet_in.CopyFrom(*p);
+    received = true;
+  };
+  mgr.packet_in_register_cb(cb_fn, nullptr);
+  std::string packet(10, '\xab');
+  // we don't need an async task because packetin_inject blocks until the
+  // callback is called
+  mock->packetin_inject(packet);
+  ASSERT_TRUE(received);
+  EXPECT_EQ(packet, packet_in.payload());
+}
+
+TEST_F(DeviceMgrPacketIORegTest, PacketOut) {
+  p4::PacketOut packet_out;
+  std::string payload(10, '\xab');
+  packet_out.set_payload(payload);
+  EXPECT_CALL(*mock, packetout_send(StrEq(payload.c_str()), payload.size()));
+  auto status = mgr.packet_out_send(packet_out);
+  EXPECT_EQ(status.code(), Code::OK);
+}
+
+using ::testing::WithParamInterface;
+using ::testing::Combine;
+using ::testing::Range;
+
+namespace {
+
+template<typename T,
+         typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+std::string to_binary(T v, int bitwidth) {
+  std::string s;
+  while (bitwidth > 0) {
+    s.push_back(static_cast<char>(v % 256));
+    v /= 256;
+    bitwidth -= 8;
+  }
+  std::reverse(s.begin(), s.end());
+  return s;
+}
+
+// iterates over all possible values for a tuple of fields with a given bitwidth
+// e.g. (0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), (0, 2, 0), ...
+template <typename T>
+struct ValueIterator {
+  ValueIterator(T bitwidths, T steps)
+      : bitwidths(bitwidths),
+        bounds(bitwidths),
+        steps(steps) {
+    std::transform(bounds.begin(), bounds.end(), bounds.begin(),
+                   [](typename T::value_type x) { return 1 << x; });
+  }
+
+  friend struct iterator;
+  struct iterator
+      : public std::iterator<std::forward_iterator_tag,
+                             typename T::value_type> {
+    explicit iterator(const ValueIterator<T> *parent, T current = {})
+        : parent(parent), current(current) { }
+
+    const T &operator*() const {
+      assert(current != parent->bounds && "Invalid iterator dereference.");
+      return current;
+    }
+
+    const T *operator->() const {
+      assert(current != parent->bounds && "Invalid iterator dereference.");
+      return &current;
+    }
+
+    bool operator==(const iterator &other) const {
+      return (parent == other.parent) && (current == other.current);
+    }
+
+    bool operator!=(const iterator &other) const {
+      return !(*this == other);
+    }
+
+    iterator &operator++() {
+      const auto &bounds = parent->bounds;
+      assert(current != bounds && "Out-of-bounds iterator increment.");
+      for (size_t i = current.size(); i > 0; i--) {
+        current.at(i - 1) += parent->steps.at(i - 1);
+        if (current.at(i - 1) < bounds.at(i - 1)) {
+          for (size_t j = i; j < current.size(); j++) current.at(j) = 0;
+          return *this;
+        } else {
+          current.at(i - 1) = bounds.at(i - 1);
+        }
+      }
+      assert(current == bounds);
+      return *this;
+    }
+
+    const iterator operator++(int) {
+      // Use operator++()
+      const iterator old(*this);
+      ++(*this);
+      return old;
+    }
+
+    const ValueIterator<T> *parent;
+    T current{};
+  };
+
+  iterator begin() const { return iterator(this); }
+  iterator end() const { return iterator(this, bounds); }
+
+  T bitwidths;
+  T bounds;
+  T steps;
+};
+
+}  // namespace
+
+class DeviceMgrPacketIOMetadataTest : public DeviceMgrPacketIOTest {
+ public:
+  static constexpr size_t num = 3;
+  static constexpr int bw1 = 2;
+  static constexpr int bw2 = 9;
+  static constexpr int bw3 = 5;
+  using VType = std::array<int, num>;
+
+ protected:
+  DeviceMgrPacketIOMetadataTest() {
+    p4::config::ControllerPacketMetadata header;
+    uint32_t id = 1;
+    for (auto bw : bitwidths) {
+      auto metadata = header.add_metadata();
+      metadata->set_id(id++);
+      metadata->set_name("f" + std::to_string(bw));
+      metadata->set_bitwidth(bw);
+    }
+    id = 1;
+    for (std::string name : {"packet_in", "packet_out"}) {
+      auto pre = header.mutable_preamble();
+      pre->set_name(name);
+      pre->set_id(id++);
+      auto packet_metadata = p4info_proto.add_controller_packet_metadata();
+      packet_metadata->CopyFrom(header);
+    }
+  }
+
+  VType bitwidths{{bw1, bw2, bw3}};
+  VType steps{{1, 1, 1}};
+};
+
+namespace {
+
+struct BitPattern {
+  void push_back(int v, int bw) {
+    for (int i = bw - 1; i >= 0; i--) {
+      int byte_offset = nbits / 8;
+      int bit_offset = nbits % 8;
+      if (bit_offset == 0) bits.push_back(0);
+      bits[byte_offset] |= (((1 << i) & v) >> i) << (7 - bit_offset);
+      nbits++;
+    }
+  }
+
+  std::string bits{};
+  int nbits{0};
+};
+
+struct PacketOutMatcher {
+ public:
+  PacketOutMatcher(const std::string &header, const std::string &payload)
+      : header(header), payload(payload) { }
+
+  bool operator()(const char *data, size_t size) const {
+    if (header.size() + payload.size() != size) return false;
+    return (!header.compare(0, std::string::npos, data, header.size()))
+        && (!payload.compare(0, std::string::npos, data + header.size(),
+                             payload.size()));
+  }
+
+  bool operator()(const std::tuple<const char *, size_t> &t) const {
+    return (*this)(std::get<0>(t), std::get<1>(t));
+  }
+
+ private:
+  const std::string &header;
+  const std::string &payload;
+};
+
+}  // namespace
+
+TEST_F(DeviceMgrPacketIOMetadataTest, PacketIn) {
+  std::string payload(10, '\xab');
+  ValueIterator<VType> values(bitwidths, steps);
+  std::vector<std::string> binary_strs(num);
+  p4::PacketIn packet_in;
+  bool received;
+  auto cb_fn = [&packet_in, &received](device_id_t, p4::PacketIn *p, void *) {
+    packet_in.CopyFrom(*p);
+    received = true;
+  };
+  mgr.packet_in_register_cb(cb_fn, nullptr);
+  for (const auto &v : values) {
+    received = false;
+    BitPattern pattern;
+    for (uint32_t id = 0; id < num; id++)
+      pattern.push_back(v[id], bitwidths[id]);
+    std::string packet = pattern.bits + payload;
+    mock->packetin_inject(packet);
+    ASSERT_TRUE(received);
+    EXPECT_EQ(payload, packet_in.payload());
+    uint32_t id = 0;
+    for (const auto &metadata : packet_in.metadata()) {
+      EXPECT_EQ(id + 1, metadata.metadata_id());
+      EXPECT_EQ(to_binary(v[id], bitwidths[id]), metadata.value());
+      id++;
+    }
+  }
+}
+
+TEST_F(DeviceMgrPacketIOMetadataTest, PacketOut) {
+  std::string payload(10, '\xab');
+  ValueIterator<VType> values(bitwidths, steps);
+  std::vector<std::string> binary_strs(num);
+  for (const auto &v : values) {
+    p4::PacketOut packet_out;
+    packet_out.set_payload(payload);
+    BitPattern pattern;
+    for (uint32_t id = 0; id < num; id++) {
+      auto metadata = packet_out.add_metadata();
+      metadata->set_metadata_id(id + 1);
+      metadata->set_value(to_binary(v[id], bitwidths[id]));
+      pattern.push_back(v[id], bitwidths[id]);
+    }
+    PacketOutMatcher matcher(pattern.bits, payload);
+    EXPECT_CALL(*mock, packetout_send(_, _)).With(AllArgs(Truly(matcher)));
+    auto status = mgr.packet_out_send(packet_out);
+    EXPECT_EQ(status.code(), Code::OK);
+  }
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi


### PR DESCRIPTION
We added code to perform encap (packet-in) and decap (packet-out) for
controller packets. We support both cases: with and without metadata
(based on the p4info), with no overhead in the case without
metadata. This is a first attempt at controller metadata support, and
the code may be improved in the future for performance.

The DeviceMgr interface has been updated slightly to better match
p4runtime.proto.

This pull requests include unit tests to test the encap and decap
logic.