### PR TITLE
Support reading direct & indirect meters

### DIFF
--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -106,8 +106,12 @@ class DummySwitchMock {
   MOCK_METHOD2(action_prof_entries_fetch,
                pi_status_t(pi_p4_id_t, pi_act_prof_fetch_res_t *));
 
+  MOCK_METHOD3(meter_read,
+               pi_status_t(pi_p4_id_t, size_t, pi_meter_spec_t *));
   MOCK_METHOD3(meter_set,
                pi_status_t(pi_p4_id_t, size_t, const pi_meter_spec_t *));
+  MOCK_METHOD3(meter_read_direct,
+               pi_status_t(pi_p4_id_t, pi_entry_handle_t, pi_meter_spec_t *));
   MOCK_METHOD3(meter_set_direct,
                pi_status_t(pi_p4_id_t, pi_entry_handle_t,
                            const pi_meter_spec_t *));

--- a/tests/testdata/unittest.p4
+++ b/tests/testdata/unittest.p4
@@ -154,6 +154,9 @@ control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metad
     @name(".CounterA")
     counter(32w1024, CounterType.packets) CounterA;
 
+    @name(".MeterA")
+    meter(32w1024, MeterType.packets) MeterA;
+
     @name(".ConstTable")
     table ConstTable {
         key = {
@@ -177,6 +180,7 @@ control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metad
         IndirectWS.apply();
         ExactOneNonAligned.apply();
         CounterA.count(32w128);
+        MeterA.execute_meter(32w128, hdr.header_test.field4);
         ConstTable.apply();
     }
 }

--- a/tests/testdata/unittest.p4info.txt
+++ b/tests/testdata/unittest.p4info.txt
@@ -300,6 +300,17 @@ direct_counters {
   }
   direct_table_id: 33582705
 }
+meters {
+  preamble {
+    id: 318820171
+    name: "MeterA"
+    alias: "MeterA"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
 direct_meters {
   preamble {
     id: 318772168


### PR DESCRIPTION
Through MeterEntry & DirectMeterEntry P4Runtime messages only (not
through TableEntry message yet, for direct meters). Wildcard Read for
DirectMeterEntry is not supported yet.