### PR TITLE
Return error on Write / Read / Get if no pipeline

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -182,21 +182,23 @@ $(BUILT_SOURCES): proto_files.ts
 	  fi; \
 	fi
 
-# confusing names...
 # libpiprotobuf = only protobuf files
-# libpiproto = protobuf + grpc
-lib_LTLIBRARIES = libpiprotobuf.la libpiproto.la
+# libpiprotogrpc = only grpc files
+# It used to be that I had a library combining both (i.e. it was created by
+# compiling and linking both proto_cpp_files and proto_grpc_files). Some
+# executables ended up linking to both libraries which lead to an issue when
+# compiling with clang in optimized mode similar to that one:
+# https://github.com/tensorflow/tensorflow/issues/8394
+lib_LTLIBRARIES = libpiprotobuf.la libpiprotogrpc.la
 
 # generated source should not be distributed
 nodist_libpiprotobuf_la_SOURCES = $(proto_cpp_files)
-nodist_libpiproto_la_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
+nodist_libpiprotogrpc_la_SOURCES = $(proto_grpc_files)
 
 libpiprotobuf_la_SOURCES = src/util.cpp
 
-libpiproto_la_SOURCES = src/util.cpp
-
 libpiprotobuf_la_LIBADD = $(PROTOBUF_LIBS)
-libpiproto_la_LIBADD = $(PROTOBUF_LIBS) $(GRPC_LIBS)
+libpiprotogrpc_la_LIBADD = libpiprotobuf.la $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 nobase_include_HEADERS = \
 PI/proto/util.h

--- a/proto/demo_grpc/Makefile.am
+++ b/proto/demo_grpc/Makefile.am
@@ -26,7 +26,8 @@ app.cpp
 COMMON_SERVER_LIBS = \
 $(top_builddir)/server/libpigrpcserver.la \
 $(top_builddir)/frontend/libpifeproto.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotogrpc.la \
+$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpiall.la
 
 if WITH_BMV2
@@ -46,13 +47,15 @@ $(top_builddir)/../targets/dummy/libpi_dummy.la
 
 test_perf_LDADD = \
 $(top_builddir)/../src/libpip4info.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotogrpc.la \
+$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/p4info/libpiconvertproto.la \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 controller_LDADD = \
 $(top_builddir)/../src/libpip4info.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotogrpc.la \
+$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/p4info/libpiconvertproto.la \
 -lmicrohttpd -lboost_system \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)

--- a/proto/server/Makefile.am
+++ b/proto/server/Makefile.am
@@ -15,7 +15,8 @@ nobase_include_HEADERS = PI/proto/pi_server.h
 
 libpigrpcserver_la_LIBADD = \
 $(top_builddir)/frontend/libpifeproto.la \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotogrpc.la \
+$(top_builddir)/libpiprotobuf.la \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)
 # causes issue with libpiproto as it includes a version of google.rpc.Status
 # -lgrpc++_error_details

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = \
 -I$(top_srcdir)/frontend \
 -I$(top_builddir)/cpp_out \
 -I$(top_srcdir)/p4info \
+-I$(top_srcdir)/server \
 -I$(top_srcdir)/../third_party/googletest/googletest/include \
 -I$(top_srcdir)/../third_party/googletest/googlemock/include \
 -DTESTDATADIR=\"$(abs_top_srcdir)/../tests/testdata\"
@@ -12,14 +13,14 @@ AM_CPPFLAGS = \
 TESTS = \
 test_p4info_convert \
 test_proto_fe \
-test_proto_fe_packet_io
+test_proto_fe_packet_io \
+test_server_no_pipeline_config
 
 common_source = main.cpp
 
 common_libs = \
 $(top_builddir)/../third_party/libgmock.la \
-$(top_builddir)/../third_party/libgtest.la \
-$(PROTOBUF_LIBS)
+$(top_builddir)/../third_party/libgtest.la
 
 test_p4info_convert_SOURCES = $(common_source) test_p4info_convert.cpp
 
@@ -27,7 +28,8 @@ test_p4info_convert_LDADD = \
 $(top_builddir)/p4info/libpiconvertproto.la \
 $(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpip4info.la \
-$(common_libs)
+$(common_libs) \
+$(PROTOBUF_LIBS)
 
 proto_fe_common_source = $(common_source) mock_switch.h mock_switch.cpp
 
@@ -42,19 +44,34 @@ test_proto_fe_packet_io.cpp
 test_proto_fe_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_proto_fe_packet_io_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 
-proto_fe_libs = \
+mock_switch_libs = \
 $(top_builddir)/p4info/libpiconvertproto.la \
 $(top_builddir)/frontend/libpifeproto.la \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \
-$(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpiall.la \
 $(top_builddir)/../src/libpip4info.la \
 $(common_libs)
 
+proto_fe_libs = \
+$(mock_switch_libs) \
+$(top_builddir)/libpiprotobuf.la \
+$(PROTOBUF_LIBS)
+
 test_proto_fe_LDADD = $(proto_fe_libs)
 test_proto_fe_packet_io_LDADD = $(proto_fe_libs)
+
+test_server_no_pipeline_config_SOURCES = $(proto_fe_common_source) \
+server/gnmi_mgr_dummy.cpp \
+server/test_no_pipeline_config.cpp
+test_server_no_pipeline_config_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
+test_server_no_pipeline_config_LDADD = \
+$(top_builddir)/server/libpigrpcserver.la \
+$(mock_switch_libs) \
+$(top_builddir)/libpiproto.la \
+$(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 check_PROGRAMS = \
 test_p4info_convert \
 test_proto_fe \
-test_proto_fe_packet_io
+test_proto_fe_packet_io \
+test_server_no_pipeline_config

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -67,7 +67,8 @@ test_server_no_pipeline_config_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_server_no_pipeline_config_LDADD = \
 $(top_builddir)/server/libpigrpcserver.la \
 $(mock_switch_libs) \
-$(top_builddir)/libpiproto.la \
+$(top_builddir)/libpiprotogrpc.la \
+$(top_builddir)/libpiprotobuf.la \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 check_PROGRAMS = \

--- a/proto/tests/server/gnmi_mgr_dummy.cpp
+++ b/proto/tests/server/gnmi_mgr_dummy.cpp
@@ -1,0 +1,76 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/frontends/proto/gnmi_mgr.h>
+
+#include "google/rpc/code.pb.h"
+
+using Status = ::google::rpc::Status;
+using Code = ::google::rpc::Code;
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+class GnmiMgrImp {
+ public:
+  Status get(const gnmi::GetRequest &request,
+             gnmi::GetResponse *response) const {
+    (void) request;
+    (void) response;
+    Status status;
+    status.set_code(Code::UNIMPLEMENTED);
+    return status;
+  }
+
+  Status set(const gnmi::SetRequest &request,
+             gnmi::SetResponse *response) {
+    (void) request;
+    (void) response;
+    Status status;
+    status.set_code(Code::UNIMPLEMENTED);
+    return status;
+  }
+};
+
+GnmiMgr::GnmiMgr()
+    : pimp(new GnmiMgrImp()) { }
+
+GnmiMgr::~GnmiMgr() = default;
+
+Status
+GnmiMgr::get(const gnmi::GetRequest &request,
+             gnmi::GetResponse *response) const {
+  return pimp->get(request, response);
+}
+
+Status
+GnmiMgr::set(const gnmi::SetRequest &request,
+             gnmi::SetResponse *response) {
+  return pimp->set(request, response);
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi

--- a/proto/tests/server/test_no_pipeline_config.cpp
+++ b/proto/tests/server/test_no_pipeline_config.cpp
@@ -1,0 +1,99 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <gtest/gtest.h>
+
+#include <p4/p4runtime.grpc.pb.h>
+
+#include <PI/proto/pi_server.h>
+
+namespace pi {
+namespace proto {
+namespace testing {
+namespace {
+
+using grpc::ClientContext;
+using grpc::Status;
+using grpc::StatusCode;
+
+class TestNoForwardingPipeline : public ::testing::Test {
+ protected:
+  TestNoForwardingPipeline()
+      : p4runtime_channel(grpc::CreateChannel(
+            grpc_server_addr, grpc::InsecureChannelCredentials())),
+        p4runtime_stub(p4::P4Runtime::NewStub(p4runtime_channel)) { }
+
+  static void SetUpTestCase() {
+    PIGrpcServerRunAddr(grpc_server_addr);
+  }
+
+  static void TearDownTestCase() {
+    PIGrpcServerShutdown();
+  }
+
+  int device_id{0};
+  std::shared_ptr<grpc::Channel> p4runtime_channel;
+  std::unique_ptr<p4::P4Runtime::Stub> p4runtime_stub;
+
+  static constexpr char grpc_server_addr[] = "0.0.0.0:50051";
+};
+
+constexpr char TestNoForwardingPipeline::grpc_server_addr[];
+
+TEST_F(TestNoForwardingPipeline, Write) {
+  p4::WriteRequest request;
+  request.set_device_id(device_id);
+  ClientContext context;
+  p4::WriteResponse rep;
+  auto status = p4runtime_stub->Write(&context, request, &rep);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(StatusCode::FAILED_PRECONDITION, status.error_code());
+}
+
+TEST_F(TestNoForwardingPipeline, Read) {
+  p4::ReadRequest request;
+  request.set_device_id(device_id);
+  ClientContext context;
+  p4::ReadResponse rep;
+  std::unique_ptr<grpc::ClientReader<p4::ReadResponse> > reader(
+      p4runtime_stub->Read(&context, request));
+  reader->Read(&rep);
+  auto status = reader->Finish();
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(StatusCode::FAILED_PRECONDITION, status.error_code());
+}
+
+TEST_F(TestNoForwardingPipeline, GetForwardingPipelineConfig) {
+  p4::GetForwardingPipelineConfigRequest request;
+  request.add_device_ids(device_id);
+  ClientContext context;
+  p4::GetForwardingPipelineConfigResponse rep;
+  auto status = p4runtime_stub->GetForwardingPipelineConfig(
+      &context, request, &rep);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(StatusCode::FAILED_PRECONDITION, status.error_code());
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi


### PR DESCRIPTION
Instead of crashing, we return a FAILED_PRECONDITION error code.
Also support multiple devices (i.e. multiple DeviceMgr instances) in
reference server implementation.