### PR TITLE
Fix P4Runtime implementation for indirect counter read

### DIFF
--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -849,8 +849,7 @@ class DeviceMgrImp {
     if (counter_entry.index() != 0) {
       auto entry = response->add_entities()->mutable_counter_entry();
       entry->CopyFrom(counter_entry);
-      auto status = counter_read_one_index(session, counter_id, entry, true);
-      if (IS_ERROR(status)) return status;
+      return counter_read_one_index(session, counter_id, entry, true);
     }
     // default index, read all
     auto counter_size = pi_p4info_counter_get_size(p4info.get(), counter_id);
@@ -862,6 +861,7 @@ class DeviceMgrImp {
     }
     for (size_t index = 0; index < counter_size; index++) {
       auto entry = response->add_entities()->mutable_counter_entry();
+      entry->set_counter_id(counter_id);
       entry->set_index(index);
       auto status = counter_read_one_index(session, counter_id, entry);
       if (IS_ERROR(status)) return status;

--- a/tests/testdata/act_prof.json
+++ b/tests/testdata/act_prof.json
@@ -2,8 +2,9 @@
     "__meta__": {
         "version": [
             2,
-            0
-        ]
+            5
+        ],
+        "compiler": "https://github.com/p4lang/p4c-bm"
     },
     "header_types": [
         {
@@ -44,7 +45,8 @@
                 ]
             ],
             "length_exp": null,
-            "max_length": null
+            "max_length": null,
+            "pragmas": []
         }
     ],
     "headers": [
@@ -52,7 +54,8 @@
             "name": "standard_metadata",
             "id": 0,
             "header_type": "standard_metadata_t",
-            "metadata": true
+            "metadata": true,
+            "pragmas": []
         }
     ],
     "header_stacks": [],
@@ -74,7 +77,8 @@
                             "mask": null,
                             "next_state": null
                         }
-                    ]
+                    ],
+                    "pragmas": []
                 }
             ]
         }
@@ -93,7 +97,8 @@
             "name": "a",
             "id": 0,
             "runtime_data": [],
-            "primitives": []
+            "primitives": [],
+            "pragmas": []
         }
     ],
     "pipelines": [
@@ -119,7 +124,8 @@
                     "next_tables": {
                         "a": "t2"
                     },
-                    "base_default_next": "t2"
+                    "base_default_next": "t2",
+                    "pragmas": []
                 },
                 {
                     "name": "t2",
@@ -138,14 +144,16 @@
                     "next_tables": {
                         "a": null
                     },
-                    "base_default_next": null
+                    "base_default_next": null,
+                    "pragmas": []
                 }
             ],
             "action_profiles": [
                 {
                     "name": "ap",
                     "id": 0,
-                    "max_size": 128
+                    "max_size": 128,
+                    "pragmas": []
                 }
             ],
             "conditionals": []

--- a/tests/testdata/l2_switch.json
+++ b/tests/testdata/l2_switch.json
@@ -2,8 +2,9 @@
     "__meta__": {
         "version": [
             2,
-            0
-        ]
+            5
+        ],
+        "compiler": "https://github.com/p4lang/p4c-bm"
     },
     "header_types": [
         {
@@ -213,8 +214,39 @@
             "pragmas": []
         },
         {
-            "name": "forward",
+            "name": "broadcast",
             "id": 1,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "intrinsic_metadata",
+                                "mcast_grp"
+                            ]
+                        },
+                        {
+                            "type": "hexstr",
+                            "value": "0x1"
+                        }
+                    ]
+                }
+            ],
+            "pragmas": []
+        },
+        {
+            "name": "_nop",
+            "id": 2,
+            "runtime_data": [],
+            "primitives": [],
+            "pragmas": []
+        },
+        {
+            "name": "forward",
+            "id": 3,
             "runtime_data": [
                 {
                     "name": "port",
@@ -255,37 +287,6 @@
                     ]
                 }
             ],
-            "pragmas": []
-        },
-        {
-            "name": "broadcast",
-            "id": 2,
-            "runtime_data": [],
-            "primitives": [
-                {
-                    "op": "modify_field",
-                    "parameters": [
-                        {
-                            "type": "field",
-                            "value": [
-                                "intrinsic_metadata",
-                                "mcast_grp"
-                            ]
-                        },
-                        {
-                            "type": "hexstr",
-                            "value": "0x1"
-                        }
-                    ]
-                }
-            ],
-            "pragmas": []
-        },
-        {
-            "name": "_nop",
-            "id": 3,
-            "runtime_data": [],
-            "primitives": [],
             "pragmas": []
         }
     ],

--- a/tests/testdata/pragmas.json
+++ b/tests/testdata/pragmas.json
@@ -2,8 +2,9 @@
     "__meta__": {
         "version": [
             2,
-            0
-        ]
+            5
+        ],
+        "compiler": "https://github.com/p4lang/p4c-bm"
     },
     "header_types": [
         {

--- a/tests/testdata/stats.json
+++ b/tests/testdata/stats.json
@@ -2,8 +2,9 @@
     "__meta__": {
         "version": [
             2,
-            0
-        ]
+            5
+        ],
+        "compiler": "https://github.com/p4lang/p4c-bm"
     },
     "header_types": [
         {
@@ -165,8 +166,62 @@
     ],
     "actions": [
         {
-            "name": "actionA",
+            "name": "_RegisterAAction",
             "id": 0,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "register_write",
+                    "parameters": [
+                        {
+                            "type": "register_array",
+                            "value": "RegisterA"
+                        },
+                        {
+                            "type": "hexstr",
+                            "value": "0xa"
+                        },
+                        {
+                            "type": "hexstr",
+                            "value": "0x4d"
+                        }
+                    ]
+                }
+            ],
+            "pragmas": []
+        },
+        {
+            "name": "actionB",
+            "id": 1,
+            "runtime_data": [
+                {
+                    "name": "param",
+                    "bitwidth": 8
+                }
+            ],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "header_test",
+                                "field8"
+                            ]
+                        },
+                        {
+                            "type": "runtime_data",
+                            "value": 0
+                        }
+                    ]
+                }
+            ],
+            "pragmas": []
+        },
+        {
+            "name": "actionA",
+            "id": 2,
             "runtime_data": [
                 {
                     "name": "param",
@@ -195,7 +250,7 @@
         },
         {
             "name": "_CounterAAction",
-            "id": 1,
+            "id": 3,
             "runtime_data": [],
             "primitives": [
                 {
@@ -208,60 +263,6 @@
                         {
                             "type": "hexstr",
                             "value": "0x80"
-                        }
-                    ]
-                }
-            ],
-            "pragmas": []
-        },
-        {
-            "name": "actionB",
-            "id": 2,
-            "runtime_data": [
-                {
-                    "name": "param",
-                    "bitwidth": 8
-                }
-            ],
-            "primitives": [
-                {
-                    "op": "modify_field",
-                    "parameters": [
-                        {
-                            "type": "field",
-                            "value": [
-                                "header_test",
-                                "field8"
-                            ]
-                        },
-                        {
-                            "type": "runtime_data",
-                            "value": 0
-                        }
-                    ]
-                }
-            ],
-            "pragmas": []
-        },
-        {
-            "name": "_RegisterAAction",
-            "id": 3,
-            "runtime_data": [],
-            "primitives": [
-                {
-                    "op": "register_write",
-                    "parameters": [
-                        {
-                            "type": "register_array",
-                            "value": "RegisterA"
-                        },
-                        {
-                            "type": "hexstr",
-                            "value": "0xa"
-                        },
-                        {
-                            "type": "hexstr",
-                            "value": "0x4d"
                         }
                     ]
                 }

--- a/tests/testdata/unittest.json
+++ b/tests/testdata/unittest.json
@@ -165,28 +165,20 @@
     ],
     "actions": [
         {
-            "name": "actionB",
+            "name": "_CounterAAction",
             "id": 0,
-            "runtime_data": [
-                {
-                    "name": "param",
-                    "bitwidth": 8
-                }
-            ],
+            "runtime_data": [],
             "primitives": [
                 {
-                    "op": "modify_field",
+                    "op": "count",
                     "parameters": [
                         {
-                            "type": "field",
-                            "value": [
-                                "header_test",
-                                "field8"
-                            ]
+                            "type": "counter_array",
+                            "value": "CounterA"
                         },
                         {
-                            "type": "runtime_data",
-                            "value": 0
+                            "type": "hexstr",
+                            "value": "0x80"
                         }
                     ]
                 }
@@ -223,8 +215,37 @@
             "pragmas": []
         },
         {
-            "name": "actionC",
+            "name": "actionB",
             "id": 2,
+            "runtime_data": [
+                {
+                    "name": "param",
+                    "bitwidth": 8
+                }
+            ],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "header_test",
+                                "field8"
+                            ]
+                        },
+                        {
+                            "type": "runtime_data",
+                            "value": 0
+                        }
+                    ]
+                }
+            ],
+            "pragmas": []
+        },
+        {
+            "name": "actionC",
+            "id": 3,
             "runtime_data": [],
             "primitives": [],
             "pragmas": []
@@ -492,8 +513,36 @@
                         "actionB"
                     ],
                     "next_tables": {
-                        "actionA": null,
-                        "actionB": null
+                        "actionA": "_CounterATable",
+                        "actionB": "_CounterATable"
+                    },
+                    "base_default_next": "_CounterATable",
+                    "pragmas": []
+                },
+                {
+                    "name": "_CounterATable",
+                    "id": 8,
+                    "match_type": "exact",
+                    "type": "simple",
+                    "max_size": 512,
+                    "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
+                    "key": [
+                        {
+                            "match_type": "exact",
+                            "target": [
+                                "header_test",
+                                "field32"
+                            ],
+                            "mask": null
+                        }
+                    ],
+                    "actions": [
+                        "_CounterAAction"
+                    ],
+                    "next_tables": {
+                        "_CounterAAction": null
                     },
                     "base_default_next": null,
                     "pragmas": []
@@ -585,6 +634,13 @@
             "is_direct": true,
             "binding": "ExactOne",
             "size": 512,
+            "pragmas": []
+        },
+        {
+            "name": "CounterA",
+            "id": 1,
+            "is_direct": false,
+            "size": 1024,
             "pragmas": []
         }
     ],

--- a/tests/testdata/unittest.p4
+++ b/tests/testdata/unittest.p4
@@ -161,6 +161,25 @@ table ExactOneNonAligned {
     size: 512;
 }
 
+counter CounterA {
+    type : packets;
+    instance_count : 1024;
+}
+
+action _CounterAAction() {
+    count(CounterA, 128);
+}
+
+table _CounterATable {
+    reads {
+         header_test.field32 : exact;
+    }
+    actions {
+        _CounterAAction;
+    }
+    size: 512;
+}
+
 control ingress {
     apply(ExactOne);
     apply(LpmOne);
@@ -170,6 +189,7 @@ control ingress {
     apply(MixMany);
     apply(IndirectWS);
     apply(ExactOneNonAligned);
+    apply(_CounterATable);
 }
 
 control egress { }

--- a/tests/testdata/valid.json
+++ b/tests/testdata/valid.json
@@ -2,8 +2,9 @@
     "__meta__": {
         "version": [
             2,
-            0
-        ]
+            5
+        ],
+        "compiler": "https://github.com/p4lang/p4c-bm"
     },
     "header_types": [
         {


### PR DESCRIPTION
Reading a single index was broken as it would cause all indices to be
read as well because of a missing return statement.
When reading all indices, the counter id was missing from the response.

Fixes issue #197