### PR TITLE
Fix invalid type for device_id in p4runtime.proto

### DIFF
--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -390,7 +390,7 @@ message ForwardingPipelineConfig {
 }
 
 message GetForwardingPipelineConfigRequest {
-  repeated uint32 device_ids = 1;
+  repeated uint64 device_ids = 1;
 }
 
 message GetForwardingPipelineConfigResponse {


### PR DESCRIPTION
Type was uint32 in GetForwardingPipelineConfigRequest. Should be uint64.