### PR TITLE
Implement support for writing direct configs in TableEntry

### DIFF
--- a/frontends_extra/cpp/PI/frontends/cpp/tables.h
+++ b/frontends_extra/cpp/PI/frontends/cpp/tables.h
@@ -258,10 +258,21 @@ class ActionEntry {
       return (tag != Tag::NONE);
   }
 
+  // caller still owns config
+  template <typename T>
+  void add_direct_res_config(pi_p4_id_t res_id, T *config) {
+    _configs.push_back({res_id, static_cast<void *>(config)});
+    direct_config.num_configs = _configs.size();
+    direct_config.configs = _configs.data();
+  }
+
  private:
   enum class Tag { NONE, ACTION_DATA, INDIRECT_HANDLE } tag;
 
   Tag type() const { return tag; }
+
+  std::vector<pi_direct_res_config_one_t> _configs;
+  pi_direct_res_config_t direct_config{0u, nullptr};
 
   union {
     ActionData _action_data;

--- a/frontends_extra/cpp/src/tables.cpp
+++ b/frontends_extra/cpp/src/tables.cpp
@@ -581,7 +581,11 @@ pi_table_entry_t
 MatchTable::build_table_entry(const ActionEntry &action_entry) const {
   pi_table_entry_t entry;
   entry.entry_properties = NULL;
-  entry.direct_res_config = NULL;
+  // TODO(antonin): we could simply use entry.direct_res_config =
+  // &action_entry.direct_config? Is it better to use a NULL pointer when the
+  // direct resource list is empty?
+  entry.direct_res_config = (action_entry.direct_config.num_configs == 0) ?
+      NULL : &action_entry.direct_config;
 
   switch (action_entry.type()) {
     case ActionEntry::Tag::NONE:

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -41,7 +41,11 @@ $(top_builddir)/../src/libpip4info.la \
 $(common_libs) \
 $(PROTOBUF_LIBS)
 
-proto_fe_common_source = $(common_source) mock_switch.h mock_switch.cpp
+proto_fe_common_source = $(common_source) \
+mock_switch.h \
+mock_switch.cpp \
+matchers.h \
+matchers.cpp
 
 test_proto_fe_SOURCES = $(proto_fe_common_source) test_proto_fe.cpp
 test_proto_fe_packet_io_SOURCES = $(proto_fe_common_source) \

--- a/proto/tests/matchers.cpp
+++ b/proto/tests/matchers.cpp
@@ -1,0 +1,306 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <gmock/gmock.h>
+
+#include <cstring>
+#include <ostream>
+#include <string>
+
+#include "p4/p4runtime.pb.h"
+
+#include "PI/int/pi_int.h"
+#include "PI/pi.h"
+
+#include "matchers.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+
+MatchKeyMatcher::MatchKeyMatcher(pi_p4_id_t t_id, const std::string &v)
+    : t_id(t_id), v(v) { }
+
+bool
+MatchKeyMatcher::MatchAndExplain(const pi_match_key_t *mk,
+                                 MatchResultListener *listener) const {
+  if (mk->table_id != t_id) {
+    *listener << "Invalid table id (expected " << t_id << " but got "
+              << mk->table_id << ")";
+    return false;
+  }
+  if (mk->data_size != v.size()) {
+    *listener << "Invalid serialized match key size (expected "
+              << v.size() << " but got " << mk->data_size << ")";
+    return false;
+  }
+  if (std::memcmp(mk->data, v.data(), v.size())) {
+    *listener << "Serialized match key data doesn't match";
+    return false;
+  }
+  return true;
+}
+
+void
+MatchKeyMatcher::DescribeTo(std::ostream *os) const {
+  *os << "is correct match key";
+}
+
+void
+MatchKeyMatcher::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not correct match key";
+}
+
+ActionDataMatcher::ActionDataMatcher(pi_p4_id_t a_id, const std::string &v)
+    : a_id(a_id), v(v) { }
+
+bool
+ActionDataMatcher::MatchAndExplain(const pi_action_data_t *action_data,
+                                   MatchResultListener *listener) const {
+  if (action_data->action_id != a_id) {
+    *listener << "Invalid action id (expected " << a_id << " but got "
+              << action_data->action_id << ")";
+    return false;
+  }
+  if (action_data->data_size != v.size()) {
+    *listener << "Invalid serialized action data size (expected "
+              << v.size() << " but got " << action_data->data_size << ")";
+    return false;
+  }
+  if (std::memcmp(action_data->data, v.data(), v.size())) {
+    *listener << "Serialized action data doesn't match";
+    return false;
+  }
+  return true;
+}
+
+void
+ActionDataMatcher::DescribeTo(std::ostream *os) const {
+  *os << "is correct action data";
+}
+
+void
+ActionDataMatcher::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not correct action data";
+}
+
+MeterSpecMatcher::MeterSpecMatcher(const p4::MeterConfig &config,
+                                   pi_meter_unit_t meter_unit,
+                                   pi_meter_type_t meter_type)
+    : config(config), meter_unit(meter_unit), meter_type(meter_type) { }
+
+bool
+MeterSpecMatcher::MatchAndExplain(const pi_meter_spec_t *spec,
+                                  MatchResultListener *listener) const {
+  auto cir = static_cast<uint64_t>(config.cir());
+  if (spec->cir != cir) {
+    *listener << "Invalid CIR (expected " << cir << " but got "
+              << spec->cir << ")";
+    return false;
+  }
+  auto cburst = static_cast<uint32_t>(config.cburst());
+  if (spec->cburst != cburst) {
+    *listener << "Invalid CBurst (expected " << cburst << " but got "
+              << spec->cburst << ")";
+    return false;
+  }
+  auto pir = static_cast<uint64_t>(config.pir());
+  if (spec->pir != pir) {
+    *listener << "Invalid PIR (expected " << pir << " but got "
+              << spec->pir << ")";
+    return false;
+  }
+  auto pburst = static_cast<uint32_t>(config.pburst());
+  if (spec->pburst != pburst) {
+    *listener << "Invalid Pburst (expected " << pburst << " but got "
+              << spec->pburst << ")";
+    return false;
+  }
+  if (spec->meter_unit != meter_unit) {
+    *listener << "Invalid meter unit";
+    return false;
+  }
+  if (spec->meter_type != meter_type) {
+    *listener << "Invalid meter type";
+    return false;
+  }
+  return true;
+}
+
+void
+MeterSpecMatcher::DescribeTo(std::ostream *os) const {
+  *os << "is correct meter spec";
+}
+
+void
+MeterSpecMatcher::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not correct meter spec";
+}
+
+CounterDataMatcher::CounterDataMatcher(const p4::CounterData &data,
+                                       bool check_bytes, bool check_packets)
+    : data(data), check_bytes(check_bytes), check_packets(check_packets) { }
+
+bool
+CounterDataMatcher::MatchAndExplain(const pi_counter_data_t *pi_data,
+                                    MatchResultListener *listener) const {
+  if (check_bytes && !(pi_data->valid & PI_COUNTER_UNIT_BYTES)) {
+    *listener << "No valid byte count";
+    return false;
+  }
+  auto byte_count = static_cast<uint64_t>(data.byte_count());
+  if (check_bytes && (pi_data->bytes != byte_count)) {
+    *listener << "Invalid byte count (expected " << byte_count << " but got "
+              << pi_data->bytes << ")";
+    return false;
+  }
+  if (check_packets && !(pi_data->valid & PI_COUNTER_UNIT_PACKETS)) {
+    *listener << "No valid packet count";
+    return false;
+  }
+  auto packet_count = static_cast<uint64_t>(data.packet_count());
+  if (check_packets && (pi_data->packets != packet_count)) {
+    *listener << "Invalid packet count (expected " << packet_count
+              << " but got " << pi_data->packets << ")";
+    return false;
+  }
+  return true;
+}
+
+void
+CounterDataMatcher::DescribeTo(std::ostream *os) const {
+  *os << "is correct counter data";
+}
+
+void
+CounterDataMatcher::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not correct counter data";
+}
+
+TableEntryMatcher_Base::TableEntryMatcher_Base() = default;
+
+void
+TableEntryMatcher_Base::add_direct_meter(pi_p4_id_t meter_id,
+                                         const p4::MeterConfig &config,
+                                         pi_meter_unit_t meter_unit,
+                                         pi_meter_type_t meter_type) {
+  meters.emplace(meter_id, MeterSpecMatcher(config, meter_unit, meter_type));
+}
+
+void
+TableEntryMatcher_Base::add_direct_counter(pi_p4_id_t counter_id,
+                                           const p4::CounterData &data,
+                                           bool check_bytes,
+                                           bool check_packets) {
+  counters.emplace(counter_id,
+                   CounterDataMatcher(data, check_bytes, check_packets));
+}
+
+bool
+TableEntryMatcher_Base::match_direct(const pi_table_entry_t *t_entry,
+                                     MatchResultListener *listener) const {
+  auto num_configs = meters.size() + counters.size();
+  auto *direct_res_config = t_entry->direct_res_config;
+  if (num_configs == 0 && direct_res_config == nullptr) return true;
+  if (direct_res_config->num_configs != num_configs) {
+    *listener << "Invalid number of direct configs (expected " << num_configs
+              << " but got " << direct_res_config->num_configs << ")";
+    return false;
+  }
+  for (size_t i = 0; i < num_configs; i++) {
+    auto *config = &direct_res_config->configs[i];
+    {
+      auto it = meters.find(config->res_id);
+      if (it != meters.end()) {
+        auto *meter_spec = static_cast<const pi_meter_spec_t *>(
+            config->config);
+        if (!it->second.MatchAndExplain(meter_spec, listener)) return false;
+      }
+    }
+    {
+      auto it = counters.find(config->res_id);
+      if (it != counters.end()) {
+        auto *counter_data = static_cast<const pi_counter_data_t *>(
+            config->config);
+        if (!it->second.MatchAndExplain(counter_data, listener)) return false;
+      }
+    }
+  }
+  return true;
+}
+
+TableEntryMatcher_Direct::TableEntryMatcher_Direct(pi_p4_id_t a_id,
+                                                   const std::string &v)
+    : action_data_matcher(a_id, v) { }
+
+bool
+TableEntryMatcher_Direct::MatchAndExplain(const pi_table_entry_t *t_entry,
+                                          MatchResultListener *listener) const {
+  if (t_entry->entry_type != PI_ACTION_ENTRY_TYPE_DATA) {
+    *listener << "Invalid table entry type (expected DATA)";
+    return false;
+  }
+  auto *action_data = t_entry->entry.action_data;
+  if (!action_data_matcher.MatchAndExplain(action_data, listener))
+    return false;
+  return match_direct(t_entry, listener);
+}
+
+void
+TableEntryMatcher_Direct::DescribeTo(std::ostream *os) const {
+  *os << "is correct table entry";
+}
+
+void
+TableEntryMatcher_Direct::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not correct table entry";
+}
+
+TableEntryMatcher_Indirect::TableEntryMatcher_Indirect(pi_indirect_handle_t h)
+    : h(h) { }
+
+bool
+TableEntryMatcher_Indirect::MatchAndExplain(
+    const pi_table_entry_t *t_entry, MatchResultListener *listener) const {
+  if (t_entry->entry_type != PI_ACTION_ENTRY_TYPE_INDIRECT) {
+    *listener << "Invalid table entry type (expected INDIRECT)";
+    return false;
+  }
+  if (t_entry->entry.indirect_handle != h) {
+    *listener << "Invalid indirect handle (expected " << h << " but got "
+              << t_entry->entry.indirect_handle << ")";
+    return false;
+  }
+  return match_direct(t_entry, listener);
+}
+
+void
+TableEntryMatcher_Indirect::DescribeTo(std::ostream *os) const {
+  *os << "is correct indirect table entry";
+}
+
+void
+TableEntryMatcher_Indirect::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not correct indirect table entry";
+}
+
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi

--- a/proto/tests/matchers.h
+++ b/proto/tests/matchers.h
@@ -1,0 +1,203 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef PROTO_TESTS_MATCHERS_H_
+#define PROTO_TESTS_MATCHERS_H_
+
+#include <gmock/gmock.h>
+
+#include <iosfwd>
+#include <string>
+#include <unordered_map>
+
+#include "p4/p4runtime.pb.h"
+
+#include "PI/pi.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+
+using ::testing::MakeMatcher;
+using ::testing::Matcher;
+using ::testing::MatcherInterface;
+using ::testing::MatchResultListener;
+
+// This is a very verbose matcher but it has the advantage to print convenient
+// error messages. Not sure I could achieve such a nice result by only using
+// googlemock base matchers (e.g. Field...)
+class MatchKeyMatcher : public MatcherInterface<const pi_match_key_t *> {
+ public:
+  MatchKeyMatcher(pi_p4_id_t t_id, const std::string &v);
+
+  bool MatchAndExplain(const pi_match_key_t *mk,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+ private:
+  pi_p4_id_t t_id;
+  std::string v;
+};
+
+inline Matcher<const pi_match_key_t *> CorrectMatchKey(
+    pi_p4_id_t t_id, const std::string &v) {
+  return MakeMatcher(new MatchKeyMatcher(t_id, v));
+}
+
+class ActionDataMatcher : public MatcherInterface<const pi_action_data_t *> {
+ public:
+  ActionDataMatcher(pi_p4_id_t a_id, const std::string &v);
+
+  bool MatchAndExplain(const pi_action_data_t *action_data,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+ private:
+  pi_p4_id_t a_id;
+  std::string v;
+};
+
+inline Matcher<const pi_action_data_t *> CorrectActionData(
+    pi_p4_id_t a_id, const std::string &v) {
+  return MakeMatcher(new ActionDataMatcher(a_id, v));
+}
+
+class MeterSpecMatcher : public MatcherInterface<const pi_meter_spec_t *> {
+ public:
+  MeterSpecMatcher(const p4::MeterConfig &config,
+                   pi_meter_unit_t meter_unit,
+                   pi_meter_type_t meter_type);
+
+  bool MatchAndExplain(const pi_meter_spec_t *spec,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+ private:
+  p4::MeterConfig config;
+  pi_meter_unit_t meter_unit;
+  pi_meter_type_t meter_type;
+};
+
+inline Matcher<const pi_meter_spec_t *> CorrectMeterSpec(
+    const p4::MeterConfig &config,
+    pi_meter_unit_t meter_unit, pi_meter_type_t meter_type) {
+  return MakeMatcher(new MeterSpecMatcher(config, meter_unit, meter_type));
+}
+
+class CounterDataMatcher : public MatcherInterface<const pi_counter_data_t *> {
+ public:
+  CounterDataMatcher(const p4::CounterData &data,
+                     bool check_bytes, bool check_packets);
+
+  bool MatchAndExplain(const pi_counter_data_t *pi_data,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+ private:
+  p4::CounterData data;
+  bool check_bytes;
+  bool check_packets;
+};
+
+inline Matcher<const pi_counter_data_t *> CorrectCounterData(
+    const p4::CounterData &data, bool check_bytes, bool check_packets) {
+  return MakeMatcher(new CounterDataMatcher(data, check_bytes, check_packets));
+}
+
+class TableEntryMatcher_Base {
+ public:
+  void add_direct_meter(pi_p4_id_t meter_id, const p4::MeterConfig &config,
+                        pi_meter_unit_t meter_unit,
+                        pi_meter_type_t meter_type);
+
+  void add_direct_counter(pi_p4_id_t counter_id, const p4::CounterData &data,
+                          bool check_bytes, bool check_packets);
+
+ protected:
+  TableEntryMatcher_Base();
+
+  bool match_direct(const pi_table_entry_t *t_entry,
+                    MatchResultListener *listener) const;
+
+  std::unordered_map<pi_p4_id_t, MeterSpecMatcher> meters;
+  std::unordered_map<pi_p4_id_t, CounterDataMatcher> counters;
+};
+
+class TableEntryMatcher_Direct
+    : public TableEntryMatcher_Base,
+      public MatcherInterface<const pi_table_entry_t *> {
+ public:
+  TableEntryMatcher_Direct(pi_p4_id_t a_id, const std::string &v);
+
+  bool MatchAndExplain(const pi_table_entry_t *t_entry,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+ private:
+  ActionDataMatcher action_data_matcher;
+};
+
+inline Matcher<const pi_table_entry_t *> CorrectTableEntryDirect(
+    pi_p4_id_t a_id, const std::string &v) {
+  return MakeMatcher(new TableEntryMatcher_Direct(a_id, v));
+}
+
+class TableEntryMatcher_Indirect
+    : public TableEntryMatcher_Base,
+      public MatcherInterface<const pi_table_entry_t *> {
+ public:
+  explicit TableEntryMatcher_Indirect(pi_indirect_handle_t h);
+
+  bool MatchAndExplain(const pi_table_entry_t *t_entry,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+ private:
+  pi_indirect_handle_t h;
+};
+
+inline Matcher<const pi_table_entry_t *> CorrectTableEntryIndirect(
+    pi_indirect_handle_t h) {
+  return MakeMatcher(new TableEntryMatcher_Indirect(h));
+}
+
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi
+
+#endif  // PROTO_TESTS_MATCHERS_H_

--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -113,11 +113,15 @@ class DummySwitchMock {
                            const pi_meter_spec_t *));
 
   MOCK_METHOD4(counter_read,
-               pi_status_t(pi_p4_id_t, size_t, int,
-                           pi_counter_data_t *counter_data));
+               pi_status_t(pi_p4_id_t, size_t, int, pi_counter_data_t *));
+  MOCK_METHOD3(counter_write,
+               pi_status_t(pi_p4_id_t, size_t, const pi_counter_data_t *));
   MOCK_METHOD4(counter_read_direct,
                pi_status_t(pi_p4_id_t, pi_entry_handle_t, int,
-                           pi_counter_data_t *counter_data));
+                           pi_counter_data_t *));
+  MOCK_METHOD3(counter_write_direct,
+               pi_status_t(pi_p4_id_t, pi_entry_handle_t,
+                           const pi_counter_data_t *));
 
   MOCK_METHOD2(packetout_send, pi_status_t(const char *, size_t));
 


### PR DESCRIPTION
We now support counter_data and meter_config fields in TableEntry message, for Write only (i.e. table insert and table modify).
   
We also support writing to direct / indirect counters using the DirectCounterEntry / CounterEntry messages.