### PR TITLE
Device mgr config update cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bmv2 is installed on your system, build the PI and the CLI with `./configure
 
     simple_switch tests/testdata/simple_router.json  // to start the switch
     ./CLI/pi_CLI_bmv2 tests/testdata/simple_router.json  // to start the CLI
-    PI CLI> assign_device 0 -- port=9090
+    PI CLI> assign_device 0 0 -- port=9090  // 0 0 : device id + config id
     PI CLI> table_add ipv4_lpm 10.0.0.1/24 => set_nhop 10.0.0.1 1
     PI CLI> table_dump ipv4_lpm
     PI CLI> table_delete ipv4_lpm <handle returned by table_add>

--- a/frontends_extra/cpp/example/example.cpp
+++ b/frontends_extra/cpp/example/example.cpp
@@ -22,6 +22,9 @@
 
 #include <cassert>
 #include <cstring>
+#include <fstream>
+#include <streambuf>
+#include <string>
 
 // auto-generated #define's
 #include "pi_fe_defines_p4.h"
@@ -83,8 +86,10 @@ int add_route_fast(uint32_t prefix, int pLen, uint32_t nhop, uint16_t port,
 
 int main() {
   pi_init(256, NULL);  // 256 max devices
-  pi_add_config_from_file(TESTDATADIR "/" "simple_router.json",
-                          PI_CONFIG_TYPE_BMV2_JSON, &p4info);
+  std::ifstream istream(TESTDATADIR "/" "simple_router.json");
+  std::string config((std::istreambuf_iterator<char>(istream)),
+                     std::istreambuf_iterator<char>());
+  pi_add_config(config.c_str(), PI_CONFIG_TYPE_BMV2_JSON, &p4info);
 
   pi_assign_extra_t assign_options[2];
   memset(assign_options, 0, sizeof(assign_options));
@@ -92,7 +97,9 @@ int main() {
   rpc_port->key = "port";
   rpc_port->v = "9090";
   assign_options[1].end_of_extras = true;
-  pi_assign_device(0, p4info, assign_options);
+  pi_assign_device(0, NULL, assign_options);
+  pi_update_device_start(0, p4info, config.c_str(), config.size());
+  pi_update_device_end(0);
 
   pi_session_init(&sess);
 

--- a/include/PI/pi.h
+++ b/include/PI/pi.h
@@ -53,8 +53,8 @@ typedef struct {
 } pi_assign_extra_t;
 
 //! Assigns a P4 config to a device. Different targets may need different
-//! indormation at that stage, so arbitary parameters can be provided using \p
-//! extra.
+//! information at that stage, so arbitary parameters can be provided using \p
+//! extra. \p p4info is NULL except if the device is already configured.
 pi_status_t pi_assign_device(pi_dev_id_t dev_id, const pi_p4info_t *p4info,
                              pi_assign_extra_t *extra);
 

--- a/proto/demo_grpc/1sw_demo.py
+++ b/proto/demo_grpc/1sw_demo.py
@@ -33,7 +33,7 @@ parser.add_argument('--dev-id', help='Device id of switch',
 parser.add_argument('--num-hosts', help='Number of hosts to connect to switch',
                     type=int, action="store", default=2)
 parser.add_argument('--json', help='Path to JSON config file',
-                    type=str, action="store", required=True)
+                    type=str, action="store", required=False)
 parser.add_argument('--pcap-dump', help='Dump packets on interfaces to pcap files',
                     type=str, action="store", required=False, default=False)
 parser.add_argument('--cpu-port', help='An optional veth to use as the CPU port',

--- a/proto/demo_grpc/README.md
+++ b/proto/demo_grpc/README.md
@@ -28,7 +28,7 @@ the switch. The gRPC server translates the protobuf messages into PI library
 calls (using the PI C++ frontend).
 
 To run the demo, you will need 3 terminal instances:
-- `sudo python 1sw_demo.py --json simple_router.json --cpu-port veth250`
+- `sudo python 1sw_demo.py --cpu-port veth250`
 - `sudo ./pi_grpc_server`
 - `sudo ./controller -c simple_router.json`
 

--- a/proto/demo_grpc/p4_mininet.py
+++ b/proto/demo_grpc/p4_mininet.py
@@ -58,7 +58,6 @@ class P4Switch(Switch):
                   **kwargs ):
         Switch.__init__( self, name, **kwargs )
         assert(sw_path)
-        assert(json_path)
         self.sw_path = sw_path
         self.json_path = json_path
         self.verbose = verbose
@@ -101,7 +100,10 @@ class P4Switch(Switch):
             args.extend( ['--nanolog', self.nanomsg] )
         args.extend( ['--device-id', str(self.device_id)] )
         P4Switch.device_id += 1
-        args.append(self.json_path)
+        if self.json_path:
+            args.append(self.json_path)
+        else:
+            args.append("--no-p4")
         if self.enable_debugger:
             args.append("--debugger")
         args.append("-- --enable-swap")

--- a/proto/demo_grpc/pi_server_main.cpp
+++ b/proto/demo_grpc/pi_server_main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
 
   auto handler = [](int s) {
     std::cout << "Server shutting down\n";
-    PIGrpcServerShutdown();
+    PIGrpcServerForceShutdown(1);  // 1 second deadline
   };
 
   PIGrpcServerRunAddr(server_address);

--- a/proto/demo_grpc/simple_router_mgr.cpp
+++ b/proto/demo_grpc/simple_router_mgr.cpp
@@ -293,7 +293,6 @@ SimpleRouterMgr::add_one_entry(p4::TableEntry *match_action_entry) {
   p4::WriteResponse rep;
   ClientContext context;
   Status status = pi_stub_->Write(&context, request, &rep);
-  assert(status.ok());
 
   entity->release_table_entry();
 

--- a/proto/demo_grpc/simple_router_mgr.h
+++ b/proto/demo_grpc/simple_router_mgr.h
@@ -77,13 +77,13 @@ class SimpleRouterMgr {
 
   typedef std::vector<char> Packet;
 
-  SimpleRouterMgr(int dev_id, pi_p4info_t *p4info,
+  SimpleRouterMgr(int dev_id,
                   boost::asio::io_service &io_service,
                   std::shared_ptr<Channel> channel);
 
   ~SimpleRouterMgr();
 
-  int assign();
+  int assign(const std::string &config_buffer);
 
   int add_route(uint32_t prefix, int pLen, uint32_t nhop, uint16_t port);
 

--- a/proto/p4/tmp/p4config.proto
+++ b/proto/p4/tmp/p4config.proto
@@ -23,6 +23,7 @@ message P4DeviceConfig {
   message Extras {
     map<string, string> kv = 1;
   }
-  Extras extras = 1;  
-  bytes device_data = 2;
+  bool reassign = 1;
+  Extras extras = 2;
+  bytes device_data = 3;
 };

--- a/proto/server/PI/proto/pi_server.h
+++ b/proto/server/PI/proto/pi_server.h
@@ -34,7 +34,11 @@ void PIGrpcServerRunAddr(const char *server_address);
 // responsible for shutting down the server for this call to ever return.
 void PIGrpcServerWait();
 
+// Shutdown server but waits for all RPCs to finish
 void PIGrpcServerShutdown();
+
+// Force-shutdown server with a deadline for all RPCs to finish
+void PIGrpcServerForceShutdown(int deadline_seconds);
 
 // Once server has been shutdown, cleanup allocated resources.
 void PIGrpcServerCleanup();

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -475,11 +475,19 @@ void PIGrpcServerWait() {
 
 void PIGrpcServerShutdown() {
   server_data->server->Shutdown();
+  server_data->cq_->Shutdown();
+  server_data->packetin_thread.join();
+}
+
+void PIGrpcServerForceShutdown(int deadline_seconds) {
+  using clock = std::chrono::system_clock;
+  auto deadline = clock::now() + std::chrono::seconds(deadline_seconds);
+  server_data->server->Shutdown(deadline);
+  server_data->cq_->Shutdown();
+  server_data->packetin_thread.join();
 }
 
 void PIGrpcServerCleanup() {
-  server_data->cq_->Shutdown();
-  server_data->packetin_thread.join();
   if (server_data->generator) delete server_data->generator;
   delete server_data;
 }

--- a/proto/tests/mock_switch.cpp
+++ b/proto/tests/mock_switch.cpp
@@ -536,6 +536,13 @@ pi_status_t _pi_assign_device(pi_dev_id_t, const pi_p4info_t *,
   return PI_STATUS_SUCCESS;
 }
 
+pi_status_t _pi_update_device_start(pi_dev_id_t, const pi_p4info_t *,
+                                    const char *, size_t) {
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_update_device_end(pi_dev_id_t) { return PI_STATUS_SUCCESS; }
+
 pi_status_t _pi_remove_device(pi_dev_id_t) { return PI_STATUS_SUCCESS; }
 
 pi_status_t _pi_session_init(pi_session_handle_t *) {

--- a/src/pi_rpc_server.c
+++ b/src/pi_rpc_server.c
@@ -212,12 +212,14 @@ static void __pi_assign_device(char *req) {
   }
 
   size_t p4info_size = strlen(req) + 1;
-  pi_p4info_t *p4info;
-  // TODO(antonin): when is this destroyed?
-  status = pi_add_config(req, PI_CONFIG_TYPE_NATIVE_JSON, &p4info);
-  if (status != PI_STATUS_SUCCESS) {
-    send_status(status);
-    return;
+  pi_p4info_t *p4info = NULL;
+  if (p4info_size > 1) {
+    // TODO(antonin): when is this destroyed?
+    status = pi_add_config(req, PI_CONFIG_TYPE_NATIVE_JSON, &p4info);
+    if (status != PI_STATUS_SUCCESS) {
+      send_status(status);
+      return;
+    }
   }
   req += p4info_size;
 

--- a/targets/rpc/pi_imp.c
+++ b/targets/rpc/pi_imp.c
@@ -191,7 +191,8 @@ pi_status_t _pi_assign_device(pi_dev_id_t dev_id, const pi_p4info_t *p4info,
     req_hdr_t hdr;
     s_pi_dev_id_t dev_id;
   } hdr_t;
-  char *p4info_json = pi_serialize_config(p4info, 0);
+  char *p4info_json = strdup("\0");
+  if (p4info) p4info_json = pi_serialize_config(p4info, 0);
   size_t p4info_size = strlen(p4info_json) + 1;
   size_t num_extras = 0;
   size_t extra_size = sizeof(uint32_t);  // for num extras

--- a/tests/CLI/run_one_test.py.in
+++ b/tests/CLI/run_one_test.py.in
@@ -156,7 +156,8 @@ def main():
     else:
         cmd = []
     cmd += [CLI_path, "-c", os.path.abspath(json_path), "-a", rpc_addr]
-    input_ = "assign_device 0 -- port={}\n".format(thrift_port)
+    input_ = "assign_device 0 0 {} -- port={}\n".format(
+        os.path.abspath(json_path), thrift_port)
     with open(command_path, "r") as f:
         input_ += f.read()
 


### PR DESCRIPTION
The original PI functions (assign / update_start / update_end / remove) were designed pretty much specifically with bmv2 in mind. As we make progress with p4runtime.proto we move towards a model were the P4 dataplane is pushed by the controller and these functions had to be slightly revisited. The assign function now accepts a NULL pointer for  p4info, which means the "device" (e.g. bmv2) was started without an initial P4 configuration. The PI P4Runtime frontend (aka DeviceMgr) was updated to more properly implement SetForwardingPipelineConfig by leveraging the new assign behavior.

The gRPC was updated to showcase that new "paradigm": bmv2 simple_switch is started without any JSON (i.e. without any P4 dataplane configuration). The initial configuration has to be pushed by the controller.