### PR TITLE
Add openconfig-if-ethernet.yang to supported models

### DIFF
--- a/proto/sysrepo/install_yangs.sh.in
+++ b/proto/sysrepo/install_yangs.sh.in
@@ -22,6 +22,15 @@ YANGS="$YANGS @abs_top_srcdir@/yang/ietf-netconf-notifications.yang"
 # I explicitly install it.
 YANGS="$YANGS @abs_top_srcdir@/yang/ietf-interfaces@2014-05-08.yang"
 
+# Sysrepo does not support when conditions involving operational state in YANG
+# This is my workaround
+# See https://github.com/sysrepo/sysrepo/issues/1018
+# The generated file is never cleaned up so 'make distcheck' will probably fail
+mkdir -p @abs_builddir@
+@SED@ 's;when "oc-if:state/oc-if:type;when "oc-if:config/oc-if:type;g' \
+ $OPENCONFIG_ROOT/interfaces/openconfig-if-ethernet.yang > @abs_builddir@/openconfig-if-ethernet.yang
+YANGS="$YANGS @abs_builddir@/openconfig-if-ethernet.yang"
+
 for YANG in $YANGS; do
     sysrepoctl -i $SEARCH_DIRS --yang $YANG
 done


### PR DESCRIPTION
This YANG model augments openconfig-interfaces for ethernet interfaces.
This commit includes a work-around to bypass a sysrepo
restriction. sysrepo does not seem to be supporting "when" statements
involving operational state in the YANG. Therefore when loading the YANG
model into sysrepo, we do a sed to replace `when
"oc-if:state/oc-if:type"` with `when "oc-if:config/oc-if:type"`/