### PR TITLE
Support is_default_action flag in P4 Runtime implementation

### DIFF
--- a/proto/frontend/src/common.cpp
+++ b/proto/frontend/src/common.cpp
@@ -51,6 +51,21 @@ Code check_proto_bytestring(const std::string &str, size_t nbits) {
   return Code::OK;
 }
 
+std::string range_default_lo(size_t nbits) {
+  size_t nbytes = (nbits + 7) / 8;
+  return std::string(nbytes, '\x00');
+}
+
+std::string range_default_hi(size_t nbits) {
+  size_t nbytes = (nbits + 7) / 8;
+  std::string hi(nbytes, '\xff');
+  size_t zero_nbits = (nbytes * 8) - nbits;
+  uint8_t mask = 0xff >> zero_nbits;
+  hi[0] &= static_cast<char>(mask);
+  assert(check_proto_bytestring(hi, nbits) == Code::OK);
+  return hi;
+}
+
 }  // namespace common
 
 }  // namespace proto

--- a/proto/frontend/src/common.h
+++ b/proto/frontend/src/common.h
@@ -59,6 +59,9 @@ struct SessionTemp {
 
 Code check_proto_bytestring(const std::string &str, size_t nbits);
 
+std::string range_default_lo(size_t nbits);
+std::string range_default_hi(size_t nbits);
+
 inline Status make_invalid_p4_id_status() {
   Status status;
   status.set_code(Code::INVALID_ARGUMENT);


### PR DESCRIPTION
Default action is no longer indicated by an empty match key.