### PR TITLE
Update p4runtime.proto

### DIFF
--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -452,10 +452,6 @@ message SetForwardingPipelineConfigRequest {
   Uint128 election_id = 2;
   Action action = 3;
   ForwardingPipelineConfig config = 4;
-
-  // TODO(wmohsin): Remove when clients have migrated to 'device_id' and
-  // 'config' above.
-  repeated ForwardingPipelineConfig configs = 5 [deprecated = true];
 }
 
 message SetForwardingPipelineConfigResponse {
@@ -465,24 +461,14 @@ message ForwardingPipelineConfig {
   config.P4Info p4info = 1;
   // Target-specific P4 configuration.
   bytes p4_device_config = 2;
-
-  // TODO(wmohsin): Remove when clients have migrated to specifying 'device_id'
-  // in SetForwardingPipelineConfigRequest.
-  uint64 device_id = 3 [deprecated = true];
 }
 
 message GetForwardingPipelineConfigRequest {
   uint64 device_id = 1;
-
-  // TODO(wmohsin): Remove when clients have migrated to 'device_id' above
-  repeated uint64 device_ids = 2 [deprecated = true];
 }
 
 message GetForwardingPipelineConfigResponse {
   ForwardingPipelineConfig config = 1;
-
-  // TODO(wmohsin): Remove when clients have migrated to 'config' above
-  repeated ForwardingPipelineConfig configs = 2 [deprecated = true];
 }
 
 // Error message used to report a single P4-entity error for a Write RPC.


### PR DESCRIPTION
Remove deprecated code related to {Set|Get}ForwardingPipelineConfig, now that clients have migrated to the new per-device style API.