### PR TITLE
P4info doc entities

### DIFF
--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -21,7 +21,7 @@ import "google/protobuf/any.proto";
 package p4.config;
 
 message P4Info {
-  repeated Extern externs = 1;
+  PkgInfo pkg_info = 1;
   repeated Table tables = 2;
   repeated Action actions = 3;
   repeated ActionProfile action_profiles = 4;
@@ -31,6 +31,35 @@ message P4Info {
   repeated DirectMeter direct_meters = 8;
   repeated ControllerPacketMetadata controller_packet_metadata = 9;
   repeated ValueSet value_sets = 10;
+  repeated Extern externs = 100;
+}
+
+message Documentation {
+  // A brief description of something, e.g. one sentence
+  string brief = 1;
+  // A more verbose description of something. Multiline is accepted. Markup format (if any) is TBD.
+  string description = 2;
+}
+
+// Top-level package documentation describing the forwarding pipeline config
+// Can be used to manage multiple P4 packages.
+message PkgInfo {
+    // a definitive name for this configuration, e.g. switch.p4_v1.0
+    string name = 1;
+    // configuration version, free-format string
+    string version = 2;
+    // brief and detailed descriptions
+    Documentation doc = 3;
+    // Miscellaneous metadata, free-form; a way to extend PkgInfo
+    repeated string annotations = 4;
+    // the target architecture, e.g. "psa"
+    string arch = 5;
+    // organization which produced the configuration, e.g. "p4.org"
+    string organization = 6;
+    // contact info for support,e.g. "tech-support@acme.org"
+    string contact = 7;
+    // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
+    string url = 8;
 }
 
 message Preamble {
@@ -55,6 +84,8 @@ message Preamble {
   // application should be able to indiscriminately use the name or the alias.
   string alias = 3;
   repeated string annotations = 4;
+  // Documentation of the entity
+  Documentation doc = 5;
 }
 
 // used to group all extern instances of the same type in one message
@@ -89,6 +120,8 @@ message MatchField {
     RANGE = 5;
   }
   MatchType match_type = 5;
+  // Documentation of the match field
+  Documentation doc = 6;
 }
 
 message Table {
@@ -134,6 +167,8 @@ message Action {
     string name = 2;
     repeated string annotations = 3;
     int32 bitwidth = 4;
+    // Documentation of the Param
+    Documentation doc = 5;
   }
   repeated Param params = 2;
 }

--- a/proto/p4info/xform/README.md
+++ b/proto/p4info/xform/README.md
@@ -1,0 +1,287 @@
+# P4Info xform - transformation utilities
+This directory contains utilities and examples for manipulating P4Info protobuf files to enhance the data models with new message elements, to facilitiate control plane API and UI generation, P4 package management, etc. The long-term goal is to establish some new conventions in P4 source code which will result in additional useful metadata to be inserted into the P4Info file. Initially, this can be done solely via new @annotations(), without requiring changes to existing P4 compilers. Later we can choose to modify P4 compilers to recognize annotations or other - possibly new - language constructs; or else establish coding conventions and the compiler will populate the P4Info file accordingly. In the meantime, we can experiment with ways to populate proposed new Message elements without modifying p4c.
+
+A utility called xform_anno.py will detect special annotations and transform them into new first-class P4Info protobuf messages or message elements.
+
+See [#275](https://github.com/p4lang/PI/issues/275), [#276](https://github.com/p4lang/PI/issues/276) for background and motivation.
+
+## Highlights
+- xform_anno.py - Python script to read P4Info proto file and transform annotations into other protobuf fields
+- examples/     - some examples of using the utility
+
+## Annotation transformations
+Selected annotations are transformed into proposed, new Message fields and the original annotations are removed.
+The new proposed messages are Documentation and PkgInfo (see PI/proto/p4/config/p4info.proto)
+
+ * @brief() is mapped to doc.brief.
+ * @description is mapped to doc.description
+
+See **Annotation transform examples** below
+## Populating PkgInfo Fields
+Currently there is no way to add top-level annotations to P4 code, which would be useful for populating PkgInfo messages (#276). The xform_anno.py utility can be used to populate the PkgInfo message directly from the command-line.
+
+See **Populating PkgInfo from the Command-line** below
+# Usage
+## Setting up
+Prerequisites: p4c-bm2-ss to generate the .proto files from the example P4 source. (see https://github.com/p4lang/p4c)
+
+First, make and install the project per the instructions at the PI top-level README. You have to install the protobuf tools too per those READMEs. Here's how I make the main project:
+```
+cd PI
+./autogen.sh
+./configure [--with-bmv2] --with-proto --without-internal-ipc --without-cli
+make
+sudo make install
+cd proto/p4info/xform/examples
+```
+## Generate P4Info files from your P4 source
+Use `gen_p4info.sh` to read P4 source and emit P4Info in three protobuf formats: binary, json and text.
+Example:
+```
+./gen_p4info.sh anno_xform1.p4
+```
+This results in three new files, automatically named:
+```
+anno_xform1.p4.p4info.json
+anno_xform1.p4.p4info.proto
+anno_xform1.p4.p4info.text
+```
+View the unmodified P4Info files:
+```
+cat anno_xform1.p4.p4info.txt
+cat anno_xform1.p4.p4info.json
+cat anno_xform1.p4.p4info.proto | protoc --decode_raw
+```
+Now play with xform_anno.py per examples below.
+
+## xform_anno.py
+### Purpose
+The purpose is to convert certain annotations into dedicated protobuf message elements. These elements are proposed enhancements and are not yet produced by the p4c compilers (via --p4runtime-file option). Another feature lets you populate PkgInfo fields direclty from the command-line.
+### Quick help
+Show help:
+```
+../xform_anno.py -h
+```
+Transform P4Info file, output to new file (suitable for a production make rule):
+```
+../xform_anno.py anno_xform1.p4.p4info.proto out.proto
+```
+Transform P4Info file, output text; verbose mode enabled to list transformation steps taken (e.g. for development):
+```
+../xform_anno.py -v -o text anno_xform1.p4.p4info.proto
+```
+Transform P4Info file (proto format) and emit json:
+```
+../xform_anno.py -o json anno_xform1.p4.p4info.proto
+```
+Dry-run with verbose output to see proposed transforms; discard output; verbose messages still visible on stderr:
+```
+../xform_anno.py -vd -o none anno_xform1.p4.p4info.proto
+```
+Transform P4Info file, parse result with protoc using raw mode (good to quickly verify encoding or examine output):
+```
+../xform_anno.py anno_xform1.p4.p4info.proto |protoc --decode_raw
+```
+Transform P4Info file, parse result with protoc with full decoding. (It's kind of a pain to specify the paths to the .proto file):
+```
+../xform_anno.py anno_xform1.p4.p4info.proto |protoc -I../../../p4/config --decode=p4.config.P4Info ../../../p4/config/p4info.proto
+```
+## Annotation transform examples
+### Table Entity and match key documentation - @brief(), @description ()
+Example P4 code snippet with new `@brief()` and `@description()` annotations for the table and a match key:
+```
+    @brief("IPv4 LPM lookup brief descrip")
+    @description("IPv4 LPM lookup long descrip. Set next hop.")
+    @myanno("ipv4_lpm_lkup anno")
+    @name(".ipv4_lpm_lkup")
+    table ipv4_lpm_lkup {
+        actions = {
+          @myanno("set_nexthop anno")
+            set_nexthop;
+            _drop;
+        }
+        key = {
+            hdr.ipv4.dstAddr: lpm @brief("IPv4 DIP") @description("IPV4 ingress Destination IP Address");
+        }
+        size = 1024;
+        default_action = _drop();
+    }
+```
+Untransformed P4Info with annotations:
+```
+tables {
+  preamble {
+    id: 33571990
+    name: "ipv4_lpm_lkup"
+    alias: "ipv4_lpm_lkup"
+    annotations: "@brief(\"IPv4 LPM lookup brief descrip\")"
+    annotations: "@description(\"IPv4 LPM lookup long descrip. Set next hop.\")"
+    annotations: "@myanno(\"ipv4_lpm_lkup anno\")"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ipv4.dstAddr"
+    annotations: "@brief(\"IPv4 DIP\")"
+    annotations: "@description(\"IPV4 ingress Destination IP Address\")"
+    bitwidth: 32
+    match_type: LPM
+  }
+  ...
+```
+Transformed P4Info. Notice the `@brief()` and `@description()` annotations are gone, and new `doc` messages appear for the table and the match field:
+```
+tables {
+  preamble {
+    id: 33571990
+    name: "ipv4_lpm_lkup"
+    alias: "ipv4_lpm_lkup"
+    annotations: "@myanno(\"ipv4_lpm_lkup anno\")"
+    doc {
+      brief: "IPv4 LPM lookup brief descrip"
+      description: "IPv4 LPM lookup long descrip. Set next hop."
+    }
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ipv4.dstAddr"
+    bitwidth: 32
+    match_type: LPM
+    doc {
+      brief: "IPv4 DIP"
+      description: "IPV4 ingress Destination IP Address"
+    }
+  }
+  ...
+```
+### Action Entity and parameter documentation - @brief(), @description ()
+Example P4 code snippet with new `@brief()` and `@description()` annotations for the action and each parameter.
+(The code appears cluttered, we need to come up with a nicer way to do this!):
+```
+    @brief("Set the next hop IP adress and egress port")
+    @description("Set the next hop IP adress and egress port longer description")
+    @name(".set_nexthop")
+    action set_nexthop(
+       @brief("Next hop IP address") @description("Next hop IP address longer description") bit<32> nexthop_ipv4,
+       @brief("The egress port") @description("The egress port longer description") egress_port_t port)
+      {
+        meta.routing_metadata.nexthop_ipv4 = nexthop_ipv4;
+        standard_metadata.egress_spec = port;
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w63;
+    }
+```
+Untransformed P4Info with annotations:
+```
+actions {
+  preamble {
+    id: 16809072
+    name: "set_nexthop"
+    alias: "set_nexthop"
+    annotations: "@brief(\"Set the next hop IP adress and egress port\")"
+    annotations: "@description(\"Set the next hop IP adress and egress port longer description\")"
+  }
+  params {
+    id: 1
+    name: "nexthop_ipv4"
+    annotations: "@brief(\"Next hop IP address\")"
+    annotations: "@description(\"Next hop IP address longer description\")"
+    bitwidth: 32
+  }
+  params {
+    id: 2
+    name: "port"
+    annotations: "@brief(\"The egress port\")"
+    annotations: "@description(\"The egress port longer description\")"
+    bitwidth: 9
+  }
+}
+```
+Transformed P4Info. Notice the `@brief()` and `@description()` annotations are gone, and new `doc` messages appear for the action and each parameter:
+```
+actions {
+  preamble {
+    id: 16809072
+    name: "set_nexthop"
+    alias: "set_nexthop"
+    doc {
+      brief: "Set the next hop IP adress and egress port"
+      description: "Set the next hop IP adress and egress port longer description"
+    }
+  }
+  params {
+    id: 1
+    name: "nexthop_ipv4"
+    bitwidth: 32
+    doc {
+      brief: "Next hop IP address"
+      description: "Next hop IP address longer description"
+    }
+  }
+  params {
+    id: 2
+    name: "port"
+    bitwidth: 9
+    doc {
+      brief: "The egress port"
+      description: "The egress port longer description"
+    }
+  }
+}
+```
+## Populating PkgInfo from the Command-line
+For the following examples, we specify the named PkgInfo fields and also add a couple of free-form annotations (meta1, meta2).
+
+Transform a P4Info file and also populate it with PkgInfo message elements from command-line, output to new file (suitable for a production make rule):
+```
+$ ../xform_anno.py --pkg_name test.p4 --pkg_doc_brief "Test P4Info" --pkg_doc_descr "A longer package description" --pkg_version "1.2.3.4" --pkg_arch "bmv2" --pkg_contact "support@p4.org" --pkg_organization "P4.org" --pkg_url "www.p4.org" --pkg_anno "meta1=value1" --pkg_anno "meta2=value2" anno_xform1.p4.p4info.proto out.proto
+
+```
+Transform a P4Info file and also populate it with PkgInfo message elements from command-line, output as text (development):
+```
+$ ../xform_anno.py -v --pkg_name test.p4 --pkg_doc_brief "Test P4Info" --pkg_doc_descr "A longer package description" --pkg_version "1.2.3.4" --pkg_arch "psa" --pkg_contact "support@p4.org" --pkg_organization "P4.org" --pkg_url "www.p4.org" --pkg_anno "meta1=value1" --pkg_anno "meta2=value2" -o text anno_xform1.p4.p4info.proto
+```
+Populate PkgInfo message elements from command-line and observe on stdout (no P4Info input file needed). We get the "description" field's text from a file "descrip.txt" which lets us populate it with arbitary long text including newlines.
+
+Here's the description file:
+```
+$ cat descrip.txt
+A long description for the P4Info.
+line 2
+line 3
+line 4
+```
+Transform the P4Info file and populate PkgInfo:
+```
+$ ../xform_anno.py -v --pkg_name test.p4 --pkg_doc_brief "Test P4Info" --pkg_doc_descr "`cat descrip.txt`" --pkg_version "1.2.3.4" --pkg_arch "psa" --pkg_contact "support@p4.org" --pkg_organization "P4.org" --pkg_url "www.p4.org" --pkg_anno "meta1=value1" --pkg_anno "meta2=value2" -i none -o text
+```
+Resulting output from above. Lines starting with +++ are from the -v option and are emitted on stderr. The output below that is the PkgInfo message populated from the command line args.
+```
++++ Added pkg_name "test.p4"
++++ Added pkg_version "1.2.3.4"
++++ Added pkg_doc_brief "Test P4Info"
++++ Added pkg_doc_descr "A long description for the P4Info.
+line 2
+line 3
+line 4"
++++ Added pkg_arch "psa"
++++ Added pkg_organization "P4.org"
++++ Added pkg_contact "support@p4.org"
++++ Added pkg_url "www.p4.org"
++++ Added pkg_anno "['meta1=value1', 'meta2=value2']"
+pkg_info {
+  name: "test.p4"
+  version: "1.2.3.4"
+  doc {
+    brief: "Test P4Info"
+    description: "A long description for the P4Info.\nline 2\nline 3\nline 4"
+  }
+  annotations: "meta1=value1"
+  annotations: "meta2=value2"
+  arch: "psa"
+  organization: "P4.org"
+  contact: "support@p4.org"
+  url: "www.p4.org"
+}
+```
+### TODO
+- Verify transforms for extern doc tags
+- Add a file merge option (specify another file to merge into the output). This can be used e.g. to populate PkgInfo from another file.

--- a/proto/p4info/xform/examples/anno_xform1.p4
+++ b/proto/p4info/xform/examples/anno_xform1.p4
@@ -1,0 +1,347 @@
+//  P4-16 Syntax
+//
+// Sample P4 program to demonstrate annotation transforms
+//
+// See https://github.com/p4lang/PI/issues/275
+// See https://github.com/p4lang/PI/issues/276
+//
+
+// Copyright 2018-present Keysight Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//
+// Chris Sommers (chris.sommers@keysight.com)
+//
+
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<9> egress_port_t;
+typedef bit<64> register_t;
+typedef bit<48> mac_addr_t;
+typedef bit<8> flavor_t;
+
+struct routing_metadata_t {
+    bit<32> nexthop_ipv4;
+}
+
+header ethernet_t {
+    mac_addr_t dstAddr;
+    mac_addr_t srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    routing_metadata_t routing_metadata;
+    bit<32> hash1;
+    bit<32> meter_tag;
+    register_t register_val;
+}
+
+struct headers {
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+
+    state start {
+        transition parse_ethernet;
+    }
+}
+
+// Define an extern to test P4info
+extern Flavor<T> {
+    Flavor(T flavor);
+    void set_flavor(T flavor);
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+
+    @brief("A simple register")
+    @description("A simple register longer description")
+    @name("my_reg")
+    register<register_t>(32w16) my_reg;
+
+    // instantiate an exterm
+    @brief("Silly named extern")
+    @description("Silly named extern longer description")
+    @name("my_flavor")
+    Flavor<flavor_t>(8w55) my_flavor;
+
+    @brief("Output packet counts per port - indir")
+    @description("Output packet counts per port, indexed by the egress_port, indirect counter")
+    @name(".out_count_indirect")
+    counter(32w512, CounterType.packets) out_count_indirect;
+
+    @brief("Output packet counts per port, indir")
+    @description("Output byte and packet counts per port, indexed by the egress_port, direct counter")
+    @name(".out_count_direct")
+    direct_counter(CounterType.packets_and_bytes) out_count_direct;
+
+    @name(".rewrite_mac")
+    action rewrite_mac(
+      @brief("Source MAC address") mac_addr_t smac)
+    {
+        hdr.ethernet.srcAddr = smac;
+        out_count_indirect.count((bit<32>)(bit<32>)standard_metadata.egress_port);
+        out_count_direct.count();
+    }
+
+    @name("._drop")
+    action _drop() {
+        mark_to_drop();
+    }
+
+    @name(".do_register")
+    action do_register(
+      @brief("register index") bit<32> index)
+    {
+      my_reg.read(meta.register_val, index);
+    }
+
+    @name(".send_packet_tbl")
+    table send_packet_tbl {
+        actions = {
+            rewrite_mac;
+            do_register;
+            _drop;
+        }
+        key = {
+            standard_metadata.egress_port: exact;
+        }
+        counters = out_count_direct;
+        size = 512;
+        default_action = _drop();
+    }
+
+    @name(".do_flavor")
+    @brief("Action sets the global flavor")
+    action do_flavor(
+      @brief("Flavor to set") flavor_t the_flavor)
+    {
+      my_flavor.set_flavor(the_flavor);
+    }
+
+    @name(".flavor_tbl")
+    table flavor_tbl {
+        actions = {
+            do_flavor;
+        }
+        default_action = do_flavor(8w0);
+    }
+
+    apply {
+       send_packet_tbl.apply();
+       flavor_tbl.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+
+    @name(".set_dmac")
+    @brief("Set destination MAC address")
+    @description("Set destination MAC address long description")
+    action set_dmac(mac_addr_t dmac) {
+        hdr.ethernet.dstAddr = dmac;
+    }
+
+    @name("._drop")
+    @brief("Drop packet")
+    @brief("Pedantic long description for Drop packet")
+    action _drop() {
+        mark_to_drop();
+    }
+
+    @brief("Set the next hop IP adress and egress port")
+    @description("Set the next hop IP adress and egress port longer description")
+    @name(".set_nexthop")
+    action set_nexthop(
+       @brief("Next hop IP address") @description("Next hop IP address longer description") bit<32> nexthop_ipv4,
+       @brief("The egress port") @description("The egress port longer description") egress_port_t port)
+      {
+        meta.routing_metadata.nexthop_ipv4 = nexthop_ipv4;
+        standard_metadata.egress_spec = port;
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w63;
+    }
+
+    @myanno("forward_tbl anno txt")
+    @brief("Forwarding Table")
+    @description("Forwarding Table. Based on the next hop, set the mac adress, else drop.")
+    @name(".forward_tbl")
+    table forward_tbl {
+        actions = {
+            set_dmac;
+            _drop;
+        }
+        key = {
+            meta.routing_metadata.nexthop_ipv4: exact;
+        }
+        size = 512;
+        default_action = _drop();
+    }
+
+    @brief("IPv4 LPM lookup brief descrip")
+    @description("IPv4 LPM lookup long descrip. Set next hop.")
+    @myanno("ipv4_lpm_lkup anno")
+    @name(".ipv4_lpm_lkup")
+    table ipv4_lpm_lkup {
+        actions = {
+          @myanno("set_nexthop anno")
+            set_nexthop;
+            _drop;
+        }
+        key = {
+            hdr.ipv4.dstAddr: lpm @brief("IPv4 DIP") @description("IPV4 ingress Destination IP Address");
+        }
+        size = 1024;
+        default_action = _drop();
+    }
+
+    // action profiles
+    @name(".indirect_action_tbl")
+    @brief("Indirect action profile")
+    @description("Table to test referencing an indirect action profile")
+    table indirect_action_tbl {
+        key = { }
+        actions = { _drop; NoAction; }
+        @name("action_profile_wo_selector")
+        @brief("Indirect action w/o selector")
+        @description("Indirect action w/o selector longer description")
+        implementation = action_profile(32w128);
+    }
+
+    @name(".indirect_action_tbl_w_selector")
+    @brief("Indirect action selector")
+    @description("Table to test referencing an indirect action selector")
+    table indirect_action_tbl_w_selector {
+        key = { meta.hash1 : selector; }
+        actions = { _drop; NoAction; }
+        @name("action_profile_w_selector")
+        @brief("Indirect action w/ selector")
+        @description("Indirect action w/ selector longer description")
+        implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+
+    // meters
+    @name(".my_meter_direct")
+    @brief("Brief descr for direct meter")
+    @description("Long description for direct meter")
+    direct_meter<bit<32>>(MeterType.packets) my_meter_direct;
+
+    @name(".my_meter_indirect")
+    @brief("Brief descr for indirect meter")
+    @description("Long description for indirect meter")
+    meter(32w16384, MeterType.packets) my_meter_indirect;
+
+    @name(".m_action_direct")
+    @brief("Reads direct meter")
+    action m_action_direct(
+      @brief("The meter index = eggress port num") bit<9> meter_idx)
+    {
+        my_meter_direct.read(meta.meter_tag);
+        standard_metadata.egress_spec = meter_idx;
+        standard_metadata.egress_spec = 9w1;
+    }
+
+    @name(".m_action_indirect")
+    @brief("Executes indirect meter")
+    action m_action_indirect(
+      @brief("The meter index = eggress port num") bit<9> meter_idx)
+    {
+        my_meter_direct.read(meta.meter_tag);
+        my_meter_indirect.execute_meter((bit<32>)meter_idx, meta.meter_tag);
+    }
+
+    @name("._read_dir_meter")
+    @brief("Reads a direct meter")
+    action _read_dir_meter() {
+        my_meter_direct.read(meta.meter_tag);
+    }
+
+    @name(".meter_tbl")
+    table meter_tbl {
+        actions = {
+            m_action_direct;
+            m_action_indirect;
+            _read_dir_meter;
+        }
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        size = 1024;
+        meters = my_meter_direct;
+    }
+
+    // apply
+    apply {
+        indirect_action_tbl.apply();
+        indirect_action_tbl_w_selector.apply();
+        meter_tbl.apply();
+
+        if (hdr.ipv4.isValid() && hdr.ipv4.ttl > 8w0) {
+            ipv4_lpm_lkup.apply();
+            forward_tbl.apply();
+        }
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/proto/p4info/xform/examples/descrip.txt
+++ b/proto/p4info/xform/examples/descrip.txt
@@ -1,0 +1,5 @@
+A long description for the P4Info.
+line 2
+line 3
+line 4
+

--- a/proto/p4info/xform/examples/gen_p4info.sh
+++ b/proto/p4info/xform/examples/gen_p4info.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+#
+# gen_p4info.sh - Utility to generate P4Info in three different formats from one P4_16 source file.
+#
+
+# Copyright 2018-present Keysight Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Chris Sommers (chris.sommers@keysight.com)
+#
+if [ $# -ne 1 ]; then
+	echo "USAGE: $0 <p4 source file>"
+	exit 1
+fi
+
+echo "Generating $1.p4info.proto ..."
+echo "p4c-bm2-ss --p4runtime-file $1.p4info.proto --p4runtime-format binary $1"
+p4c-bm2-ss --p4runtime-file $1.p4info.proto --p4runtime-format binary $1
+echo "Generating $1.p4info.json ..."
+echo "p4c-bm2-ss --p4runtime-file $1.p4info.json --p4runtime-format json $1"
+p4c-bm2-ss --p4runtime-file $1.p4info.json --p4runtime-format json $1
+echo "Generating $1.p4info.txt ..."
+echo "p4c-bm2-ss --p4runtime-file $1.p4info.txt --p4runtime-format text $1"
+p4c-bm2-ss --p4runtime-file $1.p4info.txt --p4runtime-format text $1

--- a/proto/p4info/xform/xform_anno.py
+++ b/proto/p4info/xform/xform_anno.py
@@ -1,0 +1,289 @@
+#! /usr/bin/python
+#
+# xform_anno.py - Utility to transform p4info annotations into first-class Message elements
+#
+
+# Copyright 2018-present Keysight Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Chris Sommers (chris.sommers@keysight.com)
+#
+
+import p4.config.p4info_pb2 as p4info_pb2
+import argparse
+import sys
+import google.protobuf.json_format as json_format
+import google.protobuf.text_format as text_format
+import textwrap
+
+# Conditionally print a verbose message
+def log_verbose(msg):
+    if verbose:
+        print >> sys.stderr, msg
+
+# Set document.brief
+def set_doc_brief(doc, value):
+    doc.brief = value;
+
+# Set document.description
+def set_doc_description(doc, value):
+    doc.description = value;
+
+# Extract the string value embedded in an annotation
+# Asssumes just one string, surrounded by escaped quotes e.g. "\"string\""
+def get_anno_value(anno):
+    return anno.split('(\"')[1].split('\")')[0]
+
+# Detect @brief() and @description() annotations and transform into document.brief, document.description
+def xform_doc_annotation(container_name, doc, anno_list, anno):
+    if '@brief' in anno:
+        log_verbose( "*** %sTransform doc anno in %s: %s => doc.brief" % (drystr, container_name, anno))
+        if dry == False:
+            set_doc_brief(doc, get_anno_value(anno))
+            anno_list.remove(anno)
+
+    if '@description' in anno:
+        log_verbose( "*** %sTransform doc anno in %s: %s => doc.description" % (drystr, container_name, anno))
+        if dry == False:
+            set_doc_description(doc, get_anno_value(anno))
+            anno_list.remove(anno)
+
+# Transform annotations into preamble.document.brief, .description
+def xform_preamble_doc_annotations(message):
+    #reverse iterate so deleting elements doesn't cause subsequent one to get skipped
+    for anno in reversed(message.preamble.annotations):
+        xform_doc_annotation(message.preamble.name, message.preamble.doc, message.preamble.annotations, anno)
+
+# Transform match_field annotations (doc)
+def xform_table_match_field_annotations(table):
+    for matchfield in table.match_fields:
+        #reverse iterate so deleting elements doesn't cause subsequent one to get skipped
+        for anno in reversed(matchfield.annotations):
+            xform_doc_annotation("match_field %s.%s" %(table.preamble.name, matchfield.name),
+                                 matchfield.doc, matchfield.annotations, anno)
+
+# Transform action anotations (doc)
+def xform_action_param_annotations(action):
+    for param in action.params:
+        #reverse iterate so deleting elements doesn't cause subsequent one to get skipped
+        for anno in reversed(param.annotations):
+            xform_doc_annotation("action %s(%s)" % (action.preamble.name,param.name),
+                                 param.doc, param.annotations,  anno)
+
+# Convenience function to define argument parser
+def get_arg_parser():
+
+    parser = argparse.ArgumentParser(description='P4info transform utility',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent('''\
+            Either or both of infile, outfile can be omitted; a hyphen signifies stdin and stdout, respectively.
+            Using -i none or -o none overrides input/output file descriptors.
+
+            Examples:
+            =========
+            xform_anno.py [opts] <infile> <outfile>        read infile, write to outfile
+            xform_anno.py [opts] <infile> -                read infile, write to stdout
+            xform_anno.py [opts] <infile>                  read infile, write to stdout
+            xform_anno.py [opts] - <outfile>               read stdin, write to outfile
+            xform_anno.py [opts] - -                       read stdin, write to stdout
+            xform_anno.py [opts]                           read stdin, write to stdout
+
+            Populate PkgInfo fields, some from cmd-line and one from a file; you can populate all pkg_xxx fields either way:
+
+            .xform_anno.py --pkg_name "MyPackage" --pkg_brief "A cool package" --pkg_descrip "`cat descrip.txt`" <infile> <outfile>
+        '''))
+
+    # Parsing options
+    parser.add_argument('-d', help='Dry-run only; report transforms (via -v) but do not make changes',
+                        action="store_true", dest='dry', default=False)
+
+    parser.add_argument('-v', help='Verbose reporting of transform steps',
+                        action="store_true", dest='verbose', default=False)
+
+    parser.add_argument('infile', nargs='?', help='Input file name (use - or omit for stdin; -i none means no input)',
+                        type=argparse.FileType('rb'), default=sys.stdin)
+
+    parser.add_argument('outfile', nargs='?',  help='Input file name  (use - or omit for stdout; -o none means no output)',
+                        type=argparse.FileType('wb'), default=sys.stdout)
+
+    parser.add_argument('-o', help='Output Format', dest='outfmt',
+                        type=str, action='store', choices=['proto', 'json', 'text', 'none'],
+                        default='proto')
+
+    parser.add_argument('-i', help='Input Format', dest='infmt',
+                        type=str, action='store', choices=['proto', 'json', 'none'],
+                        default='proto')
+
+    # PkgInfo elements
+    parser.add_argument('--pkg_name', help='Package name', type=str, action='store')
+    parser.add_argument('--pkg_doc_brief', help='Package document brief', type=str, action='store')
+    parser.add_argument('--pkg_doc_descr', help='Package document description', type=str, action='store')
+    parser.add_argument('--pkg_version', help='Package version', type=str, action='store')
+    parser.add_argument('--pkg_arch', help='Package target architecture', type=str, action='store')
+    parser.add_argument('--pkg_organization', help='Package organization', type=str, action='store')
+    parser.add_argument('--pkg_contact', help='Package contact', type=str, action='store')
+    parser.add_argument('--pkg_url', help='Package url', type=str, action='store')
+    parser.add_argument('--pkg_anno', help='Package annotation, can use multiple times', type=str, action='append')
+
+    return parser
+
+# Extract cmd-line args and insert into PkgInfo Message
+def add_arg_elements(args, p4info):
+    if args == None:
+        return
+    if p4info == None:
+        return
+
+    if args.pkg_name != None:
+        if dry == False:
+            p4info.pkg_info.name = args.pkg_name
+        log_verbose('+++ %sAdded pkg_name "%s"' % (drystr, args.pkg_name))
+
+    if args.pkg_version != None:
+        if dry == False:
+            p4info.pkg_info.version = args.pkg_version
+        log_verbose('+++ %sAdded pkg_version "%s"' % (drystr, args.pkg_version))
+
+    if args.pkg_doc_brief != None:
+        if dry == False:
+            p4info.pkg_info.doc.brief = args.pkg_doc_brief
+        log_verbose('+++ %sAdded pkg_doc_brief "%s"' % (drystr, args.pkg_doc_brief))
+
+    if args.pkg_doc_descr != None:
+        if dry == False:
+            p4info.pkg_info.doc.description = args.pkg_doc_descr
+        log_verbose('+++ %sAdded pkg_doc_descr "%s"' % (drystr, args.pkg_doc_descr))
+
+    if args.pkg_arch != None:
+        if dry == False:
+            p4info.pkg_info.arch = args.pkg_arch
+        log_verbose('+++ %sAdded pkg_arch "%s"' % (drystr, args.pkg_arch))
+
+    if args.pkg_organization != None:
+        if dry == False:
+            p4info.pkg_info.organization = args.pkg_organization
+        log_verbose('+++ %sAdded pkg_organization "%s"' % (drystr, args.pkg_organization))
+
+    if args.pkg_contact != None:
+        if dry == False:
+            p4info.pkg_info.contact = args.pkg_contact
+        log_verbose('+++ %sAdded pkg_contact "%s"' % (drystr, args.pkg_contact))
+
+    if args.pkg_url != None:
+        if dry == False:
+            p4info.pkg_info.url = args.pkg_url
+        log_verbose('+++ %sAdded pkg_url "%s"' % (drystr, args.pkg_url))
+
+    if args.pkg_anno != None:
+        tmp = [];
+        for anno in args.pkg_anno:
+            if dry == False:
+                p4info.pkg_info.annotations.append(anno)
+            else :
+                tmp.append(anno);
+        if dry == False:
+            log_verbose('+++ Added pkg_anno "%s"' % (p4info.pkg_info.annotations))
+        else:
+            log_verbose('+++ %sAdded pkg_anno "%s"' % (drystr, tmp))
+
+
+    return
+
+########################################################
+# Main - read file, transform it, write it
+########################################################
+
+#
+# Get args
+#
+parser = get_arg_parser()
+args = parser.parse_args()
+verbose = args.verbose
+dry = args.dry
+if dry == True:
+    drystr='(dry): '
+else:
+    drystr=''
+
+infmt = args.infmt
+outfmt = args.outfmt
+if infmt != 'none':
+    infile = args.infile
+if outfmt != 'none':
+    outfile = args.outfile
+
+#
+# Read intput into protobuf
+#
+p4info = p4info_pb2.P4Info()
+
+if (infmt == 'json'):
+    p4info = json_format.Parse(infile.read(), p4info_pb2.P4Info(), ignore_unknown_fields=False)
+    infile.close()
+elif infmt == 'proto':
+    p4info.ParseFromString(infile.read())
+    infile.close()
+
+add_arg_elements(args, p4info)
+#
+# Transform protobuf object(s)
+for table in p4info.tables:
+    log_verbose("=== process table %s" % table.preamble.name)
+    xform_preamble_doc_annotations(table)
+    xform_table_match_field_annotations(table)
+
+for action in p4info.actions:
+    log_verbose("=== process action %s" % action.preamble.name)
+    xform_preamble_doc_annotations(action)
+    xform_action_param_annotations(action)
+
+for action_profile in p4info.action_profiles:
+    log_verbose("=== process action_profile %s" % action_profile.preamble.name)
+    xform_preamble_doc_annotations(action_profile)
+
+for counter in p4info.counters:
+    log_verbose("=== process indirect counter %s" % counter.preamble.name)
+    xform_preamble_doc_annotations(counter)
+
+for counter in p4info.direct_counters:
+    log_verbose("=== process direct_counter %s" % counter.preamble.name)
+    xform_preamble_doc_annotations(counter)
+
+for meter in p4info.meters:
+    log_verbose("=== process indirect meter %s" % meter.preamble.name)
+    xform_preamble_doc_annotations(meter)
+
+for meter in p4info.direct_meters:
+    log_verbose("=== process direct_meter %s" % meter.preamble.name)
+    xform_preamble_doc_annotations(meter)
+
+for extern in p4info.externs:
+    for extern_instance in extern.instances:
+        log_verbose("=== process extern_instance %s" % extern_instance.preamble.name)
+        xform_preamble_doc_annotations(extern_instance)
+
+#
+# Write to output
+#
+if outfmt == 'json':
+    outfile.write(json_format.MessageToJson(p4info))
+    outfile.close()
+elif outfmt == 'proto':
+    outfile.write(p4info.SerializeToString())
+    outfile.close()
+elif outfmt == 'text':
+    outfile.write(text_format.MessageToString(p4info))
+    outfile.close()


### PR DESCRIPTION
Solution for #275 and #276 + utility + examples
  * #275 - p4info.proto: Added Document Message to entities and action params
  * #276 - p4info.proto: Added PkgInfo to top level P4Info
  * xform_anno.py utility to transform annotations into first-class proto messages and elements
  * Example p4 source program with annotations
  * README
  * A bash script to simplify running a demo

**TODO** - I have not been able to generate a p4info file containing externs so corresponding annotation transforms aren't verified yet.

You can play with the prototype implementation at https://github.com/chrispsommers/PI/tree/p4info-doc-entities/proto/p4/config with some related samples and utilities at https://github.com/chrispsommers/PI/tree/p4info-doc-entities/proto/p4info/xform