### PR TITLE
Using hw_sync = true when calling pi_batch_end

### DIFF
--- a/proto/frontend/src/common.h
+++ b/proto/frontend/src/common.h
@@ -47,7 +47,7 @@ struct SessionTemp {
   }
 
   ~SessionTemp() {
-    if (batch) pi_batch_end(sess, false  /* hw_sync */);
+    if (batch) pi_batch_end(sess, true  /* hw_sync */);
     pi_session_cleanup(sess);
   }
 


### PR DESCRIPTION
To ensure P4Runtime write requests are completely synchronous