### PR TITLE
Temporary fix to allow inserting default entry twice

### DIFF
--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -1411,7 +1411,10 @@ class DeviceMgrImp {
 
     auto table_lock = table_info_store.lock_table(table_id);
 
-    if (table_info_store.get_entry(table_id, match_key) != nullptr) {
+    // TODO(antonin): remove !table_entry.is_default_action() condition once we
+    // support resetting the delete action with DELETE
+    if (table_info_store.get_entry(table_id, match_key) != nullptr &&
+        !table_entry.is_default_action()) {
       RETURN_ERROR_STATUS(
           Code::ALREADY_EXISTS,
           "Match entry exists, use MODIFY if you wish to change action");


### PR DESCRIPTION
This is convenient until we actually implement delete for default
entries. Otherwise it is a pain to write test fixtures that do proper
setup & cleanup.