### PR TITLE
Infer XPath namespace qualifier from gNMI path

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -8,10 +8,10 @@ We are working on supporting gNMI and OpenConfig YANG models as part of the P4
 Runtime server. We are using [sysrepo](https://github.com/sysrepo/sysrepo) as
 our YANG configuration data store and operational state manager. If you want to
 experiment with the gNMI support, you will need to install sysrepo and its
-dependencies. We currently recommend using [version 0.7.1 of
-sysrepo](https://github.com/sysrepo/sysrepo/releases/tag/v0.7.1), which depends
-on [version 0.13-rc2 of
-libyang](https://github.com/CESNET/libyang/releases/tag/v0.13-r2).
+dependencies. We currently require [version 0.7.2 of
+sysrepo](https://github.com/sysrepo/sysrepo/releases/tag/v0.7.2), which depends
+on [version 0.14-r1 of
+libyang](https://github.com/CESNET/libyang/releases/tag/v0.14-r1).
 
 Please make sure you install all the dependencies for libyang and sysrepo. If
 you are using a Debian system, we recommend that you install the following
@@ -23,7 +23,7 @@ Then install libyang:
 
     git clone https://github.com/CESNET/libyang.git
     cd libyang
-    git checkout v0.13-r2
+    git checkout v0.14-r1
     mkdir build
     cd build
     cmake ..
@@ -34,10 +34,10 @@ Finally, install sysrepo
 
     git clone https://github.com/sysrepo/sysrepo.git
     cd sysrepo
-    git checkout v0.7.1
+    git checkout v0.7.2
     mkdir build
     cd build
-    cmake -DBUILD_EXAMPLES=Off -DCALL_TARGET_BINS_DIRECTLY=Off ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=Off -DCALL_TARGET_BINS_DIRECTLY=Off ..
     make
     [sudo] make install
 
@@ -61,16 +61,17 @@ Sysrepo data directory:   /etc/sysrepo/data/
 
 Module Name                   | Revision   | Conformance | Data Owner          | Permissions | Submodules                    | Enabled Features
 -----------------------------------------------------------------------------------------------------------------------------------------------
-ietf-interfaces               | 2014-05-08 | Installed   | root:root           | 666         |                               |
-openconfig-extensions         | 2017-04-11 | Installed   |                     |             |                               |
-openconfig-types              | 2017-08-16 | Installed   |                     |             |                               |
-openconfig-yang-types         | 2017-07-30 | Installed   |                     |             |                               |
 openconfig-interfaces         | 2017-07-14 | Installed   | root:root           | 666         |                               |
+ietf-interfaces               | 2014-05-08 | Imported    |                     |             |                               |
+openconfig-yang-types         | 2017-07-30 | Imported    |                     |             |                               |
+openconfig-extensions         | 2017-04-11 | Imported    |                     |             |                               |
+openconfig-types              | 2017-08-16 | Imported    |                     |             |                               |
+openconfig-platform           | 2016-12-22 | Installed   | root:root           | 666         |                               |
+openconfig-platform-types     | 2017-08-16 | Imported    |                     |             |                               |
 iana-if-type                  | 2014-05-08 | Installed   |                     |             |                               |
-ietf-inet-types               | 2013-07-15 | Installed   |                     |             |                               |
-ietf-netconf-acm              | 2012-02-22 | Installed   | root:root           | 666         |                               |
-ietf-netconf                  | 2011-06-01 | Installed   | root:root           | 666         |                               |
 ietf-netconf-notifications    | 2012-02-06 | Installed   | root:root           | 666         |                               |
+ietf-netconf                  | 2011-06-01 | Imported    |                     |             |                               |
+ietf-netconf-acm              | 2012-02-22 | Imported    |                     |             |                               |
 ```
 
 The P4 Runtile server library that you get after that will be able to support

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -69,6 +69,8 @@ AC_ARG_WITH([sysrepo],
     [with_sysrepo="$withval"], [with_sysrepo=no])
 AM_CONDITIONAL([WITH_SYSREPO], [test "$with_sysrepo" = yes])
 AM_COND_IF([WITH_SYSREPO], [
+    AC_CHECK_LIB([yang], [lys_parse_path], [],
+                 [AC_MSG_ERROR([Missing libyang])])
     AC_CHECK_LIB([sysrepo], [sr_connect], [],
                  [AC_MSG_ERROR([Missing libsysrepo])])
 ])

--- a/proto/server/gnmi_sysrepo.h
+++ b/proto/server/gnmi_sysrepo.h
@@ -21,9 +21,7 @@
 #ifndef PROTO_SERVER_GNMI_SYSREPO_H_
 #define PROTO_SERVER_GNMI_SYSREPO_H_
 
-#include <grpc++/grpc++.h>
-
-#include <string>
+#include <memory>
 
 #include "gnmi/gnmi.grpc.pb.h"
 
@@ -31,25 +29,7 @@ namespace pi {
 
 namespace server {
 
-class gNMIServiceSysrepoImpl : public gnmi::gNMI::Service {
- private:
-  grpc::Status Capabilities(grpc::ServerContext *context,
-                            const gnmi::CapabilityRequest *request,
-                            gnmi::CapabilityResponse *response) override;
-
-  grpc::Status Get(grpc::ServerContext *context,
-                   const gnmi::GetRequest *request,
-                   gnmi::GetResponse *response) override;
-
-  grpc::Status Set(grpc::ServerContext *context,
-                   const gnmi::SetRequest *request,
-                   gnmi::SetResponse *response) override;
-
-  grpc::Status Subscribe(
-      grpc::ServerContext *context,
-      grpc::ServerReaderWriter<gnmi::SubscribeResponse,
-                               gnmi::SubscribeRequest> *stream) override;
-};
+std::unique_ptr<gnmi::gNMI::Service> make_gnmi_service_sysrepo();
 
 }  // namespace server
 

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -580,8 +580,7 @@ void PIGrpcServerRunAddr(const char *server_address) {
     &server_data->server_port);
   builder.RegisterService(&server_data->pi_service);
 #ifdef WITH_SYSREPO
-  server_data->gnmi_service = std::unique_ptr<gnmi::gNMI::Service>(
-      new pi::server::gNMIServiceSysrepoImpl());
+  server_data->gnmi_service = ::pi::server::make_gnmi_service_sysrepo();
 #else
   server_data->gnmi_service = std::unique_ptr<gnmi::gNMI::Service>(
       new pi::server::gNMIServiceImpl());

--- a/proto/sysrepo/install_yangs.sh.in
+++ b/proto/sysrepo/install_yangs.sh.in
@@ -2,13 +2,19 @@
 
 set -e
 
-sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-interfaces@2014-05-08.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/yang/iana-if-type.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-inet-types@2013-07-15.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-netconf-acm@2012-02-22.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-netconf@2011-06-01.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/yang/ietf-netconf-notifications.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/openconfig-extensions.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/types/openconfig-types.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/types/openconfig-yang-types.yang
-sysrepoctl -i -S --yang @abs_top_srcdir@/openconfig/public/release/models/interfaces/openconfig-interfaces.yang
+OPENCONFIG_ROOT="@abs_top_srcdir@/openconfig/public/release/models"
+
+SEARCH_DIRS="-s @abs_top_srcdir@/yang \
+-s $OPENCONFIG_ROOT \
+-s $OPENCONFIG_ROOT/types"
+
+YANGS="@abs_top_srcdir@/yang/iana-if-type.yang \
+$OPENCONFIG_ROOT/interfaces/openconfig-interfaces.yang \
+$OPENCONFIG_ROOT/platform/openconfig-platform.yang"
+
+# Sysrepo deamon complains if this is missing
+YANGS="$YANGS @abs_top_srcdir@/yang/ietf-netconf-notifications.yang"
+
+for YANG in $YANGS; do
+    sysrepoctl -i $SEARCH_DIRS --yang $YANG
+done


### PR DESCRIPTION
gNMI does not assume that the module name is included in the path, as
long as there is no ambiguity, i.e. no overlap in the implemented
schemas. However, sysrepo does require the module name as a namespace
qualifier for the first element in the path. To retrieve the module
name, we iterate over all the schemas explicitly installed (aka
implementeed) in sysrepo and look at the root node(s) for each one. We
then associate that root node name to the corresponding schema name,
which lets us do the conversion from gNMI path to sysrepo XPath.

In order to implement this, we need to be able to differentiate between
modules which are installed / implemented in sysrepo and modules which
are simply imported, for which there is no data tree. For example,
openconfig-interfaces dependends on ietf-interfaces. Both YANG modules
define a "interfaces" tree. If we install both, we will end up with both
data trees and we will not be able to infer the correct namespace
qualifier (in our case oepnconfig-interfaces) from the gNMI path using
the technique described above. We therefore updated the install_yangs.sh
script to only install the models we intend to support.

The update to install_yangs.sh requires the ability to provide multiple
search directories to sysrepoctl. This is only supported in the latest
sysrepo version (0.7.2) which is why we have updated the version
requirement in the README.

Finally, this commit also installs the openconfig-platform YANG model,
even though we are not doing anything with it yet in bmv2.