### PR TITLE
Added PIGrpcServerGetPort API to get back the port number being used by the server

### DIFF
--- a/proto/server/PI/proto/pi_server.h
+++ b/proto/server/PI/proto/pi_server.h
@@ -30,6 +30,9 @@ void PIGrpcServerRun();
 // 192.168.1.1:31416, [::1]:27182, etc.)
 void PIGrpcServerRunAddr(const char *server_address);
 
+// Get port number bound to the server
+int PIGrpcServerGetPort();
+
 // Wait for the server to shutdown. Note that some other thread must be
 // responsible for shutting down the server for this call to ever return.
 void PIGrpcServerWait();

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -537,6 +537,7 @@ void packet_in_cb(DeviceMgr::device_id_t device_id, p4::PacketIn *packet,
 
 struct ServerData {
   std::string server_address;
+  int server_port;
   P4RuntimeServiceImpl pi_service;
   gNMIServiceImpl gnmi_service;
   ServerBuilder builder;
@@ -572,7 +573,8 @@ void PIGrpcServerRunAddr(const char *server_address) {
   server_data->server_address = std::string(server_address);
   auto &builder = server_data->builder;
   builder.AddListeningPort(
-    server_data->server_address, grpc::InsecureServerCredentials());
+    server_data->server_address, grpc::InsecureServerCredentials(),
+    &server_data->server_port);
   builder.RegisterService(&server_data->pi_service);
   builder.RegisterService(&server_data->gnmi_service);
   builder.SetMaxReceiveMessageSize(256*1024*1024);  // 256MB
@@ -583,6 +585,10 @@ void PIGrpcServerRunAddr(const char *server_address) {
 
 void PIGrpcServerRun() {
   PIGrpcServerRunAddr("0.0.0.0:50051");
+}
+
+int PIGrpcServerGetPort() {
+  return server_data->server_port;
 }
 
 void PIGrpcServerWait() {

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -18,7 +18,8 @@ test_proto_fe \
 test_proto_fe_packet_io \
 test_server_no_pipeline_config \
 test_server_gnmi \
-test_server_arbitration
+test_server_arbitration \
+test_pi_server
 
 common_source = main.cpp
 
@@ -88,10 +89,16 @@ server/test_arbitration.cpp
 test_server_arbitration_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_server_arbitration_LDADD = $(test_server_libs)
 
+test_pi_server_SOURCES = $(test_server_common_source) \
+server/test_pi_server.cpp
+test_pi_server_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
+test_pi_server_LDADD = $(test_server_libs)
+
 check_PROGRAMS = \
 test_p4info_convert \
 test_proto_fe \
 test_proto_fe_packet_io \
 test_server_no_pipeline_config \
 test_server_gnmi \
-test_server_arbitration
+test_server_arbitration \
+test_pi_server

--- a/proto/tests/server/test_no_pipeline_config.cpp
+++ b/proto/tests/server/test_no_pipeline_config.cpp
@@ -80,7 +80,6 @@ class TestNoForwardingPipeline : public ::testing::Test {
 constexpr char TestNoForwardingPipeline::grpc_server_addr[];
 
 TEST_F(TestNoForwardingPipeline, Write) {
-  EXPECT_EQ(PIGrpcServerGetPort(), 50051);
   p4::WriteRequest request;
   request.set_device_id(device_id);
   ClientContext context;

--- a/proto/tests/server/test_no_pipeline_config.cpp
+++ b/proto/tests/server/test_no_pipeline_config.cpp
@@ -80,6 +80,7 @@ class TestNoForwardingPipeline : public ::testing::Test {
 constexpr char TestNoForwardingPipeline::grpc_server_addr[];
 
 TEST_F(TestNoForwardingPipeline, Write) {
+  EXPECT_EQ(PIGrpcServerGetPort(), 50051);
   p4::WriteRequest request;
   request.set_device_id(device_id);
   ClientContext context;

--- a/proto/tests/server/test_pi_server.cpp
+++ b/proto/tests/server/test_pi_server.cpp
@@ -22,7 +22,7 @@ namespace testing {
 namespace {
 
 static std::string grpc_server_addr = "0.0.0.0";
-static std::string grpc_server_port = "50051";
+static std::string grpc_server_port = "50054";
 
 void StartGrpcServer() {
   std::string bind_addr = grpc_server_addr+":"+grpc_server_port;
@@ -39,7 +39,7 @@ void SetGrpcServerPort(std::string port) {
 
 TEST(TestPIGrpcServer, DefaultPort) {
   StartGrpcServer();
-  EXPECT_EQ(PIGrpcServerGetPort(), 50051);
+  EXPECT_EQ(PIGrpcServerGetPort(), 50054);
   ShutdownGrpcServer();
 }
 

--- a/proto/tests/server/test_pi_server.cpp
+++ b/proto/tests/server/test_pi_server.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
 #include <gtest/gtest.h>
 #include <PI/proto/pi_server.h>
+#include <string>
 
 namespace pi {
 namespace proto {

--- a/proto/tests/server/test_pi_server.cpp
+++ b/proto/tests/server/test_pi_server.cpp
@@ -25,7 +25,8 @@ static std::string grpc_server_addr = "0.0.0.0";
 static std::string grpc_server_port = "50051";
 
 void StartGrpcServer() {
-  PIGrpcServerRunAddr(grpc_server_addr + ":" + grpc_server_port);
+  std::string bind_addr = grpc_server_addr+":"+grpc_server_port; 
+  PIGrpcServerRunAddr(bind_addr.c_str());
 }
 
 void ShutdownGrpcServer() {

--- a/proto/tests/server/test_pi_server.cpp
+++ b/proto/tests/server/test_pi_server.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
 #include <gtest/gtest.h>
 #include <PI/proto/pi_server.h>
 

--- a/proto/tests/server/test_pi_server.cpp
+++ b/proto/tests/server/test_pi_server.cpp
@@ -25,7 +25,7 @@ static std::string grpc_server_addr = "0.0.0.0";
 static std::string grpc_server_port = "50051";
 
 void StartGrpcServer() {
-  std::string bind_addr = grpc_server_addr+":"+grpc_server_port; 
+  std::string bind_addr = grpc_server_addr+":"+grpc_server_port;
   PIGrpcServerRunAddr(bind_addr.c_str());
 }
 

--- a/proto/tests/server/test_pi_server.cpp
+++ b/proto/tests/server/test_pi_server.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <PI/proto/pi_server.h>
+
+namespace pi {
+namespace proto {
+namespace testing {
+namespace {
+
+static std::string grpc_server_addr = "0.0.0.0";
+static std::string grpc_server_port = "50051";
+
+void StartGrpcServer() {
+  PIGrpcServerRunAddr(grpc_server_addr + ":" + grpc_server_port);
+}
+
+void ShutdownGrpcServer() {
+  PIGrpcServerShutdown();
+}
+
+void SetGrpcServerPort(std::string port) {
+  grpc_server_port = port;
+}
+
+TEST(TestPIGrpcServer, DefaultPort) {
+  StartGrpcServer();
+  EXPECT_EQ(PIGrpcServerGetPort(), 50051);
+  ShutdownGrpcServer();
+}
+
+TEST(TestPIGrpcServer, RandomPort) {
+  SetGrpcServerPort("0");
+  StartGrpcServer();
+  EXPECT_NE(PIGrpcServerGetPort(), 0);
+  ShutdownGrpcServer();
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi


### PR DESCRIPTION
This is useful in testing when we start the server on a random port.