### PR TITLE
Use new {Set|Get}ForwardingPipelineConfig RPC fields

### DIFF
--- a/proto/demo_grpc/simple_router_mgr.cpp
+++ b/proto/demo_grpc/simple_router_mgr.cpp
@@ -249,10 +249,10 @@ SimpleRouterMgr::assign(const std::string &config_buffer,
   }
 
   p4::SetForwardingPipelineConfigRequest request;
+  request.set_device_id(dev_id);
   request.set_action(
       p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
-  auto config = request.add_configs();
-  config->set_device_id(dev_id);
+  auto config = request.mutable_config();
   config->set_allocated_p4info(&p4info_proto);
   p4::tmp::P4DeviceConfig device_config;
   auto extras = device_config.mutable_extras();
@@ -705,10 +705,10 @@ SimpleRouterMgr::update_config_(const std::string &config_buffer,
 
   {
     p4::SetForwardingPipelineConfigRequest request;
+    request.set_device_id(dev_id);
     request.set_action(
         p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE);
-    auto config = request.add_configs();
-    config->set_device_id(dev_id);
+    auto config = request.mutable_config();
     config->set_allocated_p4info(&p4info_proto);
     p4::tmp::P4DeviceConfig device_config;
     device_config.set_device_data(config_buffer);
@@ -728,14 +728,12 @@ SimpleRouterMgr::update_config_(const std::string &config_buffer,
 
   {
     p4::SetForwardingPipelineConfigRequest request;
+    request.set_device_id(dev_id);
     request.set_action(p4::SetForwardingPipelineConfigRequest_Action_COMMIT);
-    auto config = request.add_configs();
-    config->set_device_id(dev_id);
     p4::SetForwardingPipelineConfigResponse rep;
     ClientContext context;
     auto status = pi_stub_->SetForwardingPipelineConfig(
         &context, request, &rep);
-    config->release_p4info();
     assert(status.ok());
   }
 

--- a/proto/demo_grpc/test_perf.cpp
+++ b/proto/demo_grpc/test_perf.cpp
@@ -100,9 +100,10 @@ class P4RuntimeClient {
 
   int assign_device(int device_id, const pi_p4info_t *p4info) {
     p4::SetForwardingPipelineConfigRequest request;
+    request.set_device_id(device_id);
     request.set_action(
         p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
-    auto config = request.add_configs();
+    auto config = request.mutable_config();
     auto p4info_proto = pi::p4info::p4info_serialize_to_proto(p4info);
     config->set_allocated_p4info(&p4info_proto);
     p4::SetForwardingPipelineConfigResponse rep;

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -230,7 +230,6 @@ class DeviceMgrImp {
   }
 
   Status pipeline_config_get(p4::ForwardingPipelineConfig *config) {
-    config->set_device_id(device_id);
     config->mutable_p4info()->CopyFrom(p4info_proto);
     // TODO(antonin): we do not set the p4_device_config bytes field, as we do
     // not have a local copy of it; if it is needed by the controller, we will

--- a/proto/tests/server/test_no_pipeline_config.cpp
+++ b/proto/tests/server/test_no_pipeline_config.cpp
@@ -104,7 +104,7 @@ TEST_F(TestNoForwardingPipeline, Read) {
 
 TEST_F(TestNoForwardingPipeline, GetForwardingPipelineConfig) {
   p4::GetForwardingPipelineConfigRequest request;
-  request.add_device_ids(device_id);
+  request.set_device_id(device_id);
   ClientContext context;
   p4::GetForwardingPipelineConfigResponse rep;
   auto status = p4runtime_stub->GetForwardingPipelineConfig(


### PR DESCRIPTION
p4runtime.proto was updated and the format of the
{Set|Get}ForwardingPipelineConfig RPCs was modified, with some fields
marked as deprecated and some new fields introduced. This commit makes
sure that only the new fields are used.