### PR TITLE
Stricter match field format for ternary matches

### DIFF
--- a/proto/docs/p4runtime.md
+++ b/proto/docs/p4runtime.md
@@ -178,9 +178,13 @@ switch(p4_type(match.field_id())) {
   case TERNARY:
     assert(match.has_ternary())
     assert(!match.ternary().value().empty() && !match.ternary().mask().empty())
+    assert(match.ternary().value() ==
+           (match.ternary().value() & match.ternary().mask()))
   case LPM:
     assert(match.has_lpm())
     assert(!match.lpm().value().empty() && match.lpm().prefix_len() > 0)
+    assert(count_trailing_zeros(match.lpm().value()) >=
+           p4_bitwidth(match.field_id()) - match.lpm().prefix_len())
   case RANGE:
     Integer low, high;
     assert(match.has_range())

--- a/proto/docs/p4runtime.md
+++ b/proto/docs/p4runtime.md
@@ -176,14 +176,16 @@ switch(p4_type(match.field_id())) {
   case EXACT:
     assert(match.has_exact() && !match.exact().value().empty())
   case TERNARY:
+    Integer value, mask;
     assert(match.has_ternary())
     assert(!match.ternary().value().empty() && !match.ternary().mask().empty())
-    assert(match.ternary().value() ==
-           (match.ternary().value() & match.ternary().mask()))
+    assert(parseInteger(match.ternary().value(), &value))
+    assert(parseInteger(match.ternary().mask(), &mask))
+    assert(value == (value & mask))
   case LPM:
     assert(match.has_lpm())
     assert(!match.lpm().value().empty() && match.lpm().prefix_len() > 0)
-    assert(count_trailing_zeros(match.lpm().value()) >=
+    assert(countTrailingZeros(match.lpm().value()) >=
            p4_bitwidth(match.field_id()) - match.lpm().prefix_len())
   case RANGE:
     Integer low, high;

--- a/proto/frontend/src/common.cpp
+++ b/proto/frontend/src/common.cpp
@@ -32,20 +32,24 @@ namespace common {
 
 namespace {
 
-uint8_t clz(uint8_t b) {
-  static constexpr uint8_t clz_table_hb[16] =
+// count leading zeros in byte
+uint8_t clz(uint8_t byte) {
+  static constexpr uint8_t clz_table[16] =
       {4, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0};
-  uint8_t hb0 = b >> 4;
-  uint8_t hb1 = b & 0x0f;
-  return (hb0 == 0) ? (4 + clz_table_hb[hb1]) : clz_table_hb[hb0];
+  uint8_t half_byte_hi = byte >> 4;
+  uint8_t half_byte_lo = byte & 0x0f;
+  return (half_byte_hi == 0) ?
+      (4 + clz_table[half_byte_lo]) : clz_table[half_byte_hi];
 }
 
+// count trailing zeros in byte
 uint8_t ctz(uint8_t b) {
-  static constexpr uint8_t ctz_table_hb[16] =
+  static constexpr uint8_t ctz_table[16] =
       {4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0};
-  uint8_t hb0 = b >> 4;
-  uint8_t hb1 = b & 0x0f;
-  return (hb1 == 0) ? (4 + ctz_table_hb[hb0]) : ctz_table_hb[hb1];
+  uint8_t half_byte_hi = b >> 4;
+  uint8_t half_byte_lo = b & 0x0f;
+  return (half_byte_lo == 0) ?
+      (4 + ctz_table[half_byte_hi]) : ctz_table[half_byte_lo];
 }
 
 }  // namespace
@@ -60,7 +64,10 @@ Code check_proto_bytestring(const std::string &str, size_t nbits) {
 }
 
 bool check_prefix_trailing_zeros(const std::string &str, int pLen) {
-  size_t trailing_zeros = str.size() * 8 - pLen;
+  size_t bitwidth = str.size() * 8;
+  // must be guaranteed by caller
+  assert(pLen >= 0 && static_cast<size_t>(pLen) <= bitwidth);
+  size_t trailing_zeros = bitwidth - pLen;
   size_t pos = str.size() - 1;
   for (; trailing_zeros >= 8; trailing_zeros -= 8) {
     if (str[pos] != 0) return false;

--- a/proto/frontend/src/common.cpp
+++ b/proto/frontend/src/common.cpp
@@ -40,6 +40,14 @@ uint8_t clz(uint8_t b) {
   return (hb0 == 0) ? (4 + clz_table_hb[hb1]) : clz_table_hb[hb0];
 }
 
+uint8_t ctz(uint8_t b) {
+  static constexpr uint8_t ctz_table_hb[16] =
+      {4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0};
+  uint8_t hb0 = b >> 4;
+  uint8_t hb1 = b & 0x0f;
+  return (hb1 == 0) ? (4 + ctz_table_hb[hb0]) : ctz_table_hb[hb1];
+}
+
 }  // namespace
 
 Code check_proto_bytestring(const std::string &str, size_t nbits) {
@@ -49,6 +57,17 @@ Code check_proto_bytestring(const std::string &str, size_t nbits) {
   auto not_zero_pos = static_cast<size_t>(clz(static_cast<uint8_t>(str[0])));
   if (not_zero_pos < zero_nbits) return Code::INVALID_ARGUMENT;
   return Code::OK;
+}
+
+bool check_prefix_trailing_zeros(const std::string &str, int pLen) {
+  size_t trailing_zeros = str.size() * 8 - pLen;
+  size_t pos = str.size() - 1;
+  for (; trailing_zeros >= 8; trailing_zeros -= 8) {
+    if (str[pos] != 0) return false;
+    pos--;
+  }
+  return (trailing_zeros == 0) ||
+      (ctz(static_cast<uint8_t>(str[pos])) >= trailing_zeros);
 }
 
 std::string range_default_lo(size_t nbits) {

--- a/proto/frontend/src/common.h
+++ b/proto/frontend/src/common.h
@@ -59,6 +59,8 @@ struct SessionTemp {
 
 Code check_proto_bytestring(const std::string &str, size_t nbits);
 
+bool check_prefix_trailing_zeros(const std::string &str, int pLen);
+
 std::string range_default_lo(size_t nbits);
 std::string range_default_hi(size_t nbits);
 

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -1062,6 +1062,10 @@ class DeviceMgrImp {
       RETURN_ERROR_STATUS(
           Code::INVALID_ARGUMENT, "Prefix length cannot be < 0");
     }
+    if (static_cast<size_t>(pLen) > bitwidth) {
+      RETURN_ERROR_STATUS(
+          Code::INVALID_ARGUMENT, "Prefix length cannot be > bitwidth");
+    }
     // makes sure that value ends with zeros
     if (!common::check_prefix_trailing_zeros(value, pLen)) {
       RETURN_ERROR_STATUS(


### PR DESCRIPTION
We require that no unused bit be set in ternary (and LPM) match field
values. If this is violated, the P4 Runtime server must return an
INVALID_ARGUMENT error.