### PR TITLE
Do not assert on read when priority set for exact

### DIFF
--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -67,6 +67,8 @@ class DummySwitchMock {
 
   pi_status_t packetin_inject(const std::string &packet) const;
 
+  void set_p4info(const pi_p4info_t *p4info);
+
   MOCK_METHOD4(table_entry_add,
                pi_status_t(pi_p4_id_t, const pi_match_key_t *,
                            const pi_table_entry_t *, pi_entry_handle_t *));


### PR DESCRIPTION
The priority value in the TableEntry message only has meaning for
ternary matches. Targets may not store the unsolicited priority value
when one is provided for a non-ternary table - this is the case of
bmv2 -, which means the priority value may not be returned by a table
read operation. The P4 Runtime server implementation expects the target
to return entries which are identical to the ones written, which was
causing a crash. For now, we simply ignore unsolicited priority
values. A better fix may have been to ignore the priority when comparing
match keys for non-ternary tables in the table_info_store, but the
required changes would have been more complex.

The best thing to do would probably be to return an error for
unsolicited priority values, which requires updating the P4 Runtime
specification.

We added a gtest to make sure the crash was fixed: it required making
the table implementation in the mock switch aware of the table match
type, which is why this commit is quite large.