### PR TITLE
Add a special case to pipeline_config_set

### DIFF
--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -119,10 +119,6 @@ class DeviceMgrImp {
     p4info_proto.CopyFrom(p4info_proto_new);
   }
 
-  // TODO(antonin): we assume that VERIFY_AND_COMMIT is use for the first
-  // pipeline_config_set, when no config has been pushed to the switch; while
-  // VERIFY_AND_SAVE & COMMIT are used for config update. This is just
-  // temporary.
   Status pipeline_config_set(p4::SetForwardingPipelineConfigRequest_Action a,
                              const p4::ForwardingPipelineConfig &config) {
     Status status;
@@ -155,29 +151,55 @@ class DeviceMgrImp {
     // check that p4info => device assigned
     assert(!p4info || pi_is_device_assigned(device_id));
 
+    auto remove_device = [this]() {
+      pi_remove_device(device_id);
+      table_info_store.reset();
+      action_profs.clear();
+      p4info.reset(nullptr);
+    };
+
+    auto make_assign_options = [&p4_device_config]() {
+      std::vector<pi_assign_extra_t> assign_options;
+      for (const auto &p : p4_device_config.extras().kv()) {
+        pi_assign_extra_t e;
+        e.key = p.first.c_str();
+        e.v = p.second.c_str();
+        e.end_of_extras = 0;
+        assign_options.push_back(e);
+      }
+      assign_options.push_back({1, NULL, NULL});
+      return assign_options;
+    };
+
+    // This is for legacy support of bmv2
+    if (a == p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT &&
+        p4_device_config.device_data().empty()) {
+      if (pi_is_device_assigned(device_id)) remove_device();
+      assert(!pi_is_device_assigned(device_id));
+      auto assign_options = make_assign_options();
+      pi_status = pi_assign_device(device_id, p4info_tmp,
+                                   assign_options.data());
+      if (pi_status != PI_STATUS_SUCCESS) {
+        status.set_code(Code::UNKNOWN);
+        pi_destroy_config(p4info_tmp);
+        return status;
+      }
+      p4_change(config.p4info(), p4info_tmp);
+      return status;
+    }
+
     // assign device if needed, i.e. if device hasn't been assigned yet or if
     // the reassign flag is set
     if (a == p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE ||
         a == p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT) {
-      if (pi_is_device_assigned(device_id) && p4_device_config.reassign()) {
-        pi_remove_device(device_id);
-        table_info_store.reset();
-        action_profs.clear();
-        p4info.reset(nullptr);
-      }
+      if (pi_is_device_assigned(device_id) && p4_device_config.reassign())
+        remove_device();
       if (!pi_is_device_assigned(device_id)) {
-        std::vector<pi_assign_extra_t> assign_options;
-        for (const auto &p : p4_device_config.extras().kv()) {
-          pi_assign_extra_t e;
-          e.key = p.first.c_str();
-          e.v = p.second.c_str();
-          e.end_of_extras = 0;
-          assign_options.push_back(e);
-        }
-        assign_options.push_back({1, NULL, NULL});
+        auto assign_options = make_assign_options();
         pi_status = pi_assign_device(device_id, NULL, assign_options.data());
         if (pi_status != PI_STATUS_SUCCESS) {
           status.set_code(Code::UNKNOWN);
+          pi_destroy_config(p4info_tmp);
           return status;
         }
       }


### PR DESCRIPTION
for legacy support of some bmv2 tests, which assume the JSON config is
loaded into the switch when the bmv2 process is started.