### PR TITLE
First stab at implementing controller arbitration

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,76 @@
+# P4Runtime
+
+## Arbitration
+
+This server implementation of P4Runtime supports master-slave arbitration. In
+P4Runtime each client needs to open a bi-directional stream connection to the
+server using the `StreamChannel` RPC. The client should advertise its election
+id right away using a `MasterArbitrationUpdate` message. The process through
+which election ids are allocated to clients is out-of-scope of P4Runtime and of
+this document. The client with the highest election id is referred to as the
+"master", while all other clients are referred to as "slaves".
+
+Only the master client can successfully:
+- perform `Write` requests
+- receive `PacketIn` messages
+- send `PacketOut` messages
+
+### `MasterArbitrationUpdate` client request
+
+- if this is the first `MasterArbitrationUpdate` message sent by the client:
+  - if the election id is already used by another client connection, the server
+    should terminate the stream by returning an `INVALID_ARGUMENT` error.
+  - otherwise, if the max number of clients supported by the server is exceeded,
+    the server should terminate the stream by returning a `RESOURCE_EXHAUSTED`
+    error.
+  - otherwise, the client is added to the server's client list.
+
+- if the client is already registered with the server and sends a new
+  `MasterArbitrationUpdate` message:
+  - if the device id does not match the current one, the server should terminate
+    the stream by returning a `FAILED_PRECONDITION` error.
+  - otherwise, if the election id matches the current one, nothing happens
+  - otherwise, if the new election id is already used by another client
+    connection, the server should terminate the stream by returning an
+    `INVALID_ARGUMENT` error.
+  - otherwise, the server updates the election id for that client.
+
+### `MasterArbitrationUpdate` client response
+
+- if the mastership changed following a `MasterArbitrationUpdate` client
+  request, all existing clients are sent a `MasterArbitrationUpdate` message by
+  the server. The `device_id` and `election_id` fields must be set
+  correctly. The `status` field's code is `OK` for the master, `ALREADY_EXISTS`
+  for all the slaves.
+
+- otherwise, only the client which sent the request is notified, assuming its
+  election id changed (new connection or election id updated). The `device_id`
+  and `election_id` fields must be set correctly. The `status` field's code is
+  `OK` if that client is the master, `ALREADY_EXISTS` if it is a slave.
+
+### Packet-in
+
+Only the master receives `PacketIn` messages. If there is no master (i.e. no
+client connections), packets are dropped.
+
+### Packet-out
+
+Only the master can send `PacketOut` messages. In all other cases, the message
+is dropped.
+
+### Write requests
+
+Only the master can send `WriteRequest` messages. If a slave tries to issue a
+`Write`, error code `PERMISSION_DENIED` is returned. The master is indetified by
+using the `election_id` field. Note that all clients are trusted; we do not
+support the case where a client is using an incorrect `election_id` in his
+`WriteRequest` messages.
+
+Note that for the sake of debugging and testing, we accept `WriteRequest`
+messages when there is no master (i.e. no client connections) and the
+`election_id` field is not set.
+
+### Read requests
+
+Everyone can perform a `Read`, even clients who haven't opened the
+bi-directional stream and advertised an election id.

--- a/proto/server/Makefile.am
+++ b/proto/server/Makefile.am
@@ -9,7 +9,10 @@ AM_CXXFLAGS = -Wall -Werror
 
 lib_LTLIBRARIES = libpigrpcserver.la
 
-libpigrpcserver_la_SOURCES = pi_server.cpp
+libpigrpcserver_la_SOURCES = \
+pi_server.cpp \
+uint128.h \
+uint128.cpp
 
 nobase_include_HEADERS = PI/proto/pi_server.h
 

--- a/proto/server/PI/CPPLINT.cfg
+++ b/proto/server/PI/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-build/header_guard

--- a/proto/server/pi_server_testing.h
+++ b/proto/server/pi_server_testing.h
@@ -1,0 +1,49 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef PROTO_SERVER_PI_SERVER_TESTING_H_
+#define PROTO_SERVER_PI_SERVER_TESTING_H_
+
+#include <PI/frontends/proto/device_mgr.h>
+
+namespace p4 {
+
+class PacketIn;
+
+}  // namespace p4
+
+namespace pi {
+
+namespace server {
+
+namespace testing {
+
+void send_packet_in(::pi::fe::proto::DeviceMgr::device_id_t device_id,
+                    p4::PacketIn *packet);
+
+size_t max_connections();
+
+}  // namespace testing
+
+}  // namespace server
+
+}  // namespace pi
+
+#endif  // PROTO_SERVER_PI_SERVER_TESTING_H_

--- a/proto/server/uint128.cpp
+++ b/proto/server/uint128.cpp
@@ -1,0 +1,53 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "uint128.h"
+
+#include <iomanip>
+#include <ostream>
+
+namespace {
+
+// Saves the internal state of a stream and restores it in the destructor
+struct StreamStateSaver final {
+  explicit StreamStateSaver(std::ios &s)  // NOLINT(runtime/references)
+      : ref(s) {
+    state.copyfmt(s);
+  }
+
+  ~StreamStateSaver() {
+    ref.copyfmt(state);
+  }
+
+  std::ios &ref;
+  std::ios state{nullptr};
+};
+
+}  // namespace
+
+std::ostream &operator<<(std::ostream &out, const Uint128 &n) {
+  StreamStateSaver state_saver(out);
+  out << "0x";
+  if (n.high_ == 0)
+    out << std::hex << n.low_;
+  else
+    out << std::hex << n.high_ << std::setw(16) << std::setfill('0') << n.low_;
+  return out;
+}

--- a/proto/server/uint128.h
+++ b/proto/server/uint128.h
@@ -1,0 +1,93 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef PROTO_SERVER_UINT128_H_
+#define PROTO_SERVER_UINT128_H_
+
+#include <cstdint>
+
+#include <iosfwd>
+#include <type_traits>
+
+class Uint128 {
+ public:
+  constexpr Uint128()
+      : high_(0), low_(0) { }
+  constexpr Uint128(uint64_t high, uint64_t low)
+      : high_(high), low_(low) { }
+  template<typename T,
+           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  constexpr Uint128(T i)
+      : high_(0), low_(i) { }
+
+  Uint128& operator+=(const Uint128 &other) {
+    high_ += other.high_;
+    uint64_t new_low_ = low_ + other.low_;
+    if (new_low_ < low_) high_++;
+    low_ = new_low_;
+    return *this;
+  }
+
+  Uint128 &operator++() {
+    *this += 1;
+    return *this;
+  }
+
+  Uint128 operator++(int) {
+    Uint128 tmp(*this);
+    *this += 1;
+    return tmp;
+  }
+
+  friend bool operator==(const Uint128 &a, const Uint128 &b) {
+    return (a.high_ == b.high_) && (a.low_ == b.low_);
+  }
+
+  friend bool operator!=(const Uint128 &a, const Uint128 &b) {
+    return !(a == b);
+  }
+
+  friend bool operator<(const Uint128 &a, const Uint128 &b) {
+    return (a.high_ < b.high_) || ((a.high_ == b.high_) && (a.low_ < b.low_));
+  }
+
+  friend bool operator<=(const Uint128 &a, const Uint128 &b) {
+    return (a.high_ < b.high_) || ((a.high_ == b.high_) && (a.low_ <= b.low_));
+  }
+
+  friend bool operator>(const Uint128 &a, const Uint128 &b) {
+    return !(a <= b);
+  }
+
+  friend bool operator>=(const Uint128 &a, const Uint128 &b) {
+    return !(a < b);
+  }
+
+  friend std::ostream &operator<<(std::ostream &out, const Uint128 &n);
+
+  uint64_t high() const { return high_; }
+  uint64_t low() const { return low_; }
+
+ private:
+  uint64_t high_;
+  uint64_t low_;
+};
+
+#endif  // PROTO_SERVER_UINT128_H_

--- a/proto/server/uint128.h
+++ b/proto/server/uint128.h
@@ -56,6 +56,25 @@ class Uint128 {
     return tmp;
   }
 
+  Uint128& operator-=(const Uint128 &other) {
+    high_ -= other.high_;
+    uint64_t new_low_ = low_ - other.low_;
+    if (new_low_ > low_) high_--;
+    low_ = new_low_;
+    return *this;
+  }
+
+  Uint128 &operator--() {
+    *this -= 1;
+    return *this;
+  }
+
+  Uint128 operator--(int) {
+    Uint128 tmp(*this);
+    *this -= 1;
+    return tmp;
+  }
+
   friend bool operator==(const Uint128 &a, const Uint128 &b) {
     return (a.high_ == b.high_) && (a.low_ == b.low_);
   }

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -17,7 +17,8 @@ test_p4info_convert \
 test_proto_fe \
 test_proto_fe_packet_io \
 test_server_no_pipeline_config \
-test_server_gnmi
+test_server_gnmi \
+test_server_arbitration
 
 common_source = main.cpp
 
@@ -82,9 +83,15 @@ server/test_gnmi.cpp
 test_server_gnmi_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_server_gnmi_LDADD = $(test_server_libs)
 
+test_server_arbitration_SOURCES = $(test_server_common_source) \
+server/test_arbitration.cpp
+test_server_arbitration_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
+test_server_arbitration_LDADD = $(test_server_libs)
+
 check_PROGRAMS = \
 test_p4info_convert \
 test_proto_fe \
 test_proto_fe_packet_io \
 test_server_no_pipeline_config \
-test_server_gnmi
+test_server_gnmi \
+test_server_arbitration

--- a/proto/tests/server/test_arbitration.cpp
+++ b/proto/tests/server/test_arbitration.cpp
@@ -1,0 +1,284 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <google/rpc/code.pb.h>
+#include <p4/p4runtime.grpc.pb.h>
+
+#include <PI/proto/pi_server.h>
+
+#include <string>
+#include <vector>
+
+#include "pi_server_testing.h"
+#include "uint128.h"
+
+#include "mock_switch.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+namespace {
+
+using grpc::ClientContext;
+using grpc::Status;
+using grpc::StatusCode;
+
+// TODO(antonin): We use a synchronous client for the sake of simplicity. This
+// is not optimal as it doesn't let us set deadlines on read operations, which
+// makes it difficult to have a negative test for packet in (for examples).
+
+// TODO(antonin): We do not set the P4 forwarding pipeline, which means that a
+// Write operation is considered successful if it returns
+// FAILED_PRECONDITION. It also means that we cannot test packet out
+// "end-to-end" (packets are dropped if no P4 pipeline at the moment).
+
+class TestArbitration : public ::testing::Test {
+ protected:
+  TestArbitration()
+      : p4runtime_channel(grpc::CreateChannel(
+            grpc_server_addr, grpc::InsecureChannelCredentials())),
+        p4runtime_stub(p4::P4Runtime::NewStub(p4runtime_channel)),
+        mock(wrapper.sw()) { }
+
+  static void SetUpTestCase() {
+    PIGrpcServerRunAddr(grpc_server_addr);
+  }
+
+  static void TearDownTestCase() {
+    PIGrpcServerShutdown();
+  }
+
+  using ReaderWriter = ::grpc::ClientReaderWriter<p4::StreamMessageRequest,
+                                                  p4::StreamMessageResponse>;
+
+  static ::Uint128 convert_election_id(const p4::Uint128 &from) {
+    return ::Uint128(from.high(), from.low());
+  }
+
+  static void set_election_id(const ::Uint128 &from, p4::Uint128 *to) {
+    to->set_high(from.high());
+    to->set_low(from.low());
+  }
+
+  std::unique_ptr<ReaderWriter> stream_setup(ClientContext *context,
+                                             const ::Uint128 &election_id) {
+    auto stream = p4runtime_stub->StreamChannel(context);
+    p4::StreamMessageRequest request;
+    auto arbitration = request.mutable_arbitration();
+    arbitration->set_device_id(device_id);
+    set_election_id(election_id, arbitration->mutable_election_id());
+    stream->Write(request);
+    return stream;
+  }
+
+  Status stream_teardown(std::unique_ptr<ReaderWriter> stream) {
+    stream->WritesDone();
+    p4::StreamMessageResponse response;
+    while (stream->Read(&response))  // check that no extra messages
+      grpc::Status status(StatusCode::UNKNOWN, "");
+    return stream->Finish();
+  }
+
+  ::google::rpc::Status read_arbitration_status(ReaderWriter *stream) {
+    p4::StreamMessageResponse response;
+    while (stream->Read(&response)) {
+      if (response.update_case() != p4::StreamMessageResponse::kArbitration)
+        break;
+      return response.arbitration().status();
+    }
+    ::google::rpc::Status status;
+    status.set_code(::google::rpc::Code::UNKNOWN);
+    return status;
+  }
+
+  bool read_packet_in(ReaderWriter *stream) {
+    p4::StreamMessageResponse response;
+    while (stream->Read(&response)) {
+      if (response.update_case() != p4::StreamMessageResponse::kPacket)
+        break;
+      return true;
+    }
+    return false;
+  }
+
+  Status do_write(const Uint128 &election_id) {
+    p4::WriteRequest request;
+    request.set_device_id(device_id);
+    set_election_id(election_id, request.mutable_election_id());
+    ClientContext context;
+    p4::WriteResponse rep;
+    return p4runtime_stub->Write(&context, request, &rep);
+  }
+
+  void send_packet_out(ReaderWriter *stream, const std::string &payload) {
+    p4::StreamMessageRequest request;
+    auto packet = request.mutable_packet();
+    packet->set_payload(payload);
+    stream->Write(request);
+  }
+
+  int device_id{0};
+  std::shared_ptr<grpc::Channel> p4runtime_channel;
+  std::unique_ptr<p4::P4Runtime::Stub> p4runtime_stub;
+  DummySwitchWrapper wrapper{};
+  DummySwitchMock *mock;
+
+  static constexpr char grpc_server_addr[] = "0.0.0.0:50053";
+};
+
+constexpr char TestArbitration::grpc_server_addr[];
+
+TEST_F(TestArbitration, WriteNoMaster) {
+  // no streams, empty election id, should go through
+  {
+    p4::WriteRequest request;
+    request.set_device_id(device_id);
+    ClientContext context;
+    p4::WriteResponse rep;
+    auto status = p4runtime_stub->Write(&context, request, &rep);
+    // expect FAILED_PRECONDITION (and not PERMISSION_DENIED)
+    EXPECT_EQ(StatusCode::FAILED_PRECONDITION, status.error_code());
+  }
+  {
+    auto status = do_write(1);
+    EXPECT_EQ(StatusCode::PERMISSION_DENIED, status.error_code());
+  }
+}
+
+TEST_F(TestArbitration, DuplicateElectionId) {
+  Uint128 election_id(1);
+  ClientContext stream_1_context;
+  auto stream_1 = stream_setup(&stream_1_context, election_id);
+  ASSERT_NE(stream_1, nullptr);
+  EXPECT_EQ(read_arbitration_status(stream_1.get()).code(),
+            ::google::rpc::Code::OK);
+  ClientContext stream_2_context;
+  auto stream_2 = stream_setup(&stream_2_context, election_id);
+  ASSERT_NE(stream_2, nullptr);
+  // need to close stream_2 before stream_1, otherwise the test may fail as
+  // stream_1 can end up being closed before the arbitration message for
+  // stream_2 has had a chance to be processed by the server
+  EXPECT_EQ(stream_teardown(std::move(stream_2)).error_code(),
+            StatusCode::INVALID_ARGUMENT);
+  EXPECT_TRUE(stream_teardown(std::move(stream_1)).ok());
+}
+
+TEST_F(TestArbitration, WriteAndPacketInAndPacketOut) {
+  Uint128 master_id(2);
+  Uint128 slave_id(1);
+  const std::string payload("aaaa");
+
+  auto check_write = [this](const Uint128 &election_id, bool success) {
+    auto status = do_write(election_id);
+    if (success)
+      EXPECT_EQ(StatusCode::FAILED_PRECONDITION, status.error_code());
+    else
+      EXPECT_EQ(StatusCode::PERMISSION_DENIED, status.error_code());
+  };
+
+  auto check_packet_in = [this, &payload](ReaderWriter *stream) {
+    p4::PacketIn packet;
+    packet.set_payload(payload);
+    ::pi::server::testing::send_packet_in(device_id, &packet);
+    EXPECT_TRUE(read_packet_in(stream));
+  };
+
+  auto check_packet_out = [this, &payload](ReaderWriter *stream) {
+    using ::testing::StrEq;
+    send_packet_out(stream, payload);
+    // TODO(antonin): set a P4 pipeline so we can check this
+    // EXPECT_CALL(*mock,
+    //             packetout_send(StrEq(payload.c_str()), payload.size()));
+  };
+
+  ClientContext stream_master_context;
+  auto stream_master = stream_setup(&stream_master_context, master_id);
+  ASSERT_NE(stream_master, nullptr);
+
+  EXPECT_EQ(read_arbitration_status(stream_master.get()).code(),
+            ::google::rpc::Code::OK);
+  check_write(master_id, true);
+  check_packet_in(stream_master.get());
+  check_packet_out(stream_master.get());
+
+  ClientContext stream_slave_context;
+  auto stream_slave = stream_setup(&stream_slave_context, slave_id);
+  ASSERT_NE(stream_slave, nullptr);
+
+  EXPECT_EQ(read_arbitration_status(stream_slave.get()).code(),
+            ::google::rpc::Code::ALREADY_EXISTS);
+  check_write(master_id, true);
+  check_write(slave_id, false);
+  check_packet_in(stream_master.get());
+  check_packet_out(stream_master.get());
+
+  EXPECT_TRUE(stream_teardown(std::move(stream_master)).ok());
+
+  EXPECT_EQ(read_arbitration_status(stream_slave.get()).code(),
+            ::google::rpc::Code::OK);
+  check_write(slave_id, true);
+  check_packet_in(stream_slave.get());
+  check_packet_out(stream_slave.get());
+
+  EXPECT_TRUE(stream_teardown(std::move(stream_slave)).ok());
+}
+
+TEST_F(TestArbitration, MaxConnections) {
+  const auto max_connections = ::pi::server::testing::max_connections();
+  Uint128 election_id(100);
+  std::vector<ClientContext> contexts(max_connections);
+  std::vector<std::unique_ptr<ReaderWriter> > streams;
+  for (size_t i = 0; i < max_connections; i++) {
+    auto stream = stream_setup(&contexts.at(i), election_id--);
+    if (i == 0) {
+      EXPECT_EQ(read_arbitration_status(stream.get()).code(),
+                ::google::rpc::Code::OK);
+    } else {
+      EXPECT_EQ(read_arbitration_status(stream.get()).code(),
+                ::google::rpc::Code::ALREADY_EXISTS);
+    }
+    streams.push_back(std::move(stream));
+  }
+  {  // cannot add one more connection
+    ClientContext context;
+    auto extra_stream = stream_setup(&context, election_id--);
+    EXPECT_EQ(stream_teardown(std::move(extra_stream)).error_code(),
+              StatusCode::RESOURCE_EXHAUSTED);
+  }
+  for (auto &stream : streams)
+    EXPECT_TRUE(stream_teardown(std::move(stream)).ok());
+  {  // now we can add one
+    ClientContext context;
+    auto extra_stream = stream_setup(&context, election_id--);
+    EXPECT_EQ(read_arbitration_status(extra_stream.get()).code(),
+              ::google::rpc::Code::OK);
+    EXPECT_TRUE(stream_teardown(std::move(extra_stream)).ok());
+  }
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -40,6 +40,7 @@ run_cpplint $ROOT_DIR/proto/frontend proto/frontend
 run_cpplint $ROOT_DIR/proto/tests
 run_cpplint $ROOT_DIR/proto/src
 run_cpplint $ROOT_DIR/proto/PI proto
+run_cpplint $ROOT_DIR/proto/server
 
 echo "********************************"
 if [ $return_status -eq 0 ]; then


### PR DESCRIPTION
We switched from an asynchronous server implementation to a synchronous
one for the P4Runtime bidi stream, as it makes the code easier to reason
about and there isn't a requirement to support a huge number of
controller connections per switch.

We started implementing controller arbitration, which allows the switch
to maintain multiple controller connections simultaneously (to a single
master controller and several slaves).