### PR TITLE
Added new APIs PIGrpcServerGetPacketInCount and PIGrpcServerGetPacketOutCount for testing and debugging

### DIFF
--- a/proto/server/PI/proto/pi_server.h
+++ b/proto/server/PI/proto/pi_server.h
@@ -33,6 +33,12 @@ void PIGrpcServerRunAddr(const char *server_address);
 // Get port number bound to the server
 int PIGrpcServerGetPort();
 
+// Get number of PacketIn packets sent to client
+uint64_t PIGrpcServerGetPacketInCount(uint64_t device_id);
+
+// Get number of PacketOut packets sent to DevMgr
+uint64_t PIGrpcServerGetPacketOutCount(uint64_t device_id);
+
 // Wait for the server to shutdown. Note that some other thread must be
 // responsible for shutting down the server for this call to ever return.
 void PIGrpcServerWait();

--- a/proto/tests/server/test_arbitration.cpp
+++ b/proto/tests/server/test_arbitration.cpp
@@ -218,9 +218,12 @@ TEST_F(TestArbitration, WriteAndPacketInAndPacketOut) {
 
   EXPECT_EQ(read_arbitration_status(stream_master.get()).code(),
             ::google::rpc::Code::OK);
+  EXPECT_EQ(PIGrpcServerGetPacketInCount(device_id), 0u);
+  EXPECT_EQ(PIGrpcServerGetPacketOutCount(device_id), 0u);
   check_write(master_id, true);
   check_packet_in(stream_master.get());
   check_packet_out(stream_master.get());
+  EXPECT_EQ(PIGrpcServerGetPacketInCount(device_id), 1u);
 
   ClientContext stream_slave_context;
   auto stream_slave = stream_setup(&stream_slave_context, slave_id);
@@ -232,6 +235,7 @@ TEST_F(TestArbitration, WriteAndPacketInAndPacketOut) {
   check_write(slave_id, false);
   check_packet_in(stream_master.get());
   check_packet_out(stream_master.get());
+  EXPECT_EQ(PIGrpcServerGetPacketInCount(device_id), 2u);
 
   EXPECT_TRUE(stream_teardown(std::move(stream_master)).ok());
 
@@ -240,6 +244,7 @@ TEST_F(TestArbitration, WriteAndPacketInAndPacketOut) {
   check_write(slave_id, true);
   check_packet_in(stream_slave.get());
   check_packet_out(stream_slave.get());
+  EXPECT_EQ(PIGrpcServerGetPacketInCount(device_id), 3u);
 
   EXPECT_TRUE(stream_teardown(std::move(stream_slave)).ok());
 }


### PR DESCRIPTION
The APIs return the number of StreamMessageResponse packets sent to grpc client and PacketOut messages sent to DeviceMgr respectively
  