### PR TITLE
Tentative support for gNMI.Set + gNMI unit tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 **/.gitmodules
 **/.travis.yml
 **/Dockerfile
+**/Dockerfile.bmv2
 **/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV PI_DEPS automake \
 ENV PI_RUNTIME_DEPS libboost-system1.58.0 \
                     libjudydebian1 \
                     python
+
 COPY . /PI/
 WORKDIR /PI/
 RUN apt-get update && \

--- a/Dockerfile.bmv2
+++ b/Dockerfile.bmv2
@@ -42,6 +42,8 @@ ENV PI_RUNTIME_DEPS libboost-system1.58.0 \
                     libjudydebian1 \
                     libpcap0.8 \
                     python
+
+COPY proto/sysrepo/docker_entry_point.sh /docker_entry_point.sh
 COPY . /PI/
 WORKDIR /PI/
 RUN apt-get update && \
@@ -51,6 +53,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends $PI_DEPS $PI_RUNTIME_DEPS && \
     ./autogen.sh && \
     ./configure --with-bmv2 --with-proto --with-sysrepo && \
+    ./proto/sysrepo/install_yangs.sh && \
     make && \
     make install-strip && \
     (test "$IMAGE_TYPE" = "build" && \
@@ -60,3 +63,6 @@ RUN apt-get update && \
       echo 'Build image ready') || \
     (test "$IMAGE_TYPE" = "test" && \
       echo 'Test image ready')
+
+# start sysrepo daemon (sysrepod)
+ENTRYPOINT ["/docker_entry_point.sh"]

--- a/proto/server/gnmi_sysrepo.cpp
+++ b/proto/server/gnmi_sysrepo.cpp
@@ -20,21 +20,23 @@
 
 #include "gnmi.h"
 
+extern "C" {
+
+#include <libyang/libyang.h>
+#include <sysrepo.h>
+#include <sysrepo/values.h>
+#include <sysrepo/xpath.h>
+
+}
+
 #include <grpc++/grpc++.h>
 
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <unordered_map>
-
-extern "C" {
-
-#include "libyang/libyang.h"
-#include "sysrepo.h"
-#include "sysrepo/values.h"
-#include "sysrepo/xpath.h"
-
-}
+#include <vector>
 
 #include "gnmi/gnmi.grpc.pb.h"
 #include "log.h"
@@ -54,17 +56,17 @@ void convertFromXPath(char *xpath, gnmi::Path *gpath) {
   sr_xpath_ctx_t ctx;
   char *node = xpath;
   char *xpath_ = xpath;
-  while ((node = sr_xpath_next_node(xpath_, &ctx)) != NULL) {
+  while ((node = sr_xpath_next_node(xpath_, &ctx)) != nullptr) {
     auto *pElem = gpath->add_elem();
     pElem->set_name(node);
     char *kn;
     auto *keys = pElem->mutable_key();
-    while ((kn = sr_xpath_next_key_name(NULL, &ctx)) != NULL) {
+    while ((kn = sr_xpath_next_key_name(nullptr, &ctx)) != nullptr) {
       std::string kName(kn);  // needed here because sr_xpath_* mutates string
-      auto *kv = sr_xpath_node_key_value(NULL, kn, &ctx);
+      auto *kv = sr_xpath_node_key_value(nullptr, kn, &ctx);
       (*keys)[kName] = kv;
     }
-    xpath_ = NULL;
+    xpath_ = nullptr;
   }
 }
 
@@ -148,13 +150,79 @@ void convertToTypedValue(const sr_val_t *value, gnmi::TypedValue *typedV) {
   }
 }
 
+std::string convertDecimal64ToStr(const gnmi::Decimal64 &dec64) {
+  auto pow10 = [](uint32_t n) {
+    int64_t v = 1;
+    while (n) {
+      if (n & 1) {
+        v *= 10;
+        n--;
+      } else {
+        v = v * v;
+        n >>= 1;
+      }
+    }
+    return v;
+  };
+  int64_t multiplier = pow10(dec64.precision());
+  int64_t before_dec = dec64.digits() / multiplier;
+  int64_t after_dec = std::abs(dec64.digits() - (before_dec * multiplier));
+  auto after_dec_str = std::to_string(after_dec);
+  uint32_t zero_padding = dec64.precision() - after_dec_str.size();
+  return std::to_string(before_dec) + "." + std::string(zero_padding, '0')
+      + after_dec_str;
+}
+
+bool isTypedValueScalar(const gnmi::TypedValue &typedV) {
+  switch (typedV.value_case()) {
+    case gnmi::TypedValue::kStringVal:
+    case gnmi::TypedValue::kIntVal:
+    case gnmi::TypedValue::kUintVal:
+    case gnmi::TypedValue::kBoolVal:
+    case gnmi::TypedValue::kBytesVal:
+    case gnmi::TypedValue::kFloatVal:
+    case gnmi::TypedValue::kDecimalVal:
+      return true;
+    case gnmi::TypedValue::kLeaflistVal:
+      return false;
+    default:
+      return false;
+  }
+}
+
+bool isTypedValueLeaf(const gnmi::TypedValue &typedV) {
+  return isTypedValueScalar(typedV) ||
+      typedV.value_case() == gnmi::TypedValue::kLeaflistVal;
+}
+
+std::string convertLeafTypedValueToStr(const gnmi::TypedValue &typedV) {
+  switch (typedV.value_case()) {
+    case gnmi::TypedValue::kStringVal:
+      return typedV.string_val();
+    case gnmi::TypedValue::kIntVal:
+      return std::to_string(typedV.int_val());
+    case gnmi::TypedValue::kUintVal:
+      return std::to_string(typedV.uint_val());
+    case gnmi::TypedValue::kBoolVal:
+      return typedV.bool_val() ? "true" : "false";
+    case gnmi::TypedValue::kBytesVal:
+      return typedV.bytes_val();
+    case gnmi::TypedValue::kFloatVal:
+      return std::to_string(typedV.float_val());
+    case gnmi::TypedValue::kDecimalVal:
+      return convertDecimal64ToStr(typedV.decimal_val());
+    default:
+      return "";
+  }
+}
+
 // opens a session to sysrepo and keep it open until the object is destroyed
 struct SysrepoSession {
   SysrepoSession() = default;
 
   ~SysrepoSession() {
-    if (sess != NULL) sr_session_stop(sess);
-    if (conn != NULL) sr_disconnect(conn);
+    if (sess != nullptr) sr_session_stop(sess);
+    if (conn != nullptr) sr_disconnect(conn);
   }
 
   bool open() {
@@ -166,14 +234,86 @@ struct SysrepoSession {
     return true;
   }
 
-  sr_conn_ctx_t *conn{NULL};
-  sr_session_ctx_t *sess{NULL};
+  sr_conn_ctx_t *conn{nullptr};
+  sr_session_ctx_t *sess{nullptr};
 };
 
 // checks if str starts with substr
 bool starts_with(const std::string &str, const std::string &substr) {
   return str.substr(0, substr.size()) == substr;
 }
+
+// This class lists all the openconfig modules installed in sysrepo and loads
+// them into a libyang context. This is useful for mapping a gNMI path to the
+// corresponding module. This may be useful in the future for other things.
+class LYContext {
+ public:
+  using Map = std::unordered_map<std::string, const struct lys_module *>;
+  using iterator = Map::iterator;
+  using const_iterator = Map::const_iterator;
+
+  LYContext() {
+    parse_schemas();
+  }
+
+  const struct lys_module *get_module(const std::string &origin) const {
+    auto it = modules.find(origin);
+    return (it == modules.end()) ? nullptr : it->second;
+  }
+
+  ~LYContext() {
+    if (ctx != nullptr) {
+      ly_ctx_clean(ctx, nullptr);
+      ly_ctx_destroy(ctx, nullptr);
+    }
+  }
+
+  iterator begin() { return modules.begin(); }
+  const_iterator begin() const { return modules.begin(); }
+  iterator end() { return modules.end(); }
+  const_iterator end() const { return modules.end(); }
+
+ private:
+  void parse_schemas() {
+    SysrepoSession session;
+    if (!session.open()) return;
+    sr_schema_t *schemas = nullptr;
+    size_t schema_cnt = 0;
+    struct ly_ctx *ctx = ly_ctx_new(nullptr, 0);
+    int rc = 0;
+    rc = sr_list_schemas(session.sess, &schemas, &schema_cnt);
+    if (rc != SR_ERR_OK) return;
+
+    auto dirname = [](const std::string &path) {
+      auto sep_pos = path.find_last_of('/');
+      if (sep_pos == std::string::npos) return path;
+      return path.substr(0, sep_pos);
+    };
+
+    for (size_t i = 0; i < schema_cnt; i++) {
+      if (!schemas[i].installed) continue;
+      const char *module_name = schemas[i].module_name;
+      // Avoid issues if different modules with colliding paths are installed.
+      // For example, if both openconfig-interfaces and ietf-interfaces are
+      // installed. Since we only support modules in the openconfig tree for
+      // now, this check makes sense.
+      // See https://github.com/sysrepo/sysrepo/issues/1015
+      if (!starts_with(module_name, "openconfig")) continue;
+      const char *path_yang = schemas[i].revision.file_path_yang;
+      if (ly_ctx_set_searchdir(ctx, dirname(path_yang).c_str()) != EXIT_SUCCESS)
+        continue;
+      const struct lys_module *module = lys_parse_path(
+          ctx, path_yang, LYS_IN_YANG);
+      if (module == nullptr) continue;
+      modules.emplace(module_name, module);
+    }
+
+    sr_free_schemas(schemas, schema_cnt);
+  }
+
+  struct ly_ctx *ctx{nullptr};
+  std::unordered_map<std::string, const struct lys_module *> modules{};
+};
 
 // Utility class to convert gNMI paths to XPaths that sysrepo can understand
 // The difficulty is that gNMI does not assume that the module name is included
@@ -186,7 +326,8 @@ bool starts_with(const std::string &str, const std::string &substr) {
 // conversion from gNMI path to sysrepo XPath.
 class XPathBuilder {
  public:
-  XPathBuilder() {
+  explicit XPathBuilder(LYContext *LY_ctx)
+      : LY_ctx(LY_ctx) {
     scan_schemas();
   }
 
@@ -239,54 +380,136 @@ class XPathBuilder {
  private:
   // TODO(antonin): handle errors in scan_schemas
   void scan_schemas() {
-    SysrepoSession session;
-    if (!session.open()) return;
-    sr_schema_t *schemas = NULL;
-    size_t schema_cnt = 0;
-    struct ly_ctx *ctx = ly_ctx_new(NULL, 0);
-    int rc = 0;
-    rc = sr_list_schemas(session.sess, &schemas, &schema_cnt);
-    if (rc != SR_ERR_OK) return;
-
-    auto dirname = [](const std::string &path) {
-      auto sep_pos = path.find_last_of('/');
-      if (sep_pos == std::string::npos) return path;
-      return path.substr(0, sep_pos);
-    };
-
-    for (size_t i = 0; i < schema_cnt; i++) {
-      if (!schemas[i].installed) continue;
-      const char *module_name = schemas[i].module_name;
-      // Avoid issues if different modules with colliding paths are installed.
-      // For example, if both openconfig-interfaces and ietf-interfaces are
-      // installed. Since we only support modules in the openconfig tree for
-      // now, this check makes sense.
-      // See https://github.com/sysrepo/sysrepo/issues/1015
-      if (!starts_with(module_name, "openconfig")) continue;
-      const char *path_yang = schemas[i].revision.file_path_yang;
-      if (ly_ctx_set_searchdir(ctx, dirname(path_yang).c_str()) != EXIT_SUCCESS)
-        continue;
-      const struct lys_module *module = lys_parse_path(
-          ctx, path_yang, LYS_IN_YANG);
-      if (module == NULL) continue;
-      const struct lys_node *node = NULL;
-      while ((node = lys_getnext(node, NULL, module, 0)) != NULL) {
+    // iterate over supported modules
+    for (const auto &p : *LY_ctx) {
+      const auto &module_name = p.first;
+      const auto *module = p.second;
+      const struct lys_node *node = nullptr;
+      while ((node = lys_getnext(node, nullptr, module, 0)) != nullptr) {
         auto ns_it = namespace_mapping.find(node->name);
         if (ns_it == namespace_mapping.end()) {
           namespace_mapping.emplace(node->name, module_name);
-          SIMPLELOG << "Path " << node->name << " is in module "
-                    << schemas[i].module_name << "\n";
+          SIMPLELOG << "Path '" << node->name << "' is in module "
+                    << module_name << "\n";
         } else {
-          SIMPLELOG << "Path " << node->name << " is in multiple modules\n";
+          SIMPLELOG << "Path '" << node->name << " 'is in multiple modules\n";
         }
       }
     }
-    ly_ctx_clean(ctx, NULL);
-    ly_ctx_destroy(ctx, NULL);
-    sr_free_schemas(schemas, schema_cnt);
   }
 
+  LYContext *LY_ctx;
   std::unordered_map<std::string, std::string> namespace_mapping{};
+};
+
+std::string extractOrigin(const std::string &path) {
+  if (path.empty()) return "";
+  auto start_pos = (path[0] == '/') ? 1 : 0;
+  auto end_pos = path.find_first_of(':');
+  return (end_pos == std::string::npos) ?
+      path.substr(start_pos) : path.substr(start_pos, end_pos - start_pos);
+}
+
+sr_type_t convert_LY_type_to_sysrepo_type(LY_DATA_TYPE LY_type) {
+  switch (LY_type) {
+    case LY_TYPE_ERR:
+      return SR_UNKNOWN_T;
+    case LY_TYPE_DER:
+      return SR_UNKNOWN_T;
+    case LY_TYPE_BINARY:
+      return SR_BINARY_T;
+    case LY_TYPE_BITS:
+      return SR_BITS_T;
+    case LY_TYPE_BOOL:
+      return SR_BOOL_T;
+    case LY_TYPE_DEC64:
+      return SR_DECIMAL64_T;
+    case LY_TYPE_EMPTY:
+      return SR_LEAF_EMPTY_T;
+    case LY_TYPE_ENUM:
+      return SR_ENUM_T;
+    case LY_TYPE_IDENT:
+      return SR_IDENTITYREF_T;
+    case LY_TYPE_INST:
+      return SR_INSTANCEID_T;
+    case LY_TYPE_LEAFREF:
+      return SR_UNKNOWN_T;
+    case LY_TYPE_STRING:
+      return SR_STRING_T;
+    case LY_TYPE_UNION:
+      return SR_UNKNOWN_T;
+    case LY_TYPE_INT8:
+      return SR_INT8_T;
+    case LY_TYPE_UINT8:
+      return SR_UINT8_T;
+    case LY_TYPE_INT16:
+      return SR_INT16_T;
+    case LY_TYPE_UINT16:
+      return SR_UINT16_T;
+    case LY_TYPE_INT32:
+      return SR_INT32_T;
+    case LY_TYPE_UINT32:
+      return SR_UINT32_T;
+    case LY_TYPE_INT64:
+      return SR_INT64_T;
+    case LY_TYPE_UINT64:
+      return SR_UINT64_T;
+    default:
+      return SR_UNKNOWN_T;
+  }
+  return SR_UNKNOWN_T;
+}
+
+// This class was meant to be used to resolve the type of a node in the schema
+// tree. Because sysrepo offers a set_item_str function, it seems that this
+// class is in fact not needed.
+// TODO(antonin): remove
+class LeafTypeCache {
+ public:
+  explicit LeafTypeCache(LYContext *LY_ctx)
+      : LY_ctx(LY_ctx) { }
+
+  // returns {} if not a leaf
+  // schema_path needs to include origin
+  std::vector<sr_type_t> get_types(sr_session_ctx_t *session,
+                                   const std::string &schema_path) const {
+    auto origin = extractOrigin(schema_path);
+    if (origin == "") return {};
+    const auto *module = LY_ctx->get_module(origin);
+    if (module == nullptr) return {};
+    auto *LY_set = lys_find_path(module, nullptr, schema_path.c_str());
+    if (LY_set == nullptr) return {};
+    // TODO(antonin): when can we have more than one node in the set?
+    if (LY_set->number != 1) return {};
+    auto LY_node = LY_set->set.s[0];
+    if (LY_node->nodetype != LYS_LEAF) {
+      SIMPLELOG << "Schema path " << schema_path << " is not a leaf\n";
+      return {};
+    }
+    auto *LY_leaf = reinterpret_cast<struct lys_node_leaf *>(LY_node);
+    std::vector<sr_type_t> types;
+    get_node_types(&LY_leaf->type, &types);
+    return types;
+  }
+
+ private:
+  void get_node_types(const struct lys_type *LY_type,
+                      std::vector<sr_type_t> *types) const {
+    if (LY_type->base == LY_TYPE_LEAFREF) {
+      const auto *LY_lref = &LY_type->info.lref;
+      const auto *LY_leaf = LY_lref->target;
+      assert(LY_leaf->nodetype == LYS_LEAF);
+      return get_node_types(&LY_leaf->type, types);
+    } else if (LY_type->base == LY_TYPE_UNION) {
+      const auto *LY_union = &LY_type->info.uni;
+      for (unsigned int i = 0; i < LY_union->count; i++)
+        get_node_types(&LY_union->types[i], types);
+    } else {
+      types->push_back(convert_LY_type_to_sysrepo_type(LY_type->base));
+    }
+  }
+
+  LYContext *LY_ctx;
 };
 
 }  // namespace
@@ -310,7 +533,16 @@ class gNMIServiceSysrepoImpl : public gnmi::gNMI::Service {
       grpc::ServerReaderWriter<gnmi::SubscribeResponse,
                                gnmi::SubscribeRequest> *stream) override;
 
-  XPathBuilder xpath_builder;
+  int64_t get_timestamp() const {
+    auto tp = std::chrono::system_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        tp.time_since_epoch()).count();
+    return timestamp;
+  }
+
+  LYContext LY_ctx;
+  XPathBuilder xpath_builder{&LY_ctx};
+  LeafTypeCache leaf_type_cache{&LY_ctx};
 };
 
 std::unique_ptr<gnmi::gNMI::Service> make_gnmi_service_sysrepo() {
@@ -341,10 +573,84 @@ Status
 gNMIServiceSysrepoImpl::Set(ServerContext *context,
                             const gnmi::SetRequest *request,
                             gnmi::SetResponse *response) {
-  (void) context; (void) request; (void) response;
+  (void) context;
   SIMPLELOG << "gNMI Set\n";
   SIMPLELOG << request->DebugString();
-  return Status(StatusCode::UNIMPLEMENTED, "not implemented yet");
+  int rc = SR_ERR_OK;
+  const auto &prefix = request->prefix();
+
+  if (!request->replace().empty())
+    return Status(StatusCode::UNIMPLEMENTED, "'replace' not implemented yet");
+
+  SysrepoSession session;
+  if (!session.open()) {
+    return Status(StatusCode::UNKNOWN,
+                  "Error when connecting to yang datastore");
+  }
+
+  auto make_xpath = [this, &prefix](const gnmi::Path &path,
+                                    std::string *xpath) {
+    xpath_builder.appendToXPath(prefix, xpath);
+    xpath_builder.appendToXPath(path, xpath);
+    if (!xpath_builder.setXPathOrigin(xpath, path.origin())) return false;
+    return true;
+  };
+
+  for (const auto &path : request->delete_()) {
+    std::string xpath;
+    if (!make_xpath(path, &xpath)) {
+      return Status(StatusCode::INVALID_ARGUMENT,
+                    "Cannot convert gNMI path to XPath");
+    }
+    rc = sr_delete_item(session.sess, xpath.c_str(), SR_EDIT_DEFAULT);
+    if (rc != SR_ERR_OK)
+      return Status(StatusCode::UNKNOWN, "Error when deleting item");
+  }
+
+  for (const auto &update : request->update()) {
+    const auto &path = update.path();
+    std::string xpath;
+    if (!make_xpath(path, &xpath)) {
+      return Status(StatusCode::INVALID_ARGUMENT,
+                    "Cannot convert gNMI path to XPath");
+    }
+    const auto &typedV = update.val();
+    if (!isTypedValueLeaf(typedV)) {
+      return Status(StatusCode::UNIMPLEMENTED,
+                    "We only support setting leaves for now");
+    }
+    if (typedV.value_case() == gnmi::TypedValue::kLeaflistVal) {
+      for (const auto &typedV_e : typedV.leaflist_val().element()) {
+        if (!isTypedValueScalar(typedV_e)) {
+          return Status(StatusCode::INVALID_ARGUMENT,
+                        "Leaflist entry must be a scalar");
+        }
+        auto value_str = convertLeafTypedValueToStr(typedV_e);
+        rc = sr_set_item_str(session.sess, xpath.c_str(), value_str.c_str(),
+                             SR_EDIT_DEFAULT);
+        if (rc != SR_ERR_OK)
+          return Status(StatusCode::UNKNOWN,
+                        "Error when setting leaf list element");
+      }
+    } else {
+      auto value_str = convertLeafTypedValueToStr(typedV);
+      rc = sr_set_item_str(session.sess, xpath.c_str(), value_str.c_str(),
+                           SR_EDIT_DEFAULT);
+      if (rc != SR_ERR_OK)
+        return Status(StatusCode::UNKNOWN, "Error when setting item");
+    }
+  }
+
+  rc = sr_commit(session.sess);
+  if (rc != SR_ERR_OK) {
+    return Status(StatusCode::UNKNOWN, "Error when comitting changes");
+    // TODO(antonin): call sr_get_last_errors
+  }
+
+  // TODO(antonin): other response fields
+  response->set_timestamp(get_timestamp());
+
+  return Status::OK;
 }
 
 Status
@@ -367,16 +673,13 @@ gNMIServiceSysrepoImpl::Subscribe(
 
     gnmi::SubscribeResponse response;
     auto *notification = response.mutable_update();
-    auto tp = std::chrono::system_clock::now();
-    auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        tp.time_since_epoch()).count();
-    notification->set_timestamp(timestamp);
+    notification->set_timestamp(get_timestamp());
 
     // TODO(antonin): keep connection open
     SysrepoSession session;
     if (!session.open()) {
       return Status(StatusCode::UNKNOWN,
-                    "Error when connection to yang datastore");
+                    "Error when connecting to yang datastore");
     }
 
     const auto &prefix = sub.prefix();
@@ -390,8 +693,8 @@ gNMIServiceSysrepoImpl::Subscribe(
       }
       SIMPLELOG << "ONCE subscription for XPath: " << xpath << "\n";
 
-      sr_val_t *value = NULL;
-      sr_val_iter_t *iter = NULL;
+      sr_val_t *value = nullptr;
+      sr_val_iter_t *iter = nullptr;
       int rc = SR_ERR_OK;
 
       // get all list instances with their content (recursive)

--- a/proto/sysrepo/docker_entry_point.sh
+++ b/proto/sysrepo/docker_entry_point.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+sysrepod
+# execute docker command
+exec "$@"

--- a/proto/sysrepo/install_yangs.sh.in
+++ b/proto/sysrepo/install_yangs.sh.in
@@ -15,6 +15,13 @@ $OPENCONFIG_ROOT/platform/openconfig-platform.yang"
 # Sysrepo deamon complains if this is missing
 YANGS="$YANGS @abs_top_srcdir@/yang/ietf-netconf-notifications.yang"
 
+# Sysrepocfg cannot export the openconfig-interfaces data tree if this is not
+# explicitly installed.
+# See https://github.com/sysrepo/sysrepo/issues/1015
+# I don't know if this is the intended behavior or an issue, so in the meantime
+# I explicitly install it.
+YANGS="$YANGS @abs_top_srcdir@/yang/ietf-interfaces@2014-05-08.yang"
+
 for YANG in $YANGS; do
     sysrepoctl -i $SEARCH_DIRS --yang $YANG
 done

--- a/proto/tests/server/test_gnmi.cpp
+++ b/proto/tests/server/test_gnmi.cpp
@@ -24,8 +24,15 @@
 
 #include <gnmi/gnmi.grpc.pb.h>
 
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <unordered_map>
 
 #include "gnmi.h"
 
@@ -133,8 +140,191 @@ TEST_F(TestGNMIDummy, SubscribeErrorOnWrite) {
 
 #ifdef WITH_SYSREPO
 
+extern "C" {
+#include <sysrepo.h>
+#include <sysrepo/values.h>
+}
+
+class SysrepoSession {
+ public:
+  ~SysrepoSession() {
+    if (sess != nullptr) sr_session_stop(sess);
+    if (conn != nullptr) sr_disconnect(conn);
+  }
+
+  bool open(const std::string &app_name) {
+    int rc = SR_ERR_OK;
+    rc = sr_connect(app_name.c_str(), SR_CONN_DEFAULT, &conn);
+    if (rc != SR_ERR_OK) return false;
+    rc = sr_session_start(conn, SR_DS_RUNNING, SR_SESS_DEFAULT, &sess);
+    return rc == SR_ERR_OK;
+  }
+
+  sr_session_ctx_t *get() const { return sess; }
+
+ private:
+  sr_conn_ctx_t *conn{nullptr};
+  sr_session_ctx_t *sess{nullptr};
+};
+
+struct Event {
+  std::string xpath;
+  sr_change_oper_t oper;
+  std::string new_v_str;
+};
+
+class SysrepoEventQueue {
+ public:
+  void push_front(Event &&e) {
+    Lock lock(q_mutex);
+    queue.push_front(std::move(e));
+    lock.unlock();
+    q_not_empty.notify_one();
+  }
+
+  bool pop_back(Event *pE) {
+    Lock lock(q_mutex);
+    q_not_empty.wait(lock, [this]{ return !is_not_empty(); });
+    *pE = std::move(queue.back());
+    queue.pop_back();
+    return true;
+  }
+
+  bool pop_back(Event *pE, const std::chrono::milliseconds &max_wait) {
+    Lock lock(q_mutex);
+    auto success = q_not_empty.wait_for(
+        lock, max_wait, [this]{ return is_not_empty(); });
+    if (!success) return false;
+    *pE = std::move(queue.back());
+    queue.pop_back();
+    return true;
+  }
+
+  size_t size() const {
+    Lock lock(q_mutex);
+    return queue.size();
+  }
+
+  bool empty() const {
+    Lock lock(q_mutex);
+    return queue.empty();
+  }
+
+  void clear() {
+    Lock lock(q_mutex);
+    queue.clear();
+  }
+
+ private:
+  bool is_not_empty() const { return queue.size() > 0; }
+
+  using Lock = std::unique_lock<std::mutex>;
+  std::deque<Event> queue;
+  mutable std::mutex q_mutex;
+  mutable std::condition_variable q_not_empty;
+};
+
+#define XPATH_MAX_LEN 256
+#define VAL_STR_MAX_LEN 256
+
+int module_change_cb(sr_session_ctx_t *session, const char *module_name,
+                     sr_notif_event_t event, void *private_ctx) {
+  (void) event;
+
+  sr_change_iter_t *it = nullptr;
+  int rc = SR_ERR_OK;
+  sr_change_oper_t oper;
+  sr_val_t *old_value = nullptr;
+  sr_val_t *new_value = nullptr;
+  char val_str[VAL_STR_MAX_LEN] = {};
+
+  assert(event == SR_EV_APPLY);  // we subscribed with SR_SUBSCR_APPLY_ONLY
+
+  std::string change_path("/");
+  change_path.append(module_name).append(":*");
+
+  rc = sr_get_changes_iter(session, change_path.c_str(), &it);
+  assert(rc == SR_ERR_OK);
+
+  auto *event_queue = static_cast<SysrepoEventQueue *>(private_ctx);
+
+  while ((rc = sr_get_change_next(session, it, &oper, &old_value, &new_value))
+         == SR_ERR_OK) {
+    if (new_value->type >= SR_LEAF_EMPTY_T && !new_value->dflt) {
+      sr_val_to_buff(new_value, val_str, sizeof(val_str));
+      std::cout << "CHANGE for " << new_value->xpath << ": " << val_str << "\n";
+      event_queue->push_front(
+          {std::string(new_value->xpath), oper, std::string(val_str)});
+    }
+    sr_free_val(old_value);
+    sr_free_val(new_value);
+  }
+
+  sr_free_change_iter(it);
+
+  return SR_ERR_OK;
+}
+
+#undef XPATH_MAX_LEN
+#undef VAL_STR_MAX_LEN
+
+class SysrepoSubscriber {
+ public:
+  SysrepoSubscriber(const std::string &module_name, const std::string &app_name)
+      : module_name(module_name), app_name(app_name) { }
+
+  ~SysrepoSubscriber() {
+    if (subscription != nullptr) {
+      sr_unsubscribe(session.get(), subscription);
+      subscription = nullptr;
+    }
+  }
+
+  bool subscribe(SysrepoEventQueue *event_queue) {
+    session.open(app_name);
+    int rc = sr_module_change_subscribe(
+        session.get(), module_name.c_str(), module_change_cb,
+        static_cast<void *>(event_queue), 0, SR_SUBSCR_APPLY_ONLY,
+        &subscription);
+    return rc == SR_ERR_OK;
+  }
+
+ private:
+  std::string module_name;
+  std::string app_name;
+  SysrepoSession session;
+  sr_subscription_ctx_t *subscription{nullptr};
+};
+
+class GNMIPathBuilder {
+ public:
+  explicit GNMIPathBuilder(gnmi::Path *path)
+      : path(path) { }
+
+  GNMIPathBuilder &append(const std::string &name,
+                          const std::map<std::string, std::string> &keys = {}) {
+    auto *e = path->add_elem();
+    e->set_name(name);
+    e->mutable_key()->insert(keys.begin(), keys.end());
+    return *this;
+  }
+
+ private:
+  gnmi::Path *path;
+};
+
+// We could find a way to mock sysrepo for this. However, we are really trying
+// to verify end-to-end functionality here. We need to make sure that we are
+// using the sysrepo client library correctly and that sysrepo is doing the
+// right thing, as it is not very mature yet.
+
+// The test assumes that openconfig-interfaces is implemented in sysrepo
+
 class TestGNMISysrepo : public TestGNMI {
  protected:
+  TestGNMISysrepo()
+      : sub("openconfig-interfaces", "sub") { }
+
   static void SetUpTestCase() {
     setup_server(pi::server::make_gnmi_service_sysrepo());
   }
@@ -142,9 +332,95 @@ class TestGNMISysrepo : public TestGNMI {
   static void TearDownTestCase() {
     teardown_server();
   }
+
+  void SetUp() override {
+    ASSERT_TRUE(session.open("test"));
+    ASSERT_TRUE(cleanup_data_tree());
+    ASSERT_TRUE(sub.subscribe(&event_queue));
+  }
+
+  void TearDown() override {
+    ASSERT_TRUE(cleanup_data_tree());
+  }
+
+  bool cleanup_data_tree() const {
+    int rc = sr_delete_item(
+        session.get(), "/openconfig-interfaces:*", SR_EDIT_DEFAULT);
+    return rc == SR_ERR_OK;
+  }
+
+  gnmi::SetRequest create_iface(const std::string &name) {
+    gnmi::SetRequest req;
+    GNMIPathBuilder pb(req.mutable_prefix());
+    pb.append("interfaces").append("interface", {{"name", name}})
+        .append("config");
+    {
+      auto *update = req.add_update();
+      GNMIPathBuilder pb(update->mutable_path());
+      pb.append("name");
+      update->mutable_val()->set_string_val(name);
+    }
+    {
+      auto *update = req.add_update();
+      GNMIPathBuilder pb(update->mutable_path());
+      pb.append("type");
+      update->mutable_val()->set_string_val("iana-if-type:ethernetCsmacd");
+    }
+    return req;
+  }
+
+  std::unordered_map<std::string, Event> get_events(size_t num_events) {
+    std::unordered_map<std::string, Event> events;
+    for (size_t i = 0; i < num_events; i++) {
+      Event event;
+      if (!event_queue.pop_back(&event, std::chrono::milliseconds(500)))
+        break;
+      events.emplace(event.xpath, std::move(event));
+    }
+    return events;
+  }
+
+  bool no_more_events(
+      std::chrono::milliseconds wait = std::chrono::milliseconds(200)) {
+    std::this_thread::sleep_for(wait);
+    return event_queue.empty();
+  }
+
+  SysrepoSession session{};
+  // event_queue needs to be constructed before sub and destroyed after
+  SysrepoEventQueue event_queue;
+  SysrepoSubscriber sub;
 };
 
-TEST_F(TestGNMISysrepo, Dummy) { }
+TEST_F(TestGNMISysrepo, Set) {
+  const std::string iface_name("eth0");
+  auto req = create_iface(iface_name);
+  gnmi::SetResponse rep;
+  ClientContext context;
+  auto status = gnmi_stub->Set(&context, req, &rep);
+  EXPECT_TRUE(status.ok());
+  // name, config/name, config/type
+  size_t num_expected_events = 3u;
+  auto events = get_events(num_expected_events);
+  ASSERT_EQ(events.size(), num_expected_events);
+  auto check_event = [&events](const Event &expected_event) {
+    auto it = events.find(expected_event.xpath);
+    ASSERT_NE(it, events.end());
+    const auto &event = it->second;
+    EXPECT_EQ(event.oper, expected_event.oper);
+    EXPECT_EQ(event.new_v_str, expected_event.new_v_str);
+  };
+  check_event({
+      "/openconfig-interfaces:interfaces/interface[name='eth0']/name",
+      SR_OP_CREATED, iface_name});
+  check_event({
+      "/openconfig-interfaces:interfaces/interface[name='eth0']/config/name",
+      SR_OP_CREATED, iface_name});
+  check_event({
+      "/openconfig-interfaces:interfaces/interface[name='eth0']/config/type",
+      SR_OP_CREATED, "iana-if-type:ethernetCsmacd"});
+  EXPECT_TRUE(no_more_events());
+}
 
 #endif  // WITH_SYSREPO
 


### PR DESCRIPTION
This PR introduces support for setting leaf data nodes with
gNMI.Set. We use sysrepo's sr_set_item_str to easily convert from
protobuf leaf types to sysrepo leaf types. We only support update and
delete for now, not replace operations (see gNMI specification for
difference in semantics between update and replace).

We also introduce a first gtest for the sysrepo gNMI
implementation. This is a test for gNMI.Set/update (leaf node). We will
be adding a test for gNMI.Set/delete and a test for gNMI.Subscribe/ONCE
very soon.

In order to run the gNMI tests in the Docker image, we need to make sure
that the sysrepo daemon is running, which is why we have defined an
ENTRY_POINT to start sysrepod in Dockerfile.bmv2 (which is the Docker
image we use for CI testing).

This PR also updates the openconfig/public submodule ref pointer (to
get the latest version of the Openconfig YANG models).