### PR TITLE
Support in DeviceMgr for reading one direct counter

### DIFF
--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -109,6 +109,13 @@ class DummySwitchMock {
                pi_status_t(pi_p4_id_t, pi_entry_handle_t,
                            const pi_meter_spec_t *));
 
+  MOCK_METHOD4(counter_read,
+               pi_status_t(pi_p4_id_t, size_t, int,
+                           pi_counter_data_t *counter_data));
+  MOCK_METHOD4(counter_read_direct,
+               pi_status_t(pi_p4_id_t, pi_entry_handle_t, int,
+                           pi_counter_data_t *counter_data));
+
   MOCK_METHOD2(packetout_send, pi_status_t(const char *, size_t));
 
  private:


### PR DESCRIPTION
We only support the most common case for now (read one counter entry
from a direct counter by specifying the counter id and the table
entry). We will add support for the other cases (all counter entries
from one direct counter / all counter entries from all direct counters)
later.