### PR TITLE
Add is_const_table field to p4info.Table message

### DIFF
--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -116,6 +116,8 @@ message Table {
   repeated uint32 direct_resource_ids = 7;
   int64 size = 8;  // max number of entries in table
   bool with_entry_timeout = 9;  // entry ageing is enabled for table
+  // table with static P4 entries, cannot be modified at runtime
+  bool is_const_table = 10;
 }
 
 // used to list all possible actions in a Table


### PR DESCRIPTION
P4 tables with static entries cannot be modified at runtime. It
therefore makes sense to expose that property to the control-plane.