### PR TITLE
Rename access() in vector.c to access_element()

### DIFF
--- a/lib/vector.c
+++ b/lib/vector.c
@@ -56,27 +56,27 @@ static void vector_expand(vector_t *v) {
   v->data = realloc(v->data, v->capacity * v->e_size);
 }
 
-static void *access(const vector_t *v, size_t index) {
+static void *access_element(const vector_t *v, size_t index) {
   return (char *)v->data + (index * v->e_size);
 }
 
 void vector_push_back_empty(vector_t *v) {
   assert(v->size <= v->capacity);
   if (v->size == v->capacity) vector_expand(v);
-  memset(access(v, v->size), 0, v->e_size);
+  memset(access_element(v, v->size), 0, v->e_size);
   v->size++;
 }
 
 void vector_push_back(vector_t *v, void *e) {
   assert(v->size <= v->capacity);
   if (v->size == v->capacity) vector_expand(v);
-  memcpy(access(v, v->size), e, v->e_size);
+  memcpy(access_element(v, v->size), e, v->e_size);
   v->size++;
 }
 
 void *vector_at(const vector_t *v, size_t index) {
   assert(index < v->size);
-  return access(v, index);
+  return access_element(v, index);
 }
 
 void *vector_data(const vector_t *v) { return v->data; }
@@ -87,7 +87,7 @@ void vector_remove(vector_t *v, size_t index) {
   assert(index < v->size);
   v->size--;
   if (index == v->size) return;
-  memmove(access(v, index), access(v, index + 1),
+  memmove(access_element(v, index), access_element(v, index + 1),
           (v->size - index) * v->e_size);
 }
 
@@ -100,7 +100,7 @@ void vector_remove_e(vector_t *v, void *e) {
 void vector_destroy(vector_t *v) {
   if (v->clean_fn) {
     for (size_t index = 0; index < v->size; index++) {
-      v->clean_fn(access(v, index));
+      v->clean_fn(access_element(v, index));
     }
   }
   free(v->data);
@@ -109,5 +109,5 @@ void vector_destroy(vector_t *v) {
 
 void *vector_back(vector_t *v) {
   if (v->size == 0) return NULL;
-  return access(v, v->size - 1);
+  return access_element(v, v->size - 1);
 }


### PR DESCRIPTION
Rename access() in vector.c to access_element() because it collides with a POSIX function when compiling using clang.