### PR TITLE
Improve handling of valid in bmv2 json reader

### DIFF
--- a/generators/pd/gen_pd.py
+++ b/generators/pd/gen_pd.py
@@ -227,7 +227,7 @@ def load_json(json_str):
             fid = j_key["id"]
             match_type = get_match_type(j_key["match_type"])
             # TODO(antonin): fix this when valid match handling is improved
-            field_name = j_key["name"].replace("_valid", "valid")
+            field_name = j_key["name"].replace("$valid$", "valid")
             bitwidth = j_key["bitwidth"]
             table.key += [(field_name, fid, match_type, bitwidth)]
         table.set_match_type()

--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -357,8 +357,8 @@ static pi_status_t read_fields(reader_state_t *state, cJSON *root) {
       if (exclude_field(suffix)) continue;
 
       //  just a safeguard, given how we handle validity
-      if (!strncmp("_valid", suffix, sizeof "_valid")) {
-        PI_LOG_ERROR("Fields cannot have name '_valid'");
+      if (!strncmp("$valid$", suffix, sizeof "$valid$")) {
+        PI_LOG_ERROR("Fields cannot have name '$valid$'");
         return PI_STATUS_CONFIG_READER_ERROR;
       }
 
@@ -374,7 +374,7 @@ static pi_status_t read_fields(reader_state_t *state, cJSON *root) {
     // Adding a field to represent validity, don't know how temporary this is
     {
       char fname[256];
-      int n = snprintf(fname, sizeof(fname), "%s._valid", header_name);
+      int n = snprintf(fname, sizeof(fname), "%s.$valid$", header_name);
       if (n <= 0 || (size_t)n >= sizeof(fname)) return PI_STATUS_BUFFER_ERROR;
 
       // 1 bit field
@@ -524,7 +524,7 @@ static pi_status_t read_tables(reader_state_t *state, cJSON *root,
       const char *suffix;
       if (match_type == PI_P4INFO_MATCH_TYPE_VALID) {
         header_name = target->valuestring;
-        suffix = "_valid";
+        suffix = "$valid$";
       } else {
         header_name = cJSON_GetArrayItem(target, 0)->valuestring;
         suffix = cJSON_GetArrayItem(target, 1)->valuestring;

--- a/tests/CLI/testdata/table_dump_valid.out
+++ b/tests/CLI/testdata/table_dump_valid.out
@@ -10,8 +10,8 @@ TABLE ENTRIES
 **********
 Dumping entry 0
 Match key:
-* ethernet._valid     : VALID     01
-* h1._valid           : VALID     00
+* ethernet.$valid$    : VALID     01
+* h1.$valid$          : VALID     00
 Action entry: noop - 
 ==========
 Dumping default entry


### PR DESCRIPTION
This is now more consistent with how p4c is generating p4info.