### PR TITLE
Fix missing action profile group type

### DIFF
--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -145,6 +145,7 @@ ActionProfMgr::group_create(const p4::ActionProfileGroup &group,
   if (pi_status != PI_STATUS_SUCCESS)
     RETURN_ERROR_STATUS(Code::UNKNOWN, "Error when creating group on target");
   group_bimap.add(group.group_id(), group_h);
+  group_types.emplace(group.group_id(), group.type());
   group_members.emplace(group.group_id(), ActionProfGroupMembership());
   auto code = group_update_members(ap, group);
   RETURN_STATUS(code);
@@ -343,6 +344,16 @@ const Id *
 ActionProfMgr::retrieve_group_id(pi_indirect_handle_t h) {
   Lock lock(mutex);
   return group_bimap.retrieve_id(h);
+}
+
+const p4::ActionProfileGroup::Type
+ActionProfMgr::retrieve_group_type(const Id &group_id) {
+  Lock lock(mutex);
+  try {
+    return group_types.at(group_id);
+  } catch (std::out_of_range e) {
+    return p4::ActionProfileGroup::UNSPECIFIED;
+  }
 }
 
 }  // namespace proto

--- a/proto/frontend/src/action_prof_mgr.h
+++ b/proto/frontend/src/action_prof_mgr.h
@@ -148,6 +148,7 @@ class ActionProfMgr {
 
   const Id *retrieve_member_id(pi_indirect_handle_t h);
   const Id *retrieve_group_id(pi_indirect_handle_t h);
+  const p4::ActionProfileGroup::Type retrieve_group_type(const Id &group_id);
 
  private:
   bool check_p4_action_id(pi_p4_id_t p4_id) const;
@@ -198,6 +199,7 @@ class ActionProfMgr {
   pi_p4info_t *p4info;
   ActionProfBiMap member_bimap{};
   ActionProfBiMap group_bimap{};
+  std::map<Id, p4::ActionProfileGroup::Type> group_types{};
   std::map<Id, ActionProfGroupMembership> group_members{};
   mutable Mutex mutex{};
 };

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -753,7 +753,9 @@ class DeviceMgrImp {
         code = Code::UNKNOWN;
         break;
       }
+      auto group_type = action_prof_mgr->retrieve_group_type(*group_id);
       group->set_group_id(*group_id);
+      group->set_type(group_type);
       for (size_t j = 0; j < num; j++) {
         auto member_id = action_prof_mgr->retrieve_member_id(members_h[j]);
         if (member_id == nullptr) {


### PR DESCRIPTION
Action profile manager didn't store type of action profile group, so the
control plane gets UNSPECIFIED type (type 0) every time.