### PR TITLE
Initial support for gNMI & OpenConfig

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "proto/openconfig/gnmi"]
 	path = proto/openconfig/gnmi
 	url = https://github.com/openconfig/gnmi.git
+[submodule "proto/openconfig/public"]
+	path = proto/openconfig/public
+	url = https://github.com/openconfig/public.git

--- a/proto/.gitignore
+++ b/proto/.gitignore
@@ -2,3 +2,4 @@ cpp_out
 grpc_out
 py_out
 proto_files.ts
+sysrepo/install_yangs.sh

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,3 +1,103 @@
 # P4Runtime
 
 Find documentation under [docs](docs/).
+
+## Tentative gNMI support with sysrepo
+
+We are working on supporting gNMI and OpenConfig YANG models as part of the P4
+Runtime server. We are using [sysrepo](https://github.com/sysrepo/sysrepo) as
+our YANG configuration data store and operational state manager. If you want to
+experiment with the gNMI support, you will need to install sysrepo and its
+dependencies. We currently recommend using [version 0.7.1 of
+sysrepo](https://github.com/sysrepo/sysrepo/releases/tag/v0.7.1), which depends
+on [version 0.13-rc2 of
+libyang](https://github.com/CESNET/libyang/releases/tag/v0.13-r2).
+
+Please make sure you install all the dependencies for libyang and sysrepo. If
+you are using a Debian system, we recommend that you install the following
+packages:
+
+    build-essential cmake libpcre3-dev libavl-dev libev-dev libprotobuf-c-dev protobuf-c-compiler
+
+Then install libyang:
+
+    git clone https://github.com/CESNET/libyang.git
+    cd libyang
+    git checkout v0.13-r2
+    mkdir build
+    cd build
+    cmake ..
+    make
+    [sudo] make install
+
+Finally, install sysrepo
+
+    git clone https://github.com/sysrepo/sysrepo.git
+    cd sysrepo
+    git checkout v0.7.1
+    mkdir build
+    cd build
+    cmake -DBUILD_EXAMPLES=Off -DCALL_TARGET_BINS_DIRECTLY=Off ..
+
+You can now start the sysrepo daemon (`sudo sysrepod -d` to start in debug
+mode).
+
+In order to experiment with gNMI support, you also need to make sure to use
+`--with-sysrepo` when running `configure` for this project.
+
+After installing sysrepo and building this project, the final step is to load
+the appropriate YANG models into sysrepo. Note that for now ***we are only
+looking to support a very small subset of openconfig-interfaces***. We provide a
+script that you can run to load the YANG models: `sudo
+sysrepo/install_yangs.sh`. You can check that the YANG models were installed
+properly with `sysrepoctl -l`. The output should look like this:
+
+```
+Sysrepo schema directory: /etc/sysrepo/yang/
+Sysrepo data directory:   /etc/sysrepo/data/
+(Do not alter contents of these directories manually)
+
+Module Name                   | Revision   | Conformance | Data Owner          | Permissions | Submodules                    | Enabled Features
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ietf-interfaces               | 2014-05-08 | Installed   | root:root           | 666         |                               |
+openconfig-extensions         | 2017-04-11 | Installed   |                     |             |                               |
+openconfig-types              | 2017-08-16 | Installed   |                     |             |                               |
+openconfig-yang-types         | 2017-07-30 | Installed   |                     |             |                               |
+openconfig-interfaces         | 2017-07-14 | Installed   | root:root           | 666         |                               |
+iana-if-type                  | 2014-05-08 | Installed   |                     |             |                               |
+ietf-inet-types               | 2013-07-15 | Installed   |                     |             |                               |
+ietf-netconf-acm              | 2012-02-22 | Installed   | root:root           | 666         |                               |
+ietf-netconf                  | 2011-06-01 | Installed   | root:root           | 666         |                               |
+ietf-netconf-notifications    | 2012-02-06 | Installed   | root:root           | 666         |                               |
+```
+
+The P4 Runtile server library that you get after that will be able to support
+gNMI subscriptions (`ONCE` mode only) for the openconfig-interfaces model. Here
+is an example of a supported subscription request from a Python client:
+```
+channel = grpc.insecure_channel(<SERVER_ADDR>)
+stub = gnmi_pb2.gNMIStub(channel)
+
+def req_iterator():
+    while True:
+        req = gnmi_pb2.SubscribeRequest()
+        subList = req.subscribe
+        subList.mode = gnmi_pb2.SubscriptionList.ONCE
+        sub = subList.subscription.add()
+        path = sub.path
+        for name in ["interfaces", "interface", "..."]:
+            e = path.elem.add()
+            e.name = name
+        print "***************************"
+        print "REQUEST"
+        print req
+        print "***************************"
+        yield req
+        return
+
+for response in stub.Subscribe(req_iterator()):
+    print "***************************"
+    print "RESPONSE"
+    print response
+    print "***************************"
+```

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -63,6 +63,16 @@ AC_CHECK_LIB([microhttpd], [MHD_start_daemon], [], [
 
 AM_CONDITIONAL([WITH_PROTO_DEMO], [test "$with_proto_demo" = yes])
 
+AC_ARG_WITH([sysrepo],
+    AS_HELP_STRING([--with-sysrepo],
+                   [Use sysrepo gNMI service implementation @<:@default=no@:>@]),
+    [with_sysrepo="$withval"], [with_sysrepo=no])
+AM_CONDITIONAL([WITH_SYSREPO], [test "$with_sysrepo" = yes])
+AM_COND_IF([WITH_SYSREPO], [
+    AC_CHECK_LIB([sysrepo], [sr_connect], [],
+                 [AC_MSG_ERROR([Missing libsysrepo])])
+])
+
 dnl cannot use the path below, which would break 'make dist'
 dnl googleapis_check_f=$ac_abs_confdir/googleapis/google/rpc/status.proto
 googleapis_check_f=$ac_abs_confdir/google/rpc/status.proto
@@ -98,8 +108,11 @@ AC_CONFIG_FILES([Makefile
                  tests/Makefile
                  third_party/Makefile])
 
+AC_CONFIG_FILES([sysrepo/install_yangs.sh], [chmod +x sysrepo/install_yangs.sh])
+
 AC_OUTPUT
 
 AS_ECHO("")
 AS_ECHO("Features recap ......................................")
+AS_ECHO("Use sysrepo gNMI implementation .............. : $with_sysrepo")
 AS_ECHO("Compile demo_grpc ............................ : $with_proto_demo")

--- a/proto/server/Makefile.am
+++ b/proto/server/Makefile.am
@@ -5,6 +5,10 @@ AM_CPPFLAGS = \
 -I$(top_builddir)/cpp_out \
 -I$(top_builddir)/grpc_out
 
+if WITH_SYSREPO
+AM_CPPFLAGS += -DWITH_SYSREPO
+endif
+
 AM_CXXFLAGS = -Wall -Werror
 
 lib_LTLIBRARIES = libpigrpcserver.la
@@ -13,6 +17,12 @@ libpigrpcserver_la_SOURCES = \
 pi_server.cpp \
 uint128.h \
 uint128.cpp
+
+if WITH_SYSREPO
+libpigrpcserver_la_SOURCES += \
+gnmi_sysrepo.h \
+gnmi_sysrepo.cpp
+endif
 
 nobase_include_HEADERS = PI/proto/pi_server.h
 

--- a/proto/server/gnmi_sysrepo.cpp
+++ b/proto/server/gnmi_sysrepo.cpp
@@ -1,0 +1,320 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "gnmi_sysrepo.h"
+
+#include <grpc++/grpc++.h>
+
+#include <chrono>
+#include <string>
+
+extern "C" {
+
+#include "sysrepo.h"
+#include "sysrepo/values.h"
+#include "sysrepo/xpath.h"
+
+}
+
+#include "gnmi/gnmi.grpc.pb.h"
+
+using grpc::ServerContext;
+using grpc::ServerReaderWriter;
+using grpc::Status;
+using grpc::StatusCode;
+
+#define DEBUG
+
+#ifdef DEBUG
+#define ENABLE_SIMPLELOG true
+#else
+#define ENABLE_SIMPLELOG false
+#endif
+
+#define SIMPLELOG if (ENABLE_SIMPLELOG) std::cout
+
+namespace pi {
+
+namespace server {
+
+namespace {
+
+void convertToXPath(const gnmi::Path &path, std::string *path_str) {
+  if (path.elem().size() == 0) return;
+  for (const auto &elem : path.elem()) {
+    // TODO(antonin): this is dubious and does not work for
+    // interfaces/interface/.../state which is an example in the gNMI path
+    // specification. It is unclear whether sysrepo supports such a path or if
+    // extra work will be required to make it work.
+    if (elem.name() == "...")
+      path_str->append("/*");
+    else
+      path_str->append(elem.name());
+    for (const auto &p : elem.key())
+      path_str->append("[" + p.first + "='" + p.second + "']");
+    path_str->append("/");
+  }
+  path_str->pop_back();  // remove trailing slash
+}
+
+void convertFromXPath(char *xpath, gnmi::Path *gpath) {
+  sr_xpath_ctx_t ctx;
+  char *node = xpath;
+  char *xpath_ = xpath;
+  while ((node = sr_xpath_next_node(xpath_, &ctx)) != NULL) {
+    auto *pElem = gpath->add_elem();
+    pElem->set_name(node);
+    char *kn;
+    auto *keys = pElem->mutable_key();
+    while ((kn = sr_xpath_next_key_name(NULL, &ctx)) != NULL) {
+      std::string kName(kn);  // needed here because sr_xpath_* mutates string
+      auto *kv = sr_xpath_node_key_value(NULL, kn, &ctx);
+      (*keys)[kName] = kv;
+    }
+    xpath_ = NULL;
+  }
+}
+
+bool isLeaf(const sr_val_t *value) {
+  switch (value->type) {
+    case SR_UNKNOWN_T:
+      assert(0);
+      return false;
+    case SR_TREE_ITERATOR_T:
+      assert(0);
+      return false;
+    case SR_LIST_T:
+    case SR_CONTAINER_T:
+    case SR_CONTAINER_PRESENCE_T:
+    case SR_LEAF_EMPTY_T:
+    case SR_INSTANCEID_T:
+      return false;
+    case SR_BITS_T:   // TODO(antonin): what should this map to?
+      return false;
+    default:
+      return true;
+  }
+  return true;
+}
+
+void convertTypedValue(const sr_val_t *value, gnmi::TypedValue *typedV) {
+  switch (value->type) {
+    case SR_BINARY_T:
+      typedV->set_bytes_val(value->data.binary_val);
+      break;
+    case SR_BITS_T:
+      break;
+    case SR_BOOL_T:
+      typedV->set_bool_val(value->data.bool_val);
+      break;
+    case SR_DECIMAL64_T:
+      typedV->set_float_val(value->data.decimal64_val);
+      break;
+    case SR_ENUM_T:
+      typedV->set_string_val(value->data.enum_val);
+      break;
+    case SR_INT8_T:
+      typedV->set_int_val(value->data.int8_val);
+      break;
+    case SR_INT16_T:
+      typedV->set_int_val(value->data.int16_val);
+      break;
+    case SR_INT32_T:
+      typedV->set_int_val(value->data.int32_val);
+      break;
+    case SR_INT64_T:
+      typedV->set_int_val(value->data.int64_val);
+      break;
+    case SR_STRING_T:
+      typedV->set_string_val(value->data.string_val);
+      break;
+    case SR_UINT8_T:
+      typedV->set_uint_val(value->data.uint8_val);
+      break;
+    case SR_UINT16_T:
+      typedV->set_uint_val(value->data.uint16_val);
+      break;
+    case SR_UINT32_T:
+      typedV->set_uint_val(value->data.uint32_val);
+      break;
+    case SR_UINT64_T:
+      typedV->set_uint_val(value->data.uint64_val);
+      break;
+    case SR_ANYXML_T:
+      typedV->set_ascii_val(value->data.anyxml_val);
+      break;
+    case SR_ANYDATA_T:
+      typedV->set_ascii_val(value->data.anydata_val);
+      break;
+    case SR_IDENTITYREF_T:
+      typedV->set_string_val(value->data.string_val);
+      break;
+    default:  // cannot happen because of previous switch
+      assert(0);
+      break;
+  }
+}
+
+}  // namespace
+
+Status
+gNMIServiceSysrepoImpl::Capabilities(ServerContext *context,
+                                     const gnmi::CapabilityRequest *request,
+                                     gnmi::CapabilityResponse *response) {
+  (void) context; (void) request; (void) response;
+  SIMPLELOG << "gNMI Capabilities\n";
+  SIMPLELOG << request->DebugString();
+  return Status(StatusCode::UNIMPLEMENTED, "not implemented yet");
+}
+
+Status
+gNMIServiceSysrepoImpl::Get(ServerContext *context,
+                            const gnmi::GetRequest *request,
+                            gnmi::GetResponse *response) {
+  (void) context; (void) request; (void) response;
+  SIMPLELOG << "gNMI Get\n";
+  SIMPLELOG << request->DebugString();
+  return Status(StatusCode::UNIMPLEMENTED, "not implemented yet");
+}
+
+Status
+gNMIServiceSysrepoImpl::Set(ServerContext *context,
+                            const gnmi::SetRequest *request,
+                            gnmi::SetResponse *response) {
+  (void) context; (void) request; (void) response;
+  SIMPLELOG << "gNMI Set\n";
+  SIMPLELOG << request->DebugString();
+  return Status(StatusCode::UNIMPLEMENTED, "not implemented yet");
+}
+
+Status
+gNMIServiceSysrepoImpl::Subscribe(
+    ServerContext *context,
+    ServerReaderWriter<gnmi::SubscribeResponse,
+                       gnmi::SubscribeRequest> *stream) {
+  SIMPLELOG << "gNMI Subscribe\n";
+  gnmi::SubscribeRequest request;
+  while (stream->Read(&request)) {
+    if (!request.has_subscribe()) {
+      return Status(StatusCode::UNIMPLEMENTED,
+                    "Only subscription lists supported for now");
+    }
+    const auto &sub = request.subscribe();
+    if (sub.mode() != gnmi::SubscriptionList::ONCE) {
+      return Status(StatusCode::UNIMPLEMENTED,
+                    "Only subscriptions with ONCE mode supported for now");
+    }
+
+    gnmi::SubscribeResponse response;
+    auto *notification = response.mutable_update();
+    auto tp = std::chrono::system_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        tp.time_since_epoch()).count();
+    notification->set_timestamp(timestamp);
+
+    // TODO(antonin): keep connection open
+    struct SysrepoSession {
+      SysrepoSession() = default;
+
+      ~SysrepoSession() {
+        if (sess != NULL) sr_session_stop(sess);
+        if (conn != NULL) sr_disconnect(conn);
+      }
+
+      bool open() {
+        int rc = SR_ERR_OK;
+        rc = sr_connect("gnmiServer", SR_CONN_DEFAULT, &conn);
+        if (rc != SR_ERR_OK) return false;
+        rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &sess);
+        if (rc != SR_ERR_OK) return false;
+        return true;
+      }
+
+      sr_conn_ctx_t *conn{NULL};
+      sr_session_ctx_t *sess{NULL};
+    };
+
+    SysrepoSession session;
+    if (!session.open()) {
+      return Status(StatusCode::UNKNOWN,
+                    "Error when connection to yang datastore");
+    }
+
+    const auto &prefix = sub.prefix();
+    for (const auto &subscription : sub.subscription()) {
+      // TODO(antonin): This isn't part of the gNMI path but is required by
+      // sysrepo so I need to find a way to infer this.
+      std::string xpath("/openconfig-interfaces:");
+      convertToXPath(prefix, &xpath);
+      convertToXPath(subscription.path(), &xpath);
+      SIMPLELOG << "ONCE subscription for XPath: " << xpath << "\n";
+
+      sr_val_t *value = NULL;
+      sr_val_iter_t *iter = NULL;
+      int rc = SR_ERR_OK;
+
+      // get all list instances with their content (recursive)
+      rc = sr_get_items_iter(session.sess, xpath.c_str(), &iter);
+      if (rc != SR_ERR_OK) {
+        return Status(StatusCode::UNKNOWN,
+                      "Error while retrieving subscription items");
+      }
+
+      while (sr_get_item_next(session.sess, iter, &value) == SR_ERR_OK) {
+        char *update_xpath = value->xpath;
+        if (!isLeaf(value)) {
+          sr_free_val(value);
+          continue;
+        }
+        if (value->dflt) {  // unset
+          sr_free_val(value);
+          continue;
+        }
+
+        SIMPLELOG << "Update XPath: " << update_xpath << "\n";
+        // sr_print_val(value);
+
+        auto update = notification->add_update();
+        // TODO(antonin): use prefix for smaller messages
+        // TODO(antonin): investigate aggregation
+        convertFromXPath(update_xpath, update->mutable_path());
+        convertTypedValue(value, update->mutable_val());
+        sr_free_val(value);
+      }
+      sr_free_val_iter(iter);
+    }
+    // response.PrintDebugString();
+    stream->Write(response);
+    // Following the transmission of all updates which correspond to data items
+    // within the set of paths specified within the subscription list, a
+    // SubscribeResponse message with the sync_response field set to true MUST
+    // be transmitted, and the channel over which the SubscribeRequest was
+    // received MUST be closed.
+    gnmi::SubscribeResponse EOM;
+    EOM.set_sync_response(true);
+    stream->Write(EOM);
+    break;
+  }
+  return Status::OK;
+}
+
+}  // namespace server
+
+}  // namespace pi

--- a/proto/server/gnmi_sysrepo.h
+++ b/proto/server/gnmi_sysrepo.h
@@ -1,0 +1,58 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef PROTO_SERVER_GNMI_SYSREPO_H_
+#define PROTO_SERVER_GNMI_SYSREPO_H_
+
+#include <grpc++/grpc++.h>
+
+#include <string>
+
+#include "gnmi/gnmi.grpc.pb.h"
+
+namespace pi {
+
+namespace server {
+
+class gNMIServiceSysrepoImpl : public gnmi::gNMI::Service {
+ private:
+  grpc::Status Capabilities(grpc::ServerContext *context,
+                            const gnmi::CapabilityRequest *request,
+                            gnmi::CapabilityResponse *response) override;
+
+  grpc::Status Get(grpc::ServerContext *context,
+                   const gnmi::GetRequest *request,
+                   gnmi::GetResponse *response) override;
+
+  grpc::Status Set(grpc::ServerContext *context,
+                   const gnmi::SetRequest *request,
+                   gnmi::SetResponse *response) override;
+
+  grpc::Status Subscribe(
+      grpc::ServerContext *context,
+      grpc::ServerReaderWriter<gnmi::SubscribeResponse,
+                               gnmi::SubscribeRequest> *stream) override;
+};
+
+}  // namespace server
+
+}  // namespace pi
+
+#endif  // PROTO_SERVER_GNMI_SYSREPO_H_

--- a/proto/sysrepo/install_yangs.sh.in
+++ b/proto/sysrepo/install_yangs.sh.in
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-interfaces@2014-05-08.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/yang/iana-if-type.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-inet-types@2013-07-15.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-netconf-acm@2012-02-22.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-netconf@2011-06-01.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-netconf-notifications.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/openconfig-extensions.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/types/openconfig-types.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/types/openconfig-yang-types.yang
+sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/interfaces/openconfig-interfaces.yang

--- a/proto/yang/iana-if-type.yang
+++ b/proto/yang/iana-if-type.yang
@@ -1,0 +1,1704 @@
+module iana-if-type {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:iana-if-type";
+
+    prefix ianaift;
+
+    import ietf-interfaces {
+      prefix if;
+    }
+
+    organization "IANA";
+
+    contact
+      "        Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             4676 Admiralty Way, Suite 330
+             Marina del Rey, CA 90292
+
+     Tel:    +1 310 823 9358
+     <mailto:iana@iana.org>";
+
+    description
+      "This YANG module defines YANG identities for IANA-registered
+     interface types.
+
+     This YANG module is maintained by IANA and reflects the
+     'ifType definitions' registry.
+
+     The latest revision of this YANG module can be obtained from
+     the IANA web site.
+
+     Requests for new values should be made to IANA via
+     email (iana@iana.org).
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     The initial version of this YANG module is part of RFC 7224;
+     see the RFC itself for full legal notices.";
+
+    reference
+      "IANA 'ifType definitions' registry.
+      <http://www.iana.org/assignments/smi-numbers>";
+
+
+    revision "2014-05-08" {
+      description "Initial revision.";
+      reference
+        "RFC 7224: IANA Interface Type YANG Module";
+
+    }
+
+
+    identity iana-interface-type {
+      base if:interface-type;
+      description
+        "This identity is used as a base for all interface types
+       defined in the 'ifType definitions' registry.";
+    }
+
+    identity other {
+      base iana-interface-type;
+    }
+
+    identity regular1822 {
+      base iana-interface-type;
+    }
+
+    identity hdh1822 {
+      base iana-interface-type;
+    }
+
+    identity ddnX25 {
+      base iana-interface-type;
+    }
+
+    identity rfc877x25 {
+      base iana-interface-type;
+      reference
+        "RFC 1382 - SNMP MIB Extension for the X.25 Packet Layer";
+
+    }
+
+    identity ethernetCsmacd {
+      base iana-interface-type;
+      description
+        "For all Ethernet-like interfaces, regardless of speed,
+       as per RFC 3635.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity iso88023Csmacd {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity iso88024TokenBus {
+      base iana-interface-type;
+    }
+
+    identity iso88025TokenRing {
+      base iana-interface-type;
+    }
+
+    identity iso88026Man {
+      base iana-interface-type;
+    }
+
+    identity starLan {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity proteon10Mbit {
+      base iana-interface-type;
+    }
+
+    identity proteon80Mbit {
+      base iana-interface-type;
+    }
+
+    identity hyperchannel {
+      base iana-interface-type;
+    }
+
+    identity fddi {
+      base iana-interface-type;
+      reference
+        "RFC 1512 - FDDI Management Information Base";
+
+    }
+
+    identity lapb {
+      base iana-interface-type;
+      reference
+        "RFC 1381 - SNMP MIB Extension for X.25 LAPB";
+
+    }
+
+    identity sdlc {
+      base iana-interface-type;
+    }
+
+    identity ds1 {
+      base iana-interface-type;
+      description "DS1-MIB.";
+      reference
+        "RFC 4805 - Definitions of Managed Objects for the
+               DS1, J1, E1, DS2, and E2 Interface Types";
+
+    }
+
+    identity e1 {
+      base iana-interface-type;
+      status obsolete;
+      description "Obsolete; see DS1-MIB.";
+      reference
+        "RFC 4805 - Definitions of Managed Objects for the
+               DS1, J1, E1, DS2, and E2 Interface Types";
+
+    }
+
+    identity basicISDN {
+      base iana-interface-type;
+      description
+        "No longer used.  See also RFC 2127.";
+    }
+
+    identity primaryISDN {
+      base iana-interface-type;
+      description
+        "No longer used.  See also RFC 2127.";
+    }
+
+    identity propPointToPointSerial {
+      base iana-interface-type;
+      description "Proprietary serial.";
+    }
+
+    identity ppp {
+      base iana-interface-type;
+    }
+
+    identity softwareLoopback {
+      base iana-interface-type;
+    }
+
+    identity eon {
+      base iana-interface-type;
+      description "CLNP over IP.";
+    }
+
+    identity ethernet3Mbit {
+      base iana-interface-type;
+    }
+
+    identity nsip {
+      base iana-interface-type;
+      description "XNS over IP.";
+    }
+
+    identity slip {
+      base iana-interface-type;
+      description "Generic SLIP.";
+    }
+
+    identity ultra {
+      base iana-interface-type;
+      description "Ultra Technologies.";
+    }
+
+    identity ds3 {
+      base iana-interface-type;
+      description "DS3-MIB.";
+      reference
+        "RFC 3896 - Definitions of Managed Objects for the
+               DS3/E3 Interface Type";
+
+    }
+
+    identity sip {
+      base iana-interface-type;
+      description "SMDS, coffee.";
+      reference
+        "RFC 1694 - Definitions of Managed Objects for SMDS
+               Interfaces using SMIv2";
+
+    }
+
+    identity frameRelay {
+      base iana-interface-type;
+      description "DTE only.";
+      reference
+        "RFC 2115 - Management Information Base for Frame Relay
+               DTEs Using SMIv2";
+
+    }
+
+    identity rs232 {
+      base iana-interface-type;
+      reference
+        "RFC 1659 - Definitions of Managed Objects for RS-232-like
+               Hardware Devices using SMIv2";
+
+    }
+
+    identity para {
+      base iana-interface-type;
+      description "Parallel-port.";
+      reference
+        "RFC 1660 - Definitions of Managed Objects for
+               Parallel-printer-like Hardware Devices using
+               SMIv2";
+
+    }
+
+    identity arcnet {
+      base iana-interface-type;
+      description "ARCnet.";
+    }
+
+    identity arcnetPlus {
+      base iana-interface-type;
+      description "ARCnet Plus.";
+    }
+
+    identity atm {
+      base iana-interface-type;
+      description "ATM cells.";
+    }
+
+    identity miox25 {
+      base iana-interface-type;
+      reference
+        "RFC 1461 - SNMP MIB extension for Multiprotocol
+               Interconnect over X.25";
+
+    }
+
+    identity sonet {
+      base iana-interface-type;
+      description "SONET or SDH.";
+    }
+
+    identity x25ple {
+      base iana-interface-type;
+      reference
+        "RFC 2127 - ISDN Management Information Base using SMIv2";
+
+    }
+
+    identity iso88022llc {
+      base iana-interface-type;
+    }
+
+    identity localTalk {
+      base iana-interface-type;
+    }
+
+    identity smdsDxi {
+      base iana-interface-type;
+    }
+
+    identity frameRelayService {
+      base iana-interface-type;
+      description "FRNETSERV-MIB.";
+      reference
+        "RFC 2954 - Definitions of Managed Objects for Frame
+               Relay Service";
+
+    }
+
+    identity v35 {
+      base iana-interface-type;
+    }
+
+    identity hssi {
+      base iana-interface-type;
+    }
+
+    identity hippi {
+      base iana-interface-type;
+    }
+
+    identity modem {
+      base iana-interface-type;
+      description "Generic modem.";
+    }
+
+    identity aal5 {
+      base iana-interface-type;
+      description "AAL5 over ATM.";
+    }
+
+    identity sonetPath {
+      base iana-interface-type;
+    }
+
+    identity sonetVT {
+      base iana-interface-type;
+    }
+
+    identity smdsIcip {
+      base iana-interface-type;
+      description
+        "SMDS InterCarrier Interface.";
+    }
+
+    identity propVirtual {
+      base iana-interface-type;
+      description
+        "Proprietary virtual/internal.";
+      reference
+        "RFC 2863 - The Interfaces Group MIB";
+
+    }
+
+    identity propMultiplexor {
+      base iana-interface-type;
+      description
+        "Proprietary multiplexing.";
+      reference
+        "RFC 2863 - The Interfaces Group MIB";
+
+    }
+
+    identity ieee80212 {
+      base iana-interface-type;
+      description "100BaseVG.";
+    }
+
+    identity fibreChannel {
+      base iana-interface-type;
+      description "Fibre Channel.";
+    }
+
+    identity hippiInterface {
+      base iana-interface-type;
+      description "HIPPI interfaces.";
+    }
+
+    identity frameRelayInterconnect {
+      base iana-interface-type;
+      status obsolete;
+      description
+        "Obsolete; use either
+       frameRelay(32) or frameRelayService(44).";
+    }
+
+    identity aflane8023 {
+      base iana-interface-type;
+      description
+        "ATM Emulated LAN for 802.3.";
+    }
+
+    identity aflane8025 {
+      base iana-interface-type;
+      description
+        "ATM Emulated LAN for 802.5.";
+    }
+
+    identity cctEmul {
+      base iana-interface-type;
+      description "ATM Emulated circuit.";
+    }
+
+    identity fastEther {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity isdn {
+      base iana-interface-type;
+      description "ISDN and X.25.";
+      reference
+        "RFC 1356 - Multiprotocol Interconnect on X.25 and ISDN
+               in the Packet Mode";
+
+    }
+
+    identity v11 {
+      base iana-interface-type;
+      description "CCITT V.11/X.21.";
+    }
+
+    identity v36 {
+      base iana-interface-type;
+      description "CCITT V.36.";
+    }
+
+    identity g703at64k {
+      base iana-interface-type;
+      description "CCITT G703 at 64Kbps.";
+    }
+
+    identity g703at2mb {
+      base iana-interface-type;
+      status obsolete;
+      description "Obsolete; see DS1-MIB.";
+    }
+
+    identity qllc {
+      base iana-interface-type;
+      description "SNA QLLC.";
+    }
+
+    identity fastEtherFX {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity channel {
+      base iana-interface-type;
+      description "Channel.";
+    }
+
+    identity ieee80211 {
+      base iana-interface-type;
+      description "Radio spread spectrum.";
+    }
+
+    identity ibm370parChan {
+      base iana-interface-type;
+      description
+        "IBM System 360/370 OEMI Channel.";
+    }
+
+    identity escon {
+      base iana-interface-type;
+      description
+        "IBM Enterprise Systems Connection.";
+    }
+
+    identity dlsw {
+      base iana-interface-type;
+      description "Data Link Switching.";
+    }
+
+    identity isdns {
+      base iana-interface-type;
+      description "ISDN S/T interface.";
+    }
+
+    identity isdnu {
+      base iana-interface-type;
+      description "ISDN U interface.";
+    }
+
+    identity lapd {
+      base iana-interface-type;
+      description "Link Access Protocol D.";
+    }
+
+    identity ipSwitch {
+      base iana-interface-type;
+      description "IP Switching Objects.";
+    }
+
+    identity rsrb {
+      base iana-interface-type;
+      description
+        "Remote Source Route Bridging.";
+    }
+
+    identity atmLogical {
+      base iana-interface-type;
+      description "ATM Logical Port.";
+      reference
+        "RFC 3606 - Definitions of Supplemental Managed Objects
+               for ATM Interface";
+
+    }
+
+    identity ds0 {
+      base iana-interface-type;
+      description "Digital Signal Level 0.";
+      reference
+        "RFC 2494 - Definitions of Managed Objects for the DS0
+               and DS0 Bundle Interface Type";
+
+    }
+
+    identity ds0Bundle {
+      base iana-interface-type;
+      description
+        "Group of ds0s on the same ds1.";
+      reference
+        "RFC 2494 - Definitions of Managed Objects for the DS0
+               and DS0 Bundle Interface Type";
+
+    }
+
+    identity bsc {
+      base iana-interface-type;
+      description "Bisynchronous Protocol.";
+    }
+
+    identity async {
+      base iana-interface-type;
+      description "Asynchronous Protocol.";
+    }
+
+    identity cnr {
+      base iana-interface-type;
+      description "Combat Net Radio.";
+    }
+
+    identity iso88025Dtr {
+      base iana-interface-type;
+      description "ISO 802.5r DTR.";
+    }
+
+    identity eplrs {
+      base iana-interface-type;
+      description "Ext Pos Loc Report Sys.";
+    }
+
+    identity arap {
+      base iana-interface-type;
+      description
+        "Appletalk Remote Access Protocol.";
+    }
+
+    identity propCnls {
+      base iana-interface-type;
+      description
+        "Proprietary Connectionless Protocol.";
+    }
+
+    identity hostPad {
+      base iana-interface-type;
+      description
+        "CCITT-ITU X.29 PAD Protocol.";
+    }
+
+    identity termPad {
+      base iana-interface-type;
+      description
+        "CCITT-ITU X.3 PAD Facility.";
+    }
+
+    identity frameRelayMPI {
+      base iana-interface-type;
+      description
+        "Multiproto Interconnect over FR.";
+    }
+
+    identity x213 {
+      base iana-interface-type;
+      description "CCITT-ITU X213.";
+    }
+
+    identity adsl {
+      base iana-interface-type;
+      description
+        "Asymmetric Digital Subscriber Loop.";
+    }
+
+    identity radsl {
+      base iana-interface-type;
+      description
+        "Rate-Adapt. Digital Subscriber Loop.";
+    }
+
+    identity sdsl {
+      base iana-interface-type;
+      description
+        "Symmetric Digital Subscriber Loop.";
+    }
+
+    identity vdsl {
+      base iana-interface-type;
+      description
+        "Very H-Speed Digital Subscrib. Loop.";
+    }
+
+    identity iso88025CRFPInt {
+      base iana-interface-type;
+      description "ISO 802.5 CRFP.";
+    }
+
+    identity myrinet {
+      base iana-interface-type;
+      description "Myricom Myrinet.";
+    }
+
+    identity voiceEM {
+      base iana-interface-type;
+      description
+        "Voice recEive and transMit.";
+    }
+
+    identity voiceFXO {
+      base iana-interface-type;
+      description
+        "Voice Foreign Exchange Office.";
+    }
+
+    identity voiceFXS {
+      base iana-interface-type;
+      description
+        "Voice Foreign Exchange Station.";
+    }
+
+    identity voiceEncap {
+      base iana-interface-type;
+      description "Voice encapsulation.";
+    }
+
+    identity voiceOverIp {
+      base iana-interface-type;
+      description
+        "Voice over IP encapsulation.";
+    }
+
+    identity atmDxi {
+      base iana-interface-type;
+      description "ATM DXI.";
+    }
+
+    identity atmFuni {
+      base iana-interface-type;
+      description "ATM FUNI.";
+    }
+
+    identity atmIma {
+      base iana-interface-type;
+      description "ATM IMA.";
+    }
+
+    identity pppMultilinkBundle {
+      base iana-interface-type;
+      description "PPP Multilink Bundle.";
+    }
+
+    identity ipOverCdlc {
+      base iana-interface-type;
+      description "IBM ipOverCdlc.";
+    }
+
+    identity ipOverClaw {
+      base iana-interface-type;
+      description
+        "IBM Common Link Access to Workstn.";
+    }
+
+    identity stackToStack {
+      base iana-interface-type;
+      description "IBM stackToStack.";
+    }
+
+    identity virtualIpAddress {
+      base iana-interface-type;
+      description "IBM VIPA.";
+    }
+
+    identity mpc {
+      base iana-interface-type;
+      description
+        "IBM multi-protocol channel support.";
+    }
+
+    identity ipOverAtm {
+      base iana-interface-type;
+      description "IBM ipOverAtm.";
+      reference
+        "RFC 2320 - Definitions of Managed Objects for Classical IP
+               and ARP Over ATM Using SMIv2 (IPOA-MIB)";
+
+    }
+
+    identity iso88025Fiber {
+      base iana-interface-type;
+      description
+        "ISO 802.5j Fiber Token Ring.";
+    }
+
+    identity tdlc {
+      base iana-interface-type;
+      description
+        "IBM twinaxial data link control.";
+    }
+
+    identity gigabitEthernet {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+      reference
+        "RFC 3635 - Definitions of Managed Objects for the
+               Ethernet-like Interface Types";
+
+    }
+
+    identity hdlc {
+      base iana-interface-type;
+      description "HDLC.";
+    }
+
+    identity lapf {
+      base iana-interface-type;
+      description "LAP F.";
+    }
+
+    identity v37 {
+      base iana-interface-type;
+      description "V.37.";
+    }
+
+    identity x25mlp {
+      base iana-interface-type;
+      description "Multi-Link Protocol.";
+    }
+
+    identity x25huntGroup {
+      base iana-interface-type;
+      description "X25 Hunt Group.";
+    }
+
+    identity transpHdlc {
+      base iana-interface-type;
+      description "Transp HDLC.";
+    }
+
+    identity interleave {
+      base iana-interface-type;
+      description "Interleave channel.";
+    }
+
+    identity fast {
+      base iana-interface-type;
+      description "Fast channel.";
+    }
+
+    identity ip {
+      base iana-interface-type;
+      description
+        "IP (for APPN HPR in IP networks).";
+    }
+
+    identity docsCableMaclayer {
+      base iana-interface-type;
+      description "CATV Mac Layer.";
+    }
+
+    identity docsCableDownstream {
+      base iana-interface-type;
+      description
+        "CATV Downstream interface.";
+    }
+
+    identity docsCableUpstream {
+      base iana-interface-type;
+      description "CATV Upstream interface.";
+    }
+
+    identity a12MppSwitch {
+      base iana-interface-type;
+      description
+        "Avalon Parallel Processor.";
+    }
+
+    identity tunnel {
+      base iana-interface-type;
+      description "Encapsulation interface.";
+    }
+
+    identity coffee {
+      base iana-interface-type;
+      description "Coffee pot.";
+      reference
+        "RFC 2325 - Coffee MIB";
+
+    }
+
+    identity ces {
+      base iana-interface-type;
+      description
+        "Circuit Emulation Service.";
+    }
+
+    identity atmSubInterface {
+      base iana-interface-type;
+      description "ATM Sub Interface.";
+    }
+
+    identity l2vlan {
+      base iana-interface-type;
+      description
+        "Layer 2 Virtual LAN using 802.1Q.";
+    }
+
+    identity l3ipvlan {
+      base iana-interface-type;
+      description
+        "Layer 3 Virtual LAN using IP.";
+    }
+
+    identity l3ipxvlan {
+      base iana-interface-type;
+      description
+        "Layer 3 Virtual LAN using IPX.";
+    }
+
+    identity digitalPowerline {
+      base iana-interface-type;
+      description "IP over Power Lines.";
+    }
+
+    identity mediaMailOverIp {
+      base iana-interface-type;
+      description "Multimedia Mail over IP.";
+    }
+
+    identity dtm {
+      base iana-interface-type;
+      description
+        "Dynamic synchronous Transfer Mode.";
+    }
+
+    identity dcn {
+      base iana-interface-type;
+      description
+        "Data Communications Network.";
+    }
+
+    identity ipForward {
+      base iana-interface-type;
+      description "IP Forwarding Interface.";
+    }
+
+    identity msdsl {
+      base iana-interface-type;
+      description
+        "Multi-rate Symmetric DSL.";
+    }
+
+    identity ieee1394 {
+      base iana-interface-type;
+      description
+        "IEEE1394 High Performance Serial Bus.";
+    }
+
+    identity if-gsn {
+      base iana-interface-type;
+      description "HIPPI-6400.";
+    }
+
+    identity dvbRccMacLayer {
+      base iana-interface-type;
+      description "DVB-RCC MAC Layer.";
+    }
+
+    identity dvbRccDownstream {
+      base iana-interface-type;
+      description
+        "DVB-RCC Downstream Channel.";
+    }
+
+    identity dvbRccUpstream {
+      base iana-interface-type;
+      description
+        "DVB-RCC Upstream Channel.";
+    }
+
+    identity atmVirtual {
+      base iana-interface-type;
+      description "ATM Virtual Interface.";
+    }
+
+    identity mplsTunnel {
+      base iana-interface-type;
+      description
+        "MPLS Tunnel Virtual Interface.";
+    }
+
+    identity srp {
+      base iana-interface-type;
+      description "Spatial Reuse Protocol.";
+    }
+
+    identity voiceOverAtm {
+      base iana-interface-type;
+      description "Voice over ATM.";
+    }
+
+    identity voiceOverFrameRelay {
+      base iana-interface-type;
+      description "Voice Over Frame Relay.";
+    }
+
+    identity idsl {
+      base iana-interface-type;
+      description
+        "Digital Subscriber Loop over ISDN.";
+    }
+
+    identity compositeLink {
+      base iana-interface-type;
+      description
+        "Avici Composite Link Interface.";
+    }
+
+    identity ss7SigLink {
+      base iana-interface-type;
+      description "SS7 Signaling Link.";
+    }
+
+    identity propWirelessP2P {
+      base iana-interface-type;
+      description
+        "Prop. P2P wireless interface.";
+    }
+
+    identity frForward {
+      base iana-interface-type;
+      description "Frame Forward Interface.";
+    }
+
+    identity rfc1483 {
+      base iana-interface-type;
+      description
+        "Multiprotocol over ATM AAL5.";
+      reference
+        "RFC 1483 - Multiprotocol Encapsulation over ATM
+               Adaptation Layer 5";
+
+    }
+
+    identity usb {
+      base iana-interface-type;
+      description "USB Interface.";
+    }
+
+    identity ieee8023adLag {
+      base iana-interface-type;
+      description
+        "IEEE 802.3ad Link Aggregate.";
+    }
+
+    identity bgppolicyaccounting {
+      base iana-interface-type;
+      description "BGP Policy Accounting.";
+    }
+
+    identity frf16MfrBundle {
+      base iana-interface-type;
+      description
+        "FRF.16 Multilink Frame Relay.";
+    }
+
+    identity h323Gatekeeper {
+      base iana-interface-type;
+      description "H323 Gatekeeper.";
+    }
+
+    identity h323Proxy {
+      base iana-interface-type;
+      description
+        "H323 Voice and Video Proxy.";
+    }
+
+    identity mpls {
+      base iana-interface-type;
+      description "MPLS.";
+    }
+
+    identity mfSigLink {
+      base iana-interface-type;
+      description
+        "Multi-frequency signaling link.";
+    }
+
+    identity hdsl2 {
+      base iana-interface-type;
+      description
+        "High Bit-Rate DSL - 2nd generation.";
+    }
+
+    identity shdsl {
+      base iana-interface-type;
+      description "Multirate HDSL2.";
+    }
+
+    identity ds1FDL {
+      base iana-interface-type;
+      description
+        "Facility Data Link (4Kbps) on a DS1.";
+    }
+
+    identity pos {
+      base iana-interface-type;
+      description
+        "Packet over SONET/SDH Interface.";
+    }
+
+    identity dvbAsiIn {
+      base iana-interface-type;
+      description "DVB-ASI Input.";
+    }
+
+    identity dvbAsiOut {
+      base iana-interface-type;
+      description "DVB-ASI Output.";
+    }
+
+    identity plc {
+      base iana-interface-type;
+      description
+        "Power Line Communications.";
+    }
+
+    identity nfas {
+      base iana-interface-type;
+      description
+        "Non-Facility Associated Signaling.";
+    }
+
+    identity tr008 {
+      base iana-interface-type;
+      description "TR008.";
+    }
+
+    identity gr303RDT {
+      base iana-interface-type;
+      description "Remote Digital Terminal.";
+    }
+
+    identity gr303IDT {
+      base iana-interface-type;
+      description
+        "Integrated Digital Terminal.";
+    }
+
+    identity isup {
+      base iana-interface-type;
+      description "ISUP.";
+    }
+
+    identity propDocsWirelessMaclayer {
+      base iana-interface-type;
+      description
+        "Cisco proprietary Maclayer.";
+    }
+
+    identity propDocsWirelessDownstream {
+      base iana-interface-type;
+      description
+        "Cisco proprietary Downstream.";
+    }
+
+    identity propDocsWirelessUpstream {
+      base iana-interface-type;
+      description
+        "Cisco proprietary Upstream.";
+    }
+
+    identity hiperlan2 {
+      base iana-interface-type;
+      description
+        "HIPERLAN Type 2 Radio Interface.";
+    }
+
+    identity propBWAp2Mp {
+      base iana-interface-type;
+      description
+        "PropBroadbandWirelessAccesspt2Multipt (use of this value
+       for IEEE 802.16 WMAN interfaces as per IEEE Std 802.16f
+       is deprecated, and ieee80216WMAN(237) should be used
+       instead).";
+    }
+
+    identity sonetOverheadChannel {
+      base iana-interface-type;
+      description "SONET Overhead Channel.";
+    }
+
+    identity digitalWrapperOverheadChannel {
+      base iana-interface-type;
+      description "Digital Wrapper.";
+    }
+
+    identity aal2 {
+      base iana-interface-type;
+      description "ATM adaptation layer 2.";
+    }
+
+    identity radioMAC {
+      base iana-interface-type;
+      description
+        "MAC layer over radio links.";
+    }
+
+    identity atmRadio {
+      base iana-interface-type;
+      description "ATM over radio links.";
+    }
+
+    identity imt {
+      base iana-interface-type;
+      description "Inter-Machine Trunks.";
+    }
+
+    identity mvl {
+      base iana-interface-type;
+      description
+        "Multiple Virtual Lines DSL.";
+    }
+
+    identity reachDSL {
+      base iana-interface-type;
+      description "Long Reach DSL.";
+    }
+
+    identity frDlciEndPt {
+      base iana-interface-type;
+      description
+        "Frame Relay DLCI End Point.";
+    }
+
+    identity atmVciEndPt {
+      base iana-interface-type;
+      description "ATM VCI End Point.";
+    }
+
+    identity opticalChannel {
+      base iana-interface-type;
+      description "Optical Channel.";
+    }
+
+    identity opticalTransport {
+      base iana-interface-type;
+      description "Optical Transport.";
+    }
+
+    identity propAtm {
+      base iana-interface-type;
+      description "Proprietary ATM.";
+    }
+
+    identity voiceOverCable {
+      base iana-interface-type;
+      description
+        "Voice Over Cable Interface.";
+    }
+
+    identity infiniband {
+      base iana-interface-type;
+      description "Infiniband.";
+    }
+
+    identity teLink {
+      base iana-interface-type;
+      description "TE Link.";
+    }
+
+    identity q2931 {
+      base iana-interface-type;
+      description "Q.2931.";
+    }
+
+    identity virtualTg {
+      base iana-interface-type;
+      description "Virtual Trunk Group.";
+    }
+
+    identity sipTg {
+      base iana-interface-type;
+      description "SIP Trunk Group.";
+    }
+
+    identity sipSig {
+      base iana-interface-type;
+      description "SIP Signaling.";
+    }
+
+    identity docsCableUpstreamChannel {
+      base iana-interface-type;
+      description "CATV Upstream Channel.";
+    }
+
+    identity econet {
+      base iana-interface-type;
+      description "Acorn Econet.";
+    }
+
+    identity pon155 {
+      base iana-interface-type;
+      description
+        "FSAN 155Mb Symetrical PON interface.";
+    }
+
+    identity pon622 {
+      base iana-interface-type;
+      description
+        "FSAN 622Mb Symetrical PON interface.";
+    }
+
+    identity bridge {
+      base iana-interface-type;
+      description
+        "Transparent bridge interface.";
+    }
+
+    identity linegroup {
+      base iana-interface-type;
+      description
+        "Interface common to multiple lines.";
+    }
+
+    identity voiceEMFGD {
+      base iana-interface-type;
+      description
+        "Voice E&M Feature Group D.";
+    }
+
+    identity voiceFGDEANA {
+      base iana-interface-type;
+      description
+        "Voice FGD Exchange Access North American.";
+    }
+
+    identity voiceDID {
+      base iana-interface-type;
+      description
+        "Voice Direct Inward Dialing.";
+    }
+
+    identity mpegTransport {
+      base iana-interface-type;
+      description
+        "MPEG transport interface.";
+    }
+
+    identity sixToFour {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "6to4 interface (DEPRECATED).";
+      reference
+        "RFC 4087 - IP Tunnel MIB";
+
+    }
+
+    identity gtp {
+      base iana-interface-type;
+      description
+        "GTP (GPRS Tunneling Protocol).";
+    }
+
+    identity pdnEtherLoop1 {
+      base iana-interface-type;
+      description "Paradyne EtherLoop 1.";
+    }
+
+    identity pdnEtherLoop2 {
+      base iana-interface-type;
+      description "Paradyne EtherLoop 2.";
+    }
+
+    identity opticalChannelGroup {
+      base iana-interface-type;
+      description "Optical Channel Group.";
+    }
+
+    identity homepna {
+      base iana-interface-type;
+      description "HomePNA ITU-T G.989.";
+    }
+
+    identity gfp {
+      base iana-interface-type;
+      description
+        "Generic Framing Procedure (GFP).";
+    }
+
+    identity ciscoISLvlan {
+      base iana-interface-type;
+      description
+        "Layer 2 Virtual LAN using Cisco ISL.";
+    }
+
+    identity actelisMetaLOOP {
+      base iana-interface-type;
+      description
+        "Acteleis proprietary MetaLOOP High Speed Link.";
+    }
+
+    identity fcipLink {
+      base iana-interface-type;
+      description "FCIP Link.";
+    }
+
+    identity rpr {
+      base iana-interface-type;
+      description
+        "Resilient Packet Ring Interface Type.";
+    }
+
+    identity qam {
+      base iana-interface-type;
+      description "RF Qam Interface.";
+    }
+
+    identity lmp {
+      base iana-interface-type;
+      description
+        "Link Management Protocol.";
+      reference
+        "RFC 4327 - Link Management Protocol (LMP) Management
+               Information Base (MIB)";
+
+    }
+
+    identity cblVectaStar {
+      base iana-interface-type;
+      description
+        "Cambridge Broadband Networks Limited VectaStar.";
+    }
+
+    identity docsCableMCmtsDownstream {
+      base iana-interface-type;
+      description
+        "CATV Modular CMTS Downstream Interface.";
+    }
+
+    identity adsl2 {
+      base iana-interface-type;
+      status deprecated;
+      description
+        "Asymmetric Digital Subscriber Loop Version 2
+       (DEPRECATED/OBSOLETED - please use adsl2plus(238)
+       instead).";
+      reference
+        "RFC 4706 - Definitions of Managed Objects for Asymmetric
+               Digital Subscriber Line 2 (ADSL2)";
+
+    }
+
+    identity macSecControlledIF {
+      base iana-interface-type;
+      description "MACSecControlled.";
+    }
+
+    identity macSecUncontrolledIF {
+      base iana-interface-type;
+      description "MACSecUncontrolled.";
+    }
+
+    identity aviciOpticalEther {
+      base iana-interface-type;
+      description
+        "Avici Optical Ethernet Aggregate.";
+    }
+
+    identity atmbond {
+      base iana-interface-type;
+      description "atmbond.";
+    }
+
+    identity voiceFGDOS {
+      base iana-interface-type;
+      description
+        "Voice FGD Operator Services.";
+    }
+
+    identity mocaVersion1 {
+      base iana-interface-type;
+      description
+        "MultiMedia over Coax Alliance (MoCA) Interface
+       as documented in information provided privately to IANA.";
+    }
+
+    identity ieee80216WMAN {
+      base iana-interface-type;
+      description
+        "IEEE 802.16 WMAN interface.";
+    }
+
+    identity adsl2plus {
+      base iana-interface-type;
+      description
+        "Asymmetric Digital Subscriber Loop Version 2 -
+       Version 2 Plus and all variants.";
+    }
+
+    identity dvbRcsMacLayer {
+      base iana-interface-type;
+      description "DVB-RCS MAC Layer.";
+      reference
+        "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+
+    }
+
+    identity dvbTdm {
+      base iana-interface-type;
+      description "DVB Satellite TDM.";
+      reference
+        "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+
+    }
+
+    identity dvbRcsTdma {
+      base iana-interface-type;
+      description "DVB-RCS TDMA.";
+      reference
+        "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+
+    }
+
+    identity x86Laps {
+      base iana-interface-type;
+      description
+        "LAPS based on ITU-T X.86/Y.1323.";
+    }
+
+    identity wwanPP {
+      base iana-interface-type;
+      description "3GPP WWAN.";
+    }
+
+    identity wwanPP2 {
+      base iana-interface-type;
+      description "3GPP2 WWAN.";
+    }
+
+    identity voiceEBS {
+      base iana-interface-type;
+      description
+        "Voice P-phone EBS physical interface.";
+    }
+
+    identity ifPwType {
+      base iana-interface-type;
+      description
+        "Pseudowire interface type.";
+      reference
+        "RFC 5601 - Pseudowire (PW) Management Information Base (MIB)";
+
+    }
+
+    identity ilan {
+      base iana-interface-type;
+      description
+        "Internal LAN on a bridge per IEEE 802.1ap.";
+    }
+
+    identity pip {
+      base iana-interface-type;
+      description
+        "Provider Instance Port on a bridge per IEEE 802.1ah PBB.";
+    }
+
+    identity aluELP {
+      base iana-interface-type;
+      description
+        "Alcatel-Lucent Ethernet Link Protection.";
+    }
+
+    identity gpon {
+      base iana-interface-type;
+      description
+        "Gigabit-capable passive optical networks (G-PON) as per
+       ITU-T G.948.";
+    }
+
+    identity vdsl2 {
+      base iana-interface-type;
+      description
+        "Very high speed digital subscriber line Version 2
+       (as per ITU-T Recommendation G.993.2).";
+      reference
+        "RFC 5650 - Definitions of Managed Objects for Very High
+               Speed Digital Subscriber Line 2 (VDSL2)";
+
+    }
+
+    identity capwapDot11Profile {
+      base iana-interface-type;
+      description "WLAN Profile Interface.";
+      reference
+        "RFC 5834 - Control and Provisioning of Wireless Access
+               Points (CAPWAP) Protocol Binding MIB for
+               IEEE 802.11";
+
+    }
+
+    identity capwapDot11Bss {
+      base iana-interface-type;
+      description "WLAN BSS Interface.";
+      reference
+        "RFC 5834 - Control and Provisioning of Wireless Access
+               Points (CAPWAP) Protocol Binding MIB for
+               IEEE 802.11";
+
+    }
+
+    identity capwapWtpVirtualRadio {
+      base iana-interface-type;
+      description
+        "WTP Virtual Radio Interface.";
+      reference
+        "RFC 5833 - Control and Provisioning of Wireless Access
+               Points (CAPWAP) Protocol Base MIB";
+
+    }
+
+    identity bits {
+      base iana-interface-type;
+      description "bitsport.";
+    }
+
+    identity docsCableUpstreamRfPort {
+      base iana-interface-type;
+      description
+        "DOCSIS CATV Upstream RF Port.";
+    }
+
+    identity cableDownstreamRfPort {
+      base iana-interface-type;
+      description "CATV downstream RF Port.";
+    }
+
+    identity vmwareVirtualNic {
+      base iana-interface-type;
+      description
+        "VMware Virtual Network Interface.";
+    }
+
+    identity ieee802154 {
+      base iana-interface-type;
+      description
+        "IEEE 802.15.4 WPAN interface.";
+      reference
+        "IEEE 802.15.4-2006";
+
+    }
+
+    identity otnOdu {
+      base iana-interface-type;
+      description "OTN Optical Data Unit.";
+    }
+
+    identity otnOtu {
+      base iana-interface-type;
+      description
+        "OTN Optical channel Transport Unit.";
+    }
+
+    identity ifVfiType {
+      base iana-interface-type;
+      description
+        "VPLS Forwarding Instance Interface Type.";
+    }
+
+    identity g9981 {
+      base iana-interface-type;
+      description
+        "G.998.1 bonded interface.";
+    }
+
+    identity g9982 {
+      base iana-interface-type;
+      description
+        "G.998.2 bonded interface.";
+    }
+
+    identity g9983 {
+      base iana-interface-type;
+      description
+        "G.998.3 bonded interface.";
+    }
+
+    identity aluEpon {
+      base iana-interface-type;
+      description
+        "Ethernet Passive Optical Networks (E-PON).";
+    }
+
+    identity aluEponOnu {
+      base iana-interface-type;
+      description
+        "EPON Optical Network Unit.";
+    }
+
+    identity aluEponPhysicalUni {
+      base iana-interface-type;
+      description
+        "EPON physical User to Network interface.";
+    }
+
+    identity aluEponLogicalLink {
+      base iana-interface-type;
+      description
+        "The emulation of a point-to-point link over the EPON
+       layer.";
+    }
+
+    identity aluGponOnu {
+      base iana-interface-type;
+      description
+        "GPON Optical Network Unit.";
+      reference
+        "ITU-T G.984.2";
+
+    }
+
+    identity aluGponPhysicalUni {
+      base iana-interface-type;
+      description
+        "GPON physical User to Network interface.";
+      reference
+        "ITU-T G.984.2";
+
+    }
+
+    identity vmwareNicTeam {
+      base iana-interface-type;
+      description "VMware NIC Team.";
+    }
+  }  // module iana-if-type

--- a/proto/yang/ietf-inet-types@2013-07-15.yang
+++ b/proto/yang/ietf-inet-types@2013-07-15.yang
@@ -1,0 +1,454 @@
+module ietf-inet-types {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+
+    prefix inet;
+
+    organization
+      "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+    contact
+      "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+    description
+      "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+    revision "2013-07-15" {
+      description
+        "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+      reference
+        "RFC 6991: Common YANG Data Types";
+
+    }
+
+    revision "2010-09-24" {
+      description "Initial revision.";
+      reference
+        "RFC 6021: Common YANG Data Types";
+
+    }
+
+
+    typedef ip-version {
+      type enumeration {
+        enum "unknown" {
+          value 0;
+          description
+            "An unknown or unspecified version of the Internet
+          protocol.";
+        }
+        enum "ipv4" {
+          value 1;
+          description
+            "The IPv4 protocol as defined in RFC 791.";
+        }
+        enum "ipv6" {
+          value 2;
+          description
+            "The IPv6 protocol as defined in RFC 2460.";
+        }
+      }
+      description
+        "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+      reference
+        "RFC  791: Internet Protocol
+         RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+         RFC 4001: Textual Conventions for Internet Network Addresses";
+
+    }
+
+    typedef dscp {
+      type uint8 {
+        range "0..63";
+      }
+      description
+        "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+      reference
+        "RFC 3289: Management Information Base for the Differentiated
+              Services Architecture
+         RFC 2474: Definition of the Differentiated Services Field
+              (DS Field) in the IPv4 and IPv6 Headers
+         RFC 2780: IANA Allocation Guidelines For Values In
+              the Internet Protocol and Related Headers";
+
+    }
+
+    typedef ipv6-flow-label {
+      type uint32 {
+        range "0..1048575";
+      }
+      description
+        "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+      reference
+        "RFC 3595: Textual Conventions for IPv6 Flow Label
+         RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+
+    }
+
+    typedef port-number {
+      type uint16 {
+        range "0..65535";
+      }
+      description
+        "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+      reference
+        "RFC  768: User Datagram Protocol
+         RFC  793: Transmission Control Protocol
+         RFC 4960: Stream Control Transmission Protocol
+         RFC 4340: Datagram Congestion Control Protocol (DCCP)
+         RFC 4001: Textual Conventions for Internet Network Addresses";
+
+    }
+
+    typedef as-number {
+      type uint32;
+      description
+        "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+      reference
+        "RFC 1930: Guidelines for creation, selection, and registration
+              of an Autonomous System (AS)
+         RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+         RFC 4001: Textual Conventions for Internet Network Addresses
+         RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+              Number Space";
+
+    }
+
+    typedef ip-address {
+      type union {
+        type ipv4-address;
+        type ipv6-address;
+      }
+      description
+        "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+      reference
+        "RFC 4007: IPv6 Scoped Address Architecture";
+
+    }
+
+    typedef ipv4-address {
+      type string {
+        pattern
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?';
+      }
+      description
+        "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+    }
+
+    typedef ipv6-address {
+      type string {
+        pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?';
+        pattern
+          '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?';
+      }
+      description
+        "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+      reference
+        "RFC 4291: IP Version 6 Addressing Architecture
+         RFC 4007: IPv6 Scoped Address Architecture
+         RFC 5952: A Recommendation for IPv6 Address Text
+              Representation";
+
+    }
+
+    typedef ip-address-no-zone {
+      type union {
+        type ipv4-address-no-zone;
+        type ipv6-address-no-zone;
+      }
+      description
+        "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+      reference
+        "RFC 4007: IPv6 Scoped Address Architecture";
+
+    }
+
+    typedef ipv4-address-no-zone {
+      type ipv4-address {
+        pattern '[0-9\.]*';
+      }
+      description
+        "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    }
+
+    typedef ipv6-address-no-zone {
+      type ipv6-address {
+        pattern '[0-9a-fA-F:\.]*';
+      }
+      description
+        "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+      reference
+        "RFC 4291: IP Version 6 Addressing Architecture
+         RFC 4007: IPv6 Scoped Address Architecture
+         RFC 5952: A Recommendation for IPv6 Address Text
+              Representation";
+
+    }
+
+    typedef ip-prefix {
+      type union {
+        type ipv4-prefix;
+        type ipv6-prefix;
+      }
+      description
+        "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+    }
+
+    typedef ipv4-prefix {
+      type string {
+        pattern
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2]))';
+      }
+      description
+        "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+    }
+
+    typedef ipv6-prefix {
+      type string {
+        pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+        pattern
+          '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(/.+)';
+      }
+      description
+        "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+      reference
+        "RFC 5952: A Recommendation for IPv6 Address Text
+              Representation";
+
+    }
+
+    typedef domain-name {
+      type string {
+        length "1..253";
+        pattern
+          '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)|\.';
+      }
+      description
+        "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+      reference
+        "RFC  952: DoD Internet Host Table Specification
+         RFC 1034: Domain Names - Concepts and Facilities
+         RFC 1123: Requirements for Internet Hosts -- Application
+              and Support
+         RFC 2782: A DNS RR for specifying the location of services
+              (DNS SRV)
+         RFC 5890: Internationalized Domain Names in Applications
+              (IDNA): Definitions and Document Framework";
+
+    }
+
+    typedef host {
+      type union {
+        type ip-address;
+        type domain-name;
+      }
+      description
+        "The host type represents either an IP address or a DNS
+      domain name.";
+    }
+
+    typedef uri {
+      type string;
+      description
+        "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+      reference
+        "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+         RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+              Group: Uniform Resource Identifiers (URIs), URLs,
+              and Uniform Resource Names (URNs): Clarifications
+              and Recommendations
+         RFC 5017: MIB Textual Conventions for Uniform Resource
+              Identifiers (URIs)";
+
+    }
+  }  // module ietf-inet-types

--- a/proto/yang/ietf-interfaces@2014-05-08.yang
+++ b/proto/yang/ietf-interfaces@2014-05-08.yang
@@ -1,0 +1,707 @@
+module ietf-interfaces {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:ietf-interfaces";
+
+    prefix if;
+
+    import ietf-yang-types {
+      prefix yang;
+    }
+
+    organization
+      "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+    contact
+      "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+
+    description
+      "This module contains a collection of YANG definitions for
+     managing network interfaces.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7223; see
+     the RFC itself for full legal notices.";
+
+    revision "2014-05-08" {
+      description "Initial revision.";
+      reference
+        "RFC 7223: A YANG Data Model for Interface Management";
+
+    }
+
+
+    typedef interface-ref {
+      type leafref {
+        path "/if:interfaces/if:interface/if:name";
+      }
+      description
+        "This type is used by data models that need to reference
+       configured interfaces.";
+    }
+
+    typedef interface-state-ref {
+      type leafref {
+        path "/if:interfaces-state/if:interface/if:name";
+      }
+      description
+        "This type is used by data models that need to reference
+       the operationally present interfaces.";
+    }
+
+    identity interface-type {
+      description
+        "Base identity from which specific interface types are
+       derived.";
+    }
+
+    feature arbitrary-names {
+      description
+        "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+    }
+
+    feature pre-provisioning {
+      description
+        "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+    }
+
+    feature if-mib {
+      description
+        "This feature indicates that the device implements
+       the IF-MIB.";
+      reference
+        "RFC 2863: The Interfaces Group MIB";
+
+    }
+
+    container interfaces {
+      description
+        "Interface configuration parameters.";
+      list interface {
+        key "name";
+        description
+          "The list of configured interfaces on the device.
+
+         The operational state of an interface is available in the
+         /interfaces-state/interface list.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the
+         /interfaces-state/interface list.  If the configuration
+         of a user-controlled interface cannot be used by the system,
+         the configured interface is not instantiated in the
+         /interfaces-state/interface list.";
+        leaf name {
+          type string;
+          description
+            "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.  The 'config false'
+           list /interfaces-state/interface contains the currently
+           existing interfaces on the device.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           /interfaces-state/interface list, the server MAY reject
+           the request if the implementation does not support
+           pre-provisioning of interfaces or if the name refers to
+           an interface that can never exist in the system.  A
+           NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           /interface-state/interface list.";
+        }
+
+        leaf description {
+          type string;
+          description
+            "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           datastore.
+
+           Specifically, if the device supports ':startup', when
+           ifAlias is read the device MUST return the value of
+           'description' in the 'startup' datastore, and when it is
+           written, it MUST be written to the 'running' and 'startup'
+           datastores.  Note that it is up to the implementation to
+
+           decide whether to modify this single leaf in 'startup' or
+           perform an implicit copy-config from 'running' to
+           'startup'.
+
+           If the device does not support ':startup', ifAlias MUST
+           be mapped to the 'description' leaf in the 'running'
+           datastore.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifAlias";
+
+        }
+
+        leaf type {
+          type identityref {
+            base interface-type;
+          }
+          mandatory true;
+          description
+            "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifType";
+
+        }
+
+        leaf enabled {
+          type boolean;
+          default "true";
+          description
+            "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the 'running' datastore to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+
+
+           Changes in this leaf in the 'running' datastore are
+           reflected in ifAdminStatus, but if ifAdminStatus is
+           changed over SNMP, this leaf is not affected.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+
+        }
+
+        leaf link-up-down-trap-enable {
+          if-feature if-mib;
+          type enumeration {
+            enum "enabled" {
+              value 1;
+            }
+            enum "disabled" {
+              value 2;
+            }
+          }
+          description
+            "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                  ifLinkUpDownTrapEnable";
+
+        }
+      }  // list interface
+    }  // container interfaces
+
+    container interfaces-state {
+      config false;
+      description
+        "Data nodes for the operational state of interfaces.";
+      list interface {
+        key "name";
+        description
+          "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether they are configured or
+         not.";
+        leaf name {
+          type string;
+          description
+            "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifName";
+
+        }
+
+        leaf type {
+          type identityref {
+            base interface-type;
+          }
+          mandatory true;
+          description
+            "The type of the interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifType";
+
+        }
+
+        leaf admin-status {
+          if-feature if-mib;
+          type enumeration {
+            enum "up" {
+              value 1;
+              description
+                "Ready to pass packets.";
+            }
+            enum "down" {
+              value 2;
+              description
+                "Not ready to pass packets and not in some test mode.";
+            }
+            enum "testing" {
+              value 3;
+              description
+                "In some test mode.";
+            }
+          }
+          mandatory true;
+          description
+            "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+
+        }
+
+        leaf oper-status {
+          type enumeration {
+            enum "up" {
+              value 1;
+              description
+                "Ready to pass packets.";
+            }
+            enum "down" {
+              value 2;
+              description
+                "The interface does not pass any packets.";
+            }
+            enum "testing" {
+              value 3;
+              description
+                "In some test mode.  No operational packets can
+               be passed.";
+            }
+            enum "unknown" {
+              value 4;
+              description
+                "Status cannot be determined for some reason.";
+            }
+            enum "dormant" {
+              value 5;
+              description
+                "Waiting for some external event.";
+            }
+            enum "not-present" {
+              value 6;
+              description
+                "Some component (typically hardware) is missing.";
+            }
+            enum "lower-layer-down" {
+              value 7;
+              description
+                "Down due to state of lower-layer interface(s).";
+            }
+          }
+          mandatory true;
+          description
+            "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+
+        }
+
+        leaf last-change {
+          type yang:date-and-time;
+          description
+            "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifLastChange";
+
+        }
+
+        leaf if-index {
+          if-feature if-mib;
+          type int32 {
+            range "1..2147483647";
+          }
+          mandatory true;
+          description
+            "The ifIndex value for the ifEntry represented by this
+           interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifIndex";
+
+        }
+
+        leaf phys-address {
+          type yang:phys-address;
+          description
+            "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+
+
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+
+        }
+
+        leaf-list higher-layer-if {
+          type interface-state-ref;
+          description
+            "A list of references to interfaces layered on top of this
+           interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifStackTable";
+
+        }
+
+        leaf-list lower-layer-if {
+          type interface-state-ref;
+          description
+            "A list of references to interfaces layered underneath this
+           interface.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifStackTable";
+
+        }
+
+        leaf speed {
+          type yang:gauge64;
+          units "bits/second";
+          description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                  ifSpeed, ifHighSpeed";
+
+        }
+
+        container statistics {
+          description
+            "A collection of interface-related statistics objects.";
+          leaf discontinuity-time {
+            type yang:date-and-time;
+            mandatory true;
+            description
+              "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+          }
+
+          leaf in-octets {
+            type yang:counter64;
+            description
+              "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+
+          }
+
+          leaf in-unicast-pkts {
+            type yang:counter64;
+            description
+              "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+
+          }
+
+          leaf in-broadcast-pkts {
+            type yang:counter64;
+            description
+              "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCInBroadcastPkts";
+
+          }
+
+          leaf in-multicast-pkts {
+            type yang:counter64;
+            description
+              "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCInMulticastPkts";
+
+          }
+
+          leaf in-discards {
+            type yang:counter32;
+            description
+              "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+
+          }
+
+          leaf in-errors {
+            type yang:counter32;
+            description
+              "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifInErrors";
+
+          }
+
+          leaf in-unknown-protos {
+            type yang:counter32;
+            description
+              "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+
+          }
+
+          leaf out-octets {
+            type yang:counter64;
+            description
+              "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+
+          }
+
+          leaf out-unicast-pkts {
+            type yang:counter64;
+            description
+              "The total number of packets that higher-level protocols
+             requested be transmitted, and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+
+          }
+
+          leaf out-broadcast-pkts {
+            type yang:counter64;
+            description
+              "The total number of packets that higher-level protocols
+             requested be transmitted, and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCOutBroadcastPkts";
+
+          }
+
+          leaf out-multicast-pkts {
+            type yang:counter64;
+            description
+              "The total number of packets that higher-level protocols
+             requested be transmitted, and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB -
+                  ifHCOutMulticastPkts";
+
+          }
+
+          leaf out-discards {
+            type yang:counter32;
+            description
+              "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+
+          }
+
+          leaf out-errors {
+            type yang:counter32;
+            description
+              "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+
+
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system, and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+            reference
+              "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+
+          }
+        }  // container statistics
+      }  // list interface
+    }  // container interfaces-state
+  }  // module ietf-interfaces

--- a/proto/yang/ietf-netconf-acm@2012-02-22.yang
+++ b/proto/yang/ietf-netconf-acm@2012-02-22.yang
@@ -1,0 +1,449 @@
+module ietf-netconf-acm {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-netconf-acm";
+
+  prefix "nacm";
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     WG Chair: Mehmet Ersue
+               <mailto:mehmet.ersue@nsn.com>
+
+     WG Chair: Bert Wijnen
+               <mailto:bertietf@bwijnen.net>
+
+     Editor:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+
+  description
+    "NETCONF Access Control Model.
+
+     Copyright (c) 2012 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD
+     License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 6536; see
+     the RFC itself for full legal notices.";
+
+  revision "2012-02-22" {
+    description
+      "Initial version";
+    reference
+      "RFC 6536: Network Configuration Protocol (NETCONF)
+                 Access Control Model";
+  }
+
+  /*
+   * Extension statements
+   */
+
+  extension default-deny-write {
+    description
+      "Used to indicate that the data model node
+       represents a sensitive security system parameter.
+
+       If present, and the NACM module is enabled (i.e.,
+       /nacm/enable-nacm object equals 'true'), the NETCONF server
+       will only allow the designated 'recovery session' to have
+       write access to the node.  An explicit access control rule is
+       required for all other users.
+
+       The 'default-deny-write' extension MAY appear within a data
+       definition statement.  It is ignored otherwise.";
+  }
+
+  extension default-deny-all {
+    description
+      "Used to indicate that the data model node
+       controls a very sensitive security system parameter.
+
+       If present, and the NACM module is enabled (i.e.,
+       /nacm/enable-nacm object equals 'true'), the NETCONF server
+       will only allow the designated 'recovery session' to have
+       read, write, or execute access to the node.  An explicit
+       access control rule is required for all other users.
+
+       The 'default-deny-all' extension MAY appear within a data
+       definition statement, 'rpc' statement, or 'notification'
+       statement.  It is ignored otherwise.";
+  }
+
+  /*
+   * Derived types
+   */
+
+  typedef user-name-type {
+    type string {
+      length "1..max";
+    }
+    description
+      "General Purpose Username string.";
+  }
+
+  typedef matchall-string-type {
+    type string {
+      pattern '\*';
+    }
+    description
+      "The string containing a single asterisk '*' is used
+       to conceptually represent all possible values
+       for the particular leaf using this data type.";
+  }
+
+  typedef access-operations-type {
+    type bits {
+      bit create {
+        description
+          "Any protocol operation that creates a
+           new data node.";
+      }
+      bit read {
+        description
+          "Any protocol operation or notification that
+           returns the value of a data node.";
+      }
+      bit update {
+        description
+          "Any protocol operation that alters an existing
+           data node.";
+      }
+      bit delete {
+        description
+          "Any protocol operation that removes a data node.";
+      }
+      bit exec {
+        description
+          "Execution access to the specified protocol operation.";
+      }
+    }
+    description
+      "NETCONF Access Operation.";
+  }
+
+  typedef group-name-type {
+    type string {
+      length "1..max";
+      pattern '[^\*].*';
+    }
+    description
+      "Name of administrative group to which
+       users can be assigned.";
+  }
+
+  typedef action-type {
+    type enumeration {
+      enum permit {
+        description
+          "Requested action is permitted.";
+      }
+      enum deny {
+        description
+          "Requested action is denied.";
+      }
+    }
+    description
+      "Action taken by the server when a particular
+       rule matches.";
+  }
+
+  typedef node-instance-identifier {
+    type yang:xpath1.0;
+    description
+      "Path expression used to represent a special
+       data node instance identifier string.
+
+       A node-instance-identifier value is an
+       unrestricted YANG instance-identifier expression.
+       All the same rules as an instance-identifier apply
+       except predicates for keys are optional.  If a key
+       predicate is missing, then the node-instance-identifier
+       represents all possible server instances for that key.
+
+       This XPath expression is evaluated in the following context:
+
+        o  The set of namespace declarations are those in scope on
+           the leaf element where this type is used.
+
+        o  The set of variable bindings contains one variable,
+           'USER', which contains the name of the user of the current
+            session.
+
+        o  The function library is the core function library, but
+           note that due to the syntax restrictions of an
+           instance-identifier, no functions are allowed.
+
+        o  The context node is the root node in the data tree.";
+  }
+
+  /*
+   * Data definition statements
+   */
+
+  container nacm {
+    nacm:default-deny-all;
+
+    description
+      "Parameters for NETCONF Access Control Model.";
+
+    leaf enable-nacm {
+      type boolean;
+      default true;
+      description
+        "Enables or disables all NETCONF access control
+         enforcement.  If 'true', then enforcement
+         is enabled.  If 'false', then enforcement
+         is disabled.";
+    }
+
+    leaf read-default {
+      type action-type;
+      default "permit";
+      description
+        "Controls whether read access is granted if
+         no appropriate rule is found for a
+         particular read request.";
+    }
+
+    leaf write-default {
+      type action-type;
+      default "deny";
+      description
+        "Controls whether create, update, or delete access
+         is granted if no appropriate rule is found for a
+         particular write request.";
+    }
+
+    leaf exec-default {
+      type action-type;
+      default "permit";
+      description
+        "Controls whether exec access is granted if no appropriate
+         rule is found for a particular protocol operation request.";
+    }
+
+    leaf enable-external-groups {
+      type boolean;
+      default true;
+      description
+        "Controls whether the server uses the groups reported by the
+         NETCONF transport layer when it assigns the user to a set of
+         NACM groups.  If this leaf has the value 'false', any group
+         names reported by the transport layer are ignored by the
+         server.";
+    }
+
+    leaf denied-operations {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that a
+         protocol operation request was denied.";
+    }
+
+    leaf denied-data-writes {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that a
+         protocol operation request to alter
+         a configuration datastore was denied.";
+    }
+
+    leaf denied-notifications {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that
+         a notification was dropped for a subscription because
+         access to the event type was denied.";
+    }
+
+    container groups {
+      description
+        "NETCONF Access Control Groups.";
+
+      list group {
+        key name;
+
+        description
+          "One NACM Group Entry.  This list will only contain
+           configured entries, not any entries learned from
+           any transport protocols.";
+
+        leaf name {
+          type group-name-type;
+          description
+            "Group name associated with this entry.";
+        }
+
+        leaf-list user-name {
+          type user-name-type;
+          description
+            "Each entry identifies the username of
+             a member of the group associated with
+             this entry.";
+        }
+      }
+    }
+
+    list rule-list {
+      key "name";
+      ordered-by user;
+      description
+        "An ordered collection of access control rules.";
+
+      leaf name {
+        type string {
+          length "1..max";
+        }
+        description
+          "Arbitrary name assigned to the rule-list.";
+      }
+      leaf-list group {
+        type union {
+          type matchall-string-type;
+          type group-name-type;
+        }
+        description
+          "List of administrative groups that will be
+           assigned the associated access rights
+           defined by the 'rule' list.
+
+           The string '*' indicates that all groups apply to the
+           entry.";
+      }
+
+      list rule {
+        key "name";
+        ordered-by user;
+        description
+          "One access control rule.
+
+           Rules are processed in user-defined order until a match is
+           found.  A rule matches if 'module-name', 'rule-type', and
+           'access-operations' match the request.  If a rule
+           matches, the 'action' leaf determines if access is granted
+           or not.";
+
+        leaf name {
+          type string {
+            length "1..max";
+          }
+          description
+            "Arbitrary name assigned to the rule.";
+        }
+
+        leaf module-name {
+          type union {
+            type matchall-string-type;
+            type string;
+          }
+          default "*";
+          description
+            "Name of the module associated with this rule.
+
+             This leaf matches if it has the value '*' or if the
+             object being accessed is defined in the module with the
+             specified module name.";
+        }
+        choice rule-type {
+          description
+            "This choice matches if all leafs present in the rule
+             match the request.  If no leafs are present, the
+             choice matches all requests.";
+          case protocol-operation {
+            leaf rpc-name {
+              type union {
+                type matchall-string-type;
+                type string;
+              }
+              description
+                "This leaf matches if it has the value '*' or if
+                 its value equals the requested protocol operation
+                 name.";
+            }
+          }
+          case notification {
+            leaf notification-name {
+              type union {
+                type matchall-string-type;
+                type string;
+              }
+              description
+                "This leaf matches if it has the value '*' or if its
+                 value equals the requested notification name.";
+            }
+          }
+          case data-node {
+            leaf path {
+              type node-instance-identifier;
+              mandatory true;
+              description
+                "Data Node Instance Identifier associated with the
+                 data node controlled by this rule.
+
+                 Configuration data or state data instance
+                 identifiers start with a top-level data node.  A
+                 complete instance identifier is required for this
+                 type of path value.
+
+                 The special value '/' refers to all possible
+                 datastore contents.";
+            }
+          }
+        }
+
+        leaf access-operations {
+          type union {
+            type matchall-string-type;
+            type access-operations-type;
+          }
+          default "*";
+          description
+            "Access operations associated with this rule.
+
+             This leaf matches if it has the value '*' or if the
+             bit corresponding to the requested operation is set.";
+        }
+
+        leaf action {
+          type action-type;
+          mandatory true;
+          description
+            "The access control action associated with the
+             rule.  If a rule is determined to match a
+             particular request, then this object is used
+             to determine whether to permit or deny the
+             request.";
+        }
+
+        leaf comment {
+          type string;
+          description
+            "A textual description of the access rule.";
+        }
+      }
+    }
+  }
+}

--- a/proto/yang/ietf-netconf-notifications.yang
+++ b/proto/yang/ietf-netconf-notifications.yang
@@ -1,0 +1,292 @@
+module ietf-netconf-notifications {
+   namespace
+     "urn:ietf:params:xml:ns:yang:ietf-netconf-notifications";
+   prefix ncn;
+   import ietf-inet-types { prefix inet; }
+   import ietf-netconf { prefix nc; }
+   organization
+     "IETF NETCONF (Network Configuration Protocol) Working Group";
+   contact
+     "WG Web:   <http://tools.ietf.org/wg/netconf/>
+      WG List:  <mailto:netconf@ietf.org>
+      WG Chair: Bert Wijnen
+                <mailto:bertietf@bwijnen.net>
+      WG Chair: Mehmet Ersue
+                <mailto:mehmet.ersue@nsn.com>
+      Editor:   Andy Bierman
+                <mailto:andy@netconfcentral.org>";
+   description
+     "This module defines a YANG data model for use with the
+      NETCONF protocol that allows the NETCONF client to
+      receive common NETCONF base event notifications.
+      Copyright (c) 2012 IETF Trust and the persons identified as
+      the document authors.  All rights reserved.
+      Redistribution and use in source and binary forms, with or
+      without modification, is permitted pursuant to, and subject
+      to the license terms contained in, the Simplified BSD License
+      set forth in Section 4.c of the IETF Trust's Legal Provisions
+      Relating to IETF Documents
+      (http://trustee.ietf.org/license-info).
+      This version of this YANG module is part of RFC 6470; see
+      the RFC itself for full legal notices.";
+   revision "2012-02-06" {
+     description
+       "Initial version.";
+     reference
+       "RFC 6470: NETCONF Base Notifications";
+   }
+  grouping common-session-parms {
+    description
+      "Common session parameters to identify a
+       management session.";
+    leaf username {
+      type string;
+      mandatory true;
+      description
+        "Name of the user for the session.";
+    }
+    leaf session-id {
+      type nc:session-id-or-zero-type;
+      mandatory true;
+      description
+        "Identifier of the session.
+         A NETCONF session MUST be identified by a non-zero value.
+         A non-NETCONF session MAY be identified by the value zero.";
+    }
+    leaf source-host {
+      type inet:ip-address;
+      description
+        "Address of the remote host for the session.";
+    }
+  }
+   grouping changed-by-parms {
+    description
+      "Common parameters to identify the source
+       of a change event, such as a configuration
+       or capability change.";
+    container changed-by {
+      description
+        "Indicates the source of the change.
+         If caused by internal action, then the
+         empty leaf 'server' will be present.
+         If caused by a management session, then
+         the name, remote host address, and session ID
+         of the session that made the change will be reported.";
+      choice server-or-user {
+        mandatory true;
+        leaf server {
+          type empty;
+          description
+            "If present, the change was caused
+             by the server.";
+        }
+        case by-user {
+          uses common-session-parms;
+        }
+      } // choice server-or-user
+    } // container changed-by-parms
+  }
+  notification netconf-config-change {
+    description
+      "Generated when the NETCONF server detects that the
+       <running> or <startup> configuration datastore
+       has been changed by a management session.
+       The notification summarizes the edits that
+       have been detected.
+       The server MAY choose to also generate this
+       notification while loading a datastore during the
+       boot process for the device.";
+    uses changed-by-parms;
+    leaf datastore {
+      type enumeration {
+        enum running {
+          description "The <running> datastore has changed.";
+        }
+        enum startup {
+          description "The <startup> datastore has changed";
+        }
+      }
+      default "running";
+      description
+        "Indicates which configuration datastore has changed.";
+    }
+    list edit {
+      description
+        "An edit record SHOULD be present for each distinct
+         edit operation that the server has detected on
+         the target datastore.  This list MAY be omitted
+         if the detailed edit operations are not known.
+         The server MAY report entries in this list for
+         changes not made by a NETCONF session (e.g., CLI).";
+      leaf target {
+        type instance-identifier;
+        description
+          "Topmost node associated with the configuration change.
+           A server SHOULD set this object to the node within
+           the datastore that is being altered.  A server MAY
+           set this object to one of the ancestors of the actual
+           node that was changed, or omit this object, if the
+           exact node is not known.";
+      }
+      leaf operation {
+        type nc:edit-operation-type;
+        description
+          "Type of edit operation performed.
+           A server MUST set this object to the NETCONF edit
+           operation performed on the target datastore.";
+      }
+    } // list edit
+  } // notification netconf-config-change
+  notification netconf-capability-change {
+    description
+      "Generated when the NETCONF server detects that
+       the server capabilities have changed.
+       Indicates which capabilities have been added, deleted,
+       and/or modified.  The manner in which a server
+       capability is changed is outside the scope of this
+       document.";
+    uses changed-by-parms;
+    leaf-list added-capability {
+      type inet:uri;
+      description
+        "List of capabilities that have just been added.";
+    }
+    leaf-list deleted-capability {
+      type inet:uri;
+      description
+        "List of capabilities that have just been deleted.";
+    }
+    leaf-list modified-capability {
+      type inet:uri;
+      description
+        "List of capabilities that have just been modified.
+         A capability is considered to be modified if the
+         base URI for the capability has not changed, but
+         one or more of the parameters encoded at the end of
+         the capability URI have changed.
+         The new modified value of the complete URI is returned.";
+    }
+  } // notification netconf-capability-change
+  notification netconf-session-start {
+    description
+      "Generated when a NETCONF server detects that a
+       NETCONF session has started.  A server MAY generate
+       this event for non-NETCONF management sessions.
+       Indicates the identity of the user that started
+       the session.";
+    uses common-session-parms;
+  } // notification netconf-session-start
+  notification netconf-session-end {
+    description
+      "Generated when a NETCONF server detects that a
+       NETCONF session has terminated.
+       A server MAY optionally generate this event for
+       non-NETCONF management sessions.  Indicates the
+       identity of the user that owned the session,
+       and why the session was terminated.";
+    uses common-session-parms;
+    leaf killed-by {
+      when "../termination-reason = 'killed'";
+      type nc:session-id-type;
+      description
+        "The ID of the session that directly caused this session
+         to be abnormally terminated.  If this session was abnormally
+         terminated by a non-NETCONF session unknown to the server,
+         then this leaf will not be present.";
+    }
+    leaf termination-reason {
+      type enumeration {
+        enum "closed" {
+          description
+            "The session was terminated by the client in normal
+             fashion, e.g., by the NETCONF <close-session>
+             protocol operation.";
+        }
+        enum "killed" {
+          description
+            "The session was terminated in abnormal
+             fashion, e.g., by the NETCONF <kill-session>
+             protocol operation.";
+        }
+        enum "dropped" {
+          description
+            "The session was terminated because the transport layer
+             connection was unexpectedly closed.";
+        }
+        enum "timeout" {
+          description
+            "The session was terminated because of inactivity,
+             e.g., waiting for the <hello> message or <rpc>
+             messages.";
+        }
+        enum "bad-hello" {
+          description
+            "The client's <hello> message was invalid.";
+        }
+        enum "other" {
+          description
+            "The session was terminated for some other reason.";
+        }
+      }
+      mandatory true;
+      description
+        "Reason the session was terminated.";
+    }
+  } // notification netconf-session-end
+  notification netconf-confirmed-commit {
+    description
+      "Generated when a NETCONF server detects that a
+       confirmed-commit event has occurred.  Indicates the event
+       and the current state of the confirmed-commit procedure
+       in progress.";
+    reference
+      "RFC 6241, Section 8.4";
+    uses common-session-parms {
+      when "confirm-event != 'timeout'";
+    }
+    leaf confirm-event {
+      type enumeration {
+        enum "start" {
+          description
+            "The confirmed-commit procedure has started.";
+        }
+        enum "cancel" {
+          description
+            "The confirmed-commit procedure has been canceled,
+             e.g., due to the session being terminated, or an
+             explicit <cancel-commit> operation.";
+        }
+        enum "timeout" {
+          description
+            "The confirmed-commit procedure has been canceled
+             due to the confirm-timeout interval expiring.
+             The common session parameters will not be present
+             in this sub-mode.";
+        }
+        enum "extend" {
+          description
+            "The confirmed-commit timeout has been extended,
+             e.g., by a new <confirmed-commit> operation.";
+        }
+        enum "complete" {
+          description
+            "The confirmed-commit procedure has been completed.";
+        }
+      }
+      mandatory true;
+      description
+        "Indicates the event that caused the notification.";
+    }
+    leaf timeout {
+      when
+        "../confirm-event = 'start' or ../confirm-event = 'extend'";
+      type uint32;
+      units "seconds";
+      description
+        "The configured timeout value if the event type
+         is 'start' or 'extend'.  This value represents
+         the approximate number of seconds from the event
+         time when the 'timeout' event might occur.";
+    }
+  } // notification netconf-confirmed-commit
+}

--- a/proto/yang/ietf-netconf@2011-06-01.yang
+++ b/proto/yang/ietf-netconf@2011-06-01.yang
@@ -1,0 +1,934 @@
+module ietf-netconf {
+
+  // the namespace for NETCONF XML definitions is unchanged
+  // from RFC 4741, which this document replaces
+  namespace "urn:ietf:params:xml:ns:netconf:base:1.0";
+
+  prefix nc;
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import ietf-netconf-acm { prefix nacm; }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netconf/>
+     WG List:  <netconf@ietf.org>
+
+     WG Chair: Bert Wijnen
+               <bertietf@bwijnen.net>
+
+     WG Chair: Mehmet Ersue
+               <mehmet.ersue@nsn.com>
+
+     Editor:   Martin Bjorklund
+               <mbj@tail-f.com>
+
+     Editor:   Juergen Schoenwaelder
+               <j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Andy Bierman
+               <andy.bierman@brocade.com>";
+  description
+    "NETCONF Protocol Data Types and Protocol Operations.
+
+     Copyright (c) 2011 IETF Trust and the persons identified as
+     the document authors.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 6241; see
+     the RFC itself for full legal notices.";
+
+  revision 2011-06-01 {
+    description
+      "Initial revision;
+       2013-09-29: Updated to include NACM attributes,
+       as specified in RFC 6536: sec 3.2.5 and 3.2.8";
+    reference
+      "RFC 6241: Network Configuration Protocol";
+  }
+
+  extension get-filter-element-attributes {
+    description
+      "If this extension is present within an 'anyxml'
+       statement named 'filter', which must be conceptually
+       defined within the RPC input section for the <get>
+       and <get-config> protocol operations, then the
+       following unqualified XML attribute is supported
+       within the <filter> element, within a <get> or
+       <get-config> protocol operation:
+
+         type : optional attribute with allowed
+                value strings 'subtree' and 'xpath'.
+                If missing, the default value is 'subtree'.
+
+       If the 'xpath' feature is supported, then the
+       following unqualified XML attribute is
+       also supported:
+
+         select: optional attribute containing a
+                 string representing an XPath expression.
+                 The 'type' attribute must be equal to 'xpath'
+                 if this attribute is present.";
+  }
+
+  // NETCONF capabilities defined as features
+  feature writable-running {
+    description
+      "NETCONF :writable-running capability;
+       If the server advertises the :writable-running
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+    reference "RFC 6241, Section 8.2";
+  }
+
+  feature candidate {
+    description
+      "NETCONF :candidate capability;
+       If the server advertises the :candidate
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+    reference "RFC 6241, Section 8.3";
+  }
+
+  feature confirmed-commit {
+    if-feature candidate;
+    description
+      "NETCONF :confirmed-commit:1.1 capability;
+       If the server advertises the :confirmed-commit:1.1
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+
+    reference "RFC 6241, Section 8.4";
+  }
+
+  feature rollback-on-error {
+    description
+      "NETCONF :rollback-on-error capability;
+       If the server advertises the :rollback-on-error
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+    reference "RFC 6241, Section 8.5";
+  }
+
+  feature validate {
+    description
+      "NETCONF :validate:1.1 capability;
+       If the server advertises the :validate:1.1
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+    reference "RFC 6241, Section 8.6";
+  }
+
+  feature startup {
+    description
+      "NETCONF :startup capability;
+       If the server advertises the :startup
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+    reference "RFC 6241, Section 8.7";
+  }
+
+  feature url {
+    description
+      "NETCONF :url capability;
+       If the server advertises the :url
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+    reference "RFC 6241, Section 8.8";
+  }
+
+  feature xpath {
+    description
+      "NETCONF :xpath capability;
+       If the server advertises the :xpath
+       capability for a session, then this feature must
+       also be enabled for that session.  Otherwise,
+       this feature must not be enabled.";
+    reference "RFC 6241, Section 8.9";
+  }
+
+  // NETCONF Simple Types
+
+  typedef session-id-type {
+    type uint32 {
+      range "1..max";
+    }
+    description
+      "NETCONF Session Id";
+  }
+
+  typedef session-id-or-zero-type {
+    type uint32;
+    description
+      "NETCONF Session Id or Zero to indicate none";
+  }
+  typedef error-tag-type {
+    type enumeration {
+       enum in-use {
+         description
+           "The request requires a resource that
+            already is in use.";
+       }
+       enum invalid-value {
+         description
+           "The request specifies an unacceptable value for one
+            or more parameters.";
+       }
+       enum too-big {
+         description
+           "The request or response (that would be generated) is
+            too large for the implementation to handle.";
+       }
+       enum missing-attribute {
+         description
+           "An expected attribute is missing.";
+       }
+       enum bad-attribute {
+         description
+           "An attribute value is not correct; e.g., wrong type,
+            out of range, pattern mismatch.";
+       }
+       enum unknown-attribute {
+         description
+           "An unexpected attribute is present.";
+       }
+       enum missing-element {
+         description
+           "An expected element is missing.";
+       }
+       enum bad-element {
+         description
+           "An element value is not correct; e.g., wrong type,
+            out of range, pattern mismatch.";
+       }
+       enum unknown-element {
+         description
+           "An unexpected element is present.";
+       }
+       enum unknown-namespace {
+         description
+           "An unexpected namespace is present.";
+       }
+       enum access-denied {
+         description
+           "Access to the requested protocol operation or
+            data model is denied because authorization failed.";
+       }
+       enum lock-denied {
+         description
+           "Access to the requested lock is denied because the
+            lock is currently held by another entity.";
+       }
+       enum resource-denied {
+         description
+           "Request could not be completed because of
+            insufficient resources.";
+       }
+       enum rollback-failed {
+         description
+           "Request to roll back some configuration change (via
+            rollback-on-error or <discard-changes> operations)
+            was not completed for some reason.";
+
+       }
+       enum data-exists {
+         description
+           "Request could not be completed because the relevant
+            data model content already exists.  For example,
+            a 'create' operation was attempted on data that
+            already exists.";
+       }
+       enum data-missing {
+         description
+           "Request could not be completed because the relevant
+            data model content does not exist.  For example,
+            a 'delete' operation was attempted on
+            data that does not exist.";
+       }
+       enum operation-not-supported {
+         description
+           "Request could not be completed because the requested
+            operation is not supported by this implementation.";
+       }
+       enum operation-failed {
+         description
+           "Request could not be completed because the requested
+            operation failed for some reason not covered by
+            any other error condition.";
+       }
+       enum partial-operation {
+         description
+           "This error-tag is obsolete, and SHOULD NOT be sent
+            by servers conforming to this document.";
+       }
+       enum malformed-message {
+         description
+           "A message could not be handled because it failed to
+            be parsed correctly.  For example, the message is not
+            well-formed XML or it uses an invalid character set.";
+       }
+     }
+     description "NETCONF Error Tag";
+     reference "RFC 6241, Appendix A";
+  }
+
+  typedef error-severity-type {
+    type enumeration {
+      enum error {
+        description "Error severity";
+      }
+      enum warning {
+        description "Warning severity";
+      }
+    }
+    description "NETCONF Error Severity";
+    reference "RFC 6241, Section 4.3";
+  }
+
+  typedef edit-operation-type {
+    type enumeration {
+      enum merge {
+        description
+          "The configuration data identified by the
+           element containing this attribute is merged
+           with the configuration at the corresponding
+           level in the configuration datastore identified
+           by the target parameter.";
+      }
+      enum replace {
+        description
+          "The configuration data identified by the element
+           containing this attribute replaces any related
+           configuration in the configuration datastore
+           identified by the target parameter.  If no such
+           configuration data exists in the configuration
+           datastore, it is created.  Unlike a
+           <copy-config> operation, which replaces the
+           entire target configuration, only the configuration
+           actually present in the config parameter is affected.";
+      }
+      enum create {
+        description
+          "The configuration data identified by the element
+           containing this attribute is added to the
+           configuration if and only if the configuration
+           data does not already exist in the configuration
+           datastore.  If the configuration data exists, an
+           <rpc-error> element is returned with an
+           <error-tag> value of 'data-exists'.";
+      }
+      enum delete {
+        description
+          "The configuration data identified by the element
+           containing this attribute is deleted from the
+           configuration if and only if the configuration
+           data currently exists in the configuration
+           datastore.  If the configuration data does not
+           exist, an <rpc-error> element is returned with
+           an <error-tag> value of 'data-missing'.";
+      }
+      enum remove {
+        description
+          "The configuration data identified by the element
+           containing this attribute is deleted from the
+           configuration if the configuration
+           data currently exists in the configuration
+           datastore.  If the configuration data does not
+           exist, the 'remove' operation is silently ignored
+           by the server.";
+      }
+    }
+    default "merge";
+    description "NETCONF 'operation' attribute values";
+    reference "RFC 6241, Section 7.2";
+  }
+
+  // NETCONF Standard Protocol Operations
+
+  rpc get-config {
+    description
+      "Retrieve all or part of a specified configuration.";
+
+    reference "RFC 6241, Section 7.1";
+
+    input {
+      container source {
+        description
+          "Particular configuration to retrieve.";
+
+        choice config-source {
+          mandatory true;
+          description
+            "The configuration to retrieve.";
+          leaf candidate {
+            if-feature candidate;
+            type empty;
+            description
+              "The candidate configuration is the config source.";
+          }
+          leaf running {
+            type empty;
+            description
+              "The running configuration is the config source.";
+          }
+          leaf startup {
+            if-feature startup;
+            type empty;
+            description
+              "The startup configuration is the config source.
+               This is optional-to-implement on the server because
+               not all servers will support filtering for this
+               datastore.";
+          }
+        }
+      }
+
+      anyxml filter {
+        description
+          "Subtree or XPath filter to use.";
+        nc:get-filter-element-attributes;
+      }
+    }
+
+    output {
+      anyxml data {
+        description
+          "Copy of the source datastore subset that matched
+           the filter criteria (if any).  An empty data container
+           indicates that the request did not produce any results.";
+      }
+    }
+  }
+
+  rpc edit-config {
+    description
+      "The <edit-config> operation loads all or part of a specified
+       configuration to the specified target configuration.";
+
+    reference "RFC 6241, Section 7.2";
+
+    input {
+      container target {
+        description
+          "Particular configuration to edit.";
+
+        choice config-target {
+          mandatory true;
+          description
+            "The configuration target.";
+
+          leaf candidate {
+            if-feature candidate;
+            type empty;
+            description
+              "The candidate configuration is the config target.";
+          }
+          leaf running {
+            if-feature writable-running;
+            type empty;
+            description
+              "The running configuration is the config source.";
+          }
+        }
+      }
+
+      leaf default-operation {
+        type enumeration {
+          enum merge {
+            description
+              "The default operation is merge.";
+          }
+          enum replace {
+            description
+              "The default operation is replace.";
+          }
+          enum none {
+            description
+              "There is no default operation.";
+          }
+        }
+        default "merge";
+        description
+          "The default operation to use.";
+      }
+
+      leaf test-option {
+        if-feature validate;
+        type enumeration {
+          enum test-then-set {
+            description
+              "The server will test and then set if no errors.";
+          }
+          enum set {
+            description
+              "The server will set without a test first.";
+          }
+
+          enum test-only {
+            description
+              "The server will only test and not set, even
+               if there are no errors.";
+          }
+        }
+        default "test-then-set";
+        description
+          "The test option to use.";
+      }
+
+      leaf error-option {
+        type enumeration {
+          enum stop-on-error {
+            description
+              "The server will stop on errors.";
+          }
+          enum continue-on-error {
+            description
+              "The server may continue on errors.";
+          }
+          enum rollback-on-error {
+            description
+              "The server will roll back on errors.
+               This value can only be used if the 'rollback-on-error'
+               feature is supported.";
+          }
+        }
+        default "stop-on-error";
+        description
+          "The error option to use.";
+      }
+
+      choice edit-content {
+        mandatory true;
+        description
+          "The content for the edit operation.";
+
+        anyxml config {
+          description
+            "Inline Config content.";
+        }
+        leaf url {
+          if-feature url;
+          type inet:uri;
+          description
+            "URL-based config content.";
+        }
+      }
+    }
+  }
+
+  rpc copy-config {
+    description
+      "Create or replace an entire configuration datastore with the
+       contents of another complete configuration datastore.";
+
+    reference "RFC 6241, Section 7.3";
+
+    input {
+      container target {
+        description
+          "Particular configuration to copy to.";
+
+        choice config-target {
+          mandatory true;
+          description
+            "The configuration target of the copy operation.";
+
+          leaf candidate {
+            if-feature candidate;
+            type empty;
+            description
+              "The candidate configuration is the config target.";
+          }
+          leaf running {
+            if-feature writable-running;
+            type empty;
+            description
+              "The running configuration is the config target.
+               This is optional-to-implement on the server.";
+          }
+          leaf startup {
+            if-feature startup;
+            type empty;
+            description
+              "The startup configuration is the config target.";
+          }
+          leaf url {
+            if-feature url;
+            type inet:uri;
+            description
+              "The URL-based configuration is the config target.";
+          }
+        }
+      }
+
+      container source {
+        description
+          "Particular configuration to copy from.";
+
+        choice config-source {
+          mandatory true;
+          description
+            "The configuration source for the copy operation.";
+
+          leaf candidate {
+            if-feature candidate;
+            type empty;
+            description
+              "The candidate configuration is the config source.";
+          }
+          leaf running {
+            type empty;
+            description
+              "The running configuration is the config source.";
+          }
+          leaf startup {
+            if-feature startup;
+            type empty;
+            description
+              "The startup configuration is the config source.";
+          }
+          leaf url {
+            if-feature url;
+            type inet:uri;
+            description
+              "The URL-based configuration is the config source.";
+          }
+          anyxml config {
+            description
+              "Inline Config content: <config> element.  Represents
+               an entire configuration datastore, not
+               a subset of the running datastore.";
+          }
+        }
+      }
+    }
+  }
+
+  rpc delete-config {
+    nacm:default-deny-all;
+    description
+      "Delete a configuration datastore.";
+
+    reference "RFC 6241, Section 7.4";
+
+    input {
+      container target {
+        description
+          "Particular configuration to delete.";
+
+        choice config-target {
+          mandatory true;
+          description
+            "The configuration target to delete.";
+
+          leaf startup {
+            if-feature startup;
+            type empty;
+            description
+              "The startup configuration is the config target.";
+          }
+          leaf url {
+            if-feature url;
+            type inet:uri;
+            description
+              "The URL-based configuration is the config target.";
+          }
+        }
+      }
+    }
+  }
+
+  rpc lock {
+    description
+      "The lock operation allows the client to lock the configuration
+       system of a device.";
+
+    reference "RFC 6241, Section 7.5";
+
+    input {
+      container target {
+        description
+          "Particular configuration to lock.";
+
+        choice config-target {
+          mandatory true;
+          description
+            "The configuration target to lock.";
+
+          leaf candidate {
+            if-feature candidate;
+            type empty;
+            description
+              "The candidate configuration is the config target.";
+          }
+          leaf running {
+            type empty;
+            description
+              "The running configuration is the config target.";
+          }
+          leaf startup {
+            if-feature startup;
+            type empty;
+            description
+              "The startup configuration is the config target.";
+          }
+        }
+      }
+    }
+  }
+
+  rpc unlock {
+    description
+      "The unlock operation is used to release a configuration lock,
+       previously obtained with the 'lock' operation.";
+
+    reference "RFC 6241, Section 7.6";
+
+    input {
+      container target {
+        description
+          "Particular configuration to unlock.";
+
+        choice config-target {
+          mandatory true;
+          description
+            "The configuration target to unlock.";
+
+          leaf candidate {
+            if-feature candidate;
+            type empty;
+            description
+              "The candidate configuration is the config target.";
+          }
+          leaf running {
+            type empty;
+            description
+              "The running configuration is the config target.";
+          }
+          leaf startup {
+            if-feature startup;
+            type empty;
+            description
+              "The startup configuration is the config target.";
+          }
+        }
+      }
+    }
+  }
+
+  rpc get {
+    description
+      "Retrieve running configuration and device state information.";
+
+    reference "RFC 6241, Section 7.7";
+
+    input {
+      anyxml filter {
+        description
+          "This parameter specifies the portion of the system
+           configuration and state data to retrieve.";
+        nc:get-filter-element-attributes;
+      }
+    }
+
+    output {
+      anyxml data {
+        description
+          "Copy of the running datastore subset and/or state
+           data that matched the filter criteria (if any).
+           An empty data container indicates that the request did not
+           produce any results.";
+      }
+    }
+  }
+
+  rpc close-session {
+    description
+      "Request graceful termination of a NETCONF session.";
+
+    reference "RFC 6241, Section 7.8";
+  }
+
+  rpc kill-session {
+    nacm:default-deny-all;
+    description
+      "Force the termination of a NETCONF session.";
+
+    reference "RFC 6241, Section 7.9";
+
+    input {
+      leaf session-id {
+        type session-id-type;
+        mandatory true;
+        description
+          "Particular session to kill.";
+      }
+    }
+  }
+
+  rpc commit {
+    if-feature candidate;
+
+    description
+      "Commit the candidate configuration as the device's new
+       current configuration.";
+
+    reference "RFC 6241, Section 8.3.4.1";
+
+    input {
+      leaf confirmed {
+        if-feature confirmed-commit;
+        type empty;
+        description
+          "Requests a confirmed commit.";
+        reference "RFC 6241, Section 8.3.4.1";
+      }
+
+      leaf confirm-timeout {
+        if-feature confirmed-commit;
+        type uint32 {
+          range "1..max";
+        }
+        units "seconds";
+        default "600";   // 10 minutes
+        description
+          "The timeout interval for a confirmed commit.";
+        reference "RFC 6241, Section 8.3.4.1";
+      }
+
+      leaf persist {
+        if-feature confirmed-commit;
+        type string;
+        description
+          "This parameter is used to make a confirmed commit
+           persistent.  A persistent confirmed commit is not aborted
+           if the NETCONF session terminates.  The only way to abort
+           a persistent confirmed commit is to let the timer expire,
+           or to use the <cancel-commit> operation.
+
+           The value of this parameter is a token that must be given
+           in the 'persist-id' parameter of <commit> or
+           <cancel-commit> operations in order to confirm or cancel
+           the persistent confirmed commit.
+
+           The token should be a random string.";
+        reference "RFC 6241, Section 8.3.4.1";
+      }
+
+      leaf persist-id {
+        if-feature confirmed-commit;
+        type string;
+        description
+          "This parameter is given in order to commit a persistent
+           confirmed commit.  The value must be equal to the value
+           given in the 'persist' parameter to the <commit> operation.
+           If it does not match, the operation fails with an
+          'invalid-value' error.";
+        reference "RFC 6241, Section 8.3.4.1";
+      }
+
+    }
+  }
+
+  rpc discard-changes {
+    if-feature candidate;
+
+    description
+      "Revert the candidate configuration to the current
+       running configuration.";
+    reference "RFC 6241, Section 8.3.4.2";
+  }
+
+  rpc cancel-commit {
+    if-feature confirmed-commit;
+    description
+      "This operation is used to cancel an ongoing confirmed commit.
+       If the confirmed commit is persistent, the parameter
+       'persist-id' must be given, and it must match the value of the
+       'persist' parameter.";
+    reference "RFC 6241, Section 8.4.4.1";
+
+    input {
+      leaf persist-id {
+        type string;
+        description
+          "This parameter is given in order to cancel a persistent
+           confirmed commit.  The value must be equal to the value
+           given in the 'persist' parameter to the <commit> operation.
+           If it does not match, the operation fails with an
+          'invalid-value' error.";
+      }
+    }
+  }
+
+  rpc validate {
+    if-feature validate;
+
+    description
+      "Validates the contents of the specified configuration.";
+
+    reference "RFC 6241, Section 8.6.4.1";
+
+    input {
+      container source {
+        description
+          "Particular configuration to validate.";
+
+        choice config-source {
+          mandatory true;
+          description
+            "The configuration source to validate.";
+
+          leaf candidate {
+            if-feature candidate;
+            type empty;
+            description
+              "The candidate configuration is the config source.";
+          }
+          leaf running {
+            type empty;
+            description
+              "The running configuration is the config source.";
+          }
+          leaf startup {
+            if-feature startup;
+            type empty;
+            description
+              "The startup configuration is the config source.";
+          }
+          leaf url {
+            if-feature url;
+            type inet:uri;
+            description
+              "The URL-based configuration is the config source.";
+          }
+          anyxml config {
+            description
+              "Inline Config content: <config> element.  Represents
+               an entire configuration datastore, not
+               a subset of the running datastore.";
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/proto/yang/ietf-yang-types@2013-07-15.yang
+++ b/proto/yang/ietf-yang-types@2013-07-15.yang
@@ -1,0 +1,474 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}


### PR DESCRIPTION
We only support gNMI subscriptions in ONCE mode and the openconfig-interfaces YANG model.

We choose to use sysrepo as a YANG data store and to process XPaths, to avoid having to implement our own solution. Using sysrepo may not be appropriate for a production product, and this support is mostly meant as a proof-of-concept at this stage.

See proto/README.md for more information and instructions on how to test out gNMI support.