### PR TITLE
missing stdio.h includes added

### DIFF
--- a/CLI/act_profs/act_prof_common.c
+++ b/CLI/act_profs/act_prof_common.c
@@ -23,6 +23,7 @@
 #include "PI/p4info.h"
 #include "PI/pi.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/CLI/add_p4.c
+++ b/CLI/add_p4.c
@@ -24,6 +24,7 @@
 
 #include <PI/pi.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/CLI/device_commands.c
+++ b/CLI/device_commands.c
@@ -25,6 +25,7 @@
 
 #include "PI/pi.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/CLI/table_common.c
+++ b/CLI/table_common.c
@@ -25,6 +25,7 @@
 #include "PI/frontends/generic/pi.h"
 #include "PI/pi.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/CLI/table_delete.c
+++ b/CLI/table_delete.c
@@ -26,6 +26,7 @@
 #include "PI/pi.h"
 
 #include <inttypes.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/CLI/utils.c
+++ b/CLI/utils.c
@@ -20,10 +20,11 @@
 
 #include "PI/pi.h"
 
-#include <readline/readline.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <readline/readline.h>
 
 int count_tokens(const char *str) {
   int count = 0;


### PR DESCRIPTION
this adds stdio.h include to several files to prevent errors like:

```
/usr/include/readline/readline.h:918:3: error: unknown type name ‘FILE’
   FILE *outf;
   ^~~~
table_delete.c: In function ‘do_table_delete’:
table_delete.c:53:5: error: implicit declaration of function ‘printf’ [-Werror=implicit-function-declaration]
     printf("Entry with handle %" PRIu64 " was successfully removed.\n", handle);
     ^~~~~~
table_delete.c:53:5: error: incompatible implicit declaration of built-in function ‘printf’ [-Werror]
```