### PR TITLE
Fix default action set in P4Runtime DeviceMgr

### DIFF
--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -958,6 +958,7 @@ class DeviceMgrImp {
 
   Code construct_match_key(const p4::TableEntry &entry,
                            pi::MatchKey *match_key) const {
+    if (entry.match().empty()) return Code::OK;
     auto code = validate_match_key(entry);
     if (code != Code::OK) return code;
     for (const auto &mf : entry.match()) {

--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -70,6 +70,10 @@ class DummySwitchMock {
   MOCK_METHOD4(table_entry_add,
                pi_status_t(pi_p4_id_t, const pi_match_key_t *,
                            const pi_table_entry_t *, pi_entry_handle_t *));
+  MOCK_METHOD2(table_default_action_set,
+               pi_status_t(pi_p4_id_t, const pi_table_entry_t *));
+  MOCK_METHOD2(table_default_action_get,
+               pi_status_t(pi_p4_id_t, pi_table_entry_t *));
   MOCK_METHOD2(table_entry_delete_wkey,
                pi_status_t(pi_p4_id_t, const pi_match_key_t *));
   MOCK_METHOD3(table_entry_modify_wkey,


### PR DESCRIPTION
When the match key is empty, it means "set default action", and
DeviceMgr should not try to "validate" the match key, which would result
in an error (because of missing fields).
Added GTest unit test.
Many issues remain with default actions (e.g. direct resources support)
and default action get has not been tested yet, but it is now possible
to set the default action.