### PR TITLE
Wrap indirect resource index in proto message in P4Runtime

### DIFF
--- a/proto/demo_grpc/simple_router_mgr.cpp
+++ b/proto/demo_grpc/simple_router_mgr.cpp
@@ -653,7 +653,8 @@ SimpleRouterMgr::query_counter_(const std::string &counter_name, size_t index,
   auto entity = request.add_entities();
   auto counter_entry = entity->mutable_counter_entry();
   counter_entry->set_counter_id(counter_id);
-  counter_entry->set_index(index);
+  auto index_msg = counter_entry->mutable_index();
+  index_msg->set_index(index);
 
   p4::ReadResponse rep;
   ClientContext context;
@@ -662,7 +663,7 @@ SimpleRouterMgr::query_counter_(const std::string &counter_name, size_t index,
     for (const auto &entity : rep.entities()) {
       const auto &rep_entry = entity.counter_entry();
       if (rep_entry.counter_id() == counter_id &&
-          static_cast<size_t>(rep_entry.index()) == index) {
+          static_cast<size_t>(rep_entry.index().index()) == index) {
         counter_data->CopyFrom(rep_entry.data());
         return 0;
       }

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -256,7 +256,7 @@ message Index {
 // For WriteRequest, Update.Type must be MODIFY.
 // For ReadRequest, the scope is defined as follows:
 // - All meter cells for all meters if meter_id = 0 (default).
-// - All meter cells for given meter_id if index = 0 (default).
+// - All meter cells for given meter_id if index is unset (default).
 message MeterEntry {
   uint32 meter_id = 1;
   Index index = 2;
@@ -301,7 +301,7 @@ message MeterConfig {
 // For WriteRequest, Update.Type must be MODIFY.
 // For ReadRequest, the scope is defined as follows:
 // - All counter cells for all meters if counter_id = 0 (default).
-// - All counter cells for given counter_id if index = 0 (default).
+// - All counter cells for given counter_id if index is unset (default).
 message CounterEntry {
   uint32 counter_id = 1;
   Index index = 2;

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -241,6 +241,17 @@ message ActionProfileGroup {
   int32 max_size = 4;  // cannot be modified after a group has been created
 }
 
+// An index as a protobuf message. In proto3, fields cannot be optional and
+// there is no difference between an unset integer field and an integer field
+// set to 0. This is inconvenient for reading from P4 array-like structures,
+// such as indirect counters and meters. We need a way to do a wildcard read on
+// these but we cannot use a default zero index value to do so, as zero is a
+// valid index (first entry in the array). We therefore wrap the index in a
+// message.
+message Index {
+  int64 index = 1;
+}
+
 //------------------------------------------------------------------------------
 // For WriteRequest, Update.Type must be MODIFY.
 // For ReadRequest, the scope is defined as follows:
@@ -248,7 +259,7 @@ message ActionProfileGroup {
 // - All meter cells for given meter_id if index = 0 (default).
 message MeterEntry {
   uint32 meter_id = 1;
-  int64 index = 2;
+  Index index = 2;
   MeterConfig config = 3;
 }
 
@@ -293,7 +304,7 @@ message MeterConfig {
 // - All counter cells for given counter_id if index = 0 (default).
 message CounterEntry {
   uint32 counter_id = 1;
-  int64 index = 2;
+  Index index = 2;
   CounterData data = 3;
 }
 

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -1452,6 +1452,11 @@ class IndirectMeterTest : public DeviceMgrTest  {
     return config;
   }
 
+  void set_index(p4::MeterEntry *meter_entry, int index) const {
+    auto *index_msg = meter_entry->mutable_index();
+    index_msg->set_index(index);
+  }
+
   pi_p4_id_t m_id{0};
   size_t m_size{0};
 };
@@ -1461,7 +1466,7 @@ TEST_F(IndirectMeterTest, WriteAndRead) {
   p4::ReadResponse response;
   p4::MeterEntry meter_entry;
   meter_entry.set_meter_id(m_id);
-  meter_entry.set_index(index);
+  set_index(&meter_entry, index);
   auto meter_config = make_meter_config();
   meter_entry.mutable_config()->CopyFrom(meter_config);
   // meter type & unit as per the P4 program
@@ -1666,6 +1671,11 @@ class IndirectCounterTest : public DeviceMgrTest  {
     return status;
   }
 
+  void set_index(p4::CounterEntry *counter_entry, int index) const {
+    auto *index_msg = counter_entry->mutable_index();
+    index_msg->set_index(index);
+  }
+
   pi_p4_id_t c_id{0};
   size_t c_size{0};
 };
@@ -1675,7 +1685,7 @@ TEST_F(IndirectCounterTest, WriteAndRead) {
   p4::ReadResponse response;
   p4::CounterEntry counter_entry;
   counter_entry.set_counter_id(c_id);
-  counter_entry.set_index(index);
+  set_index(&counter_entry, index);
   auto *counter_data = counter_entry.mutable_data();
   counter_data->set_packet_count(3);
   // check packets, but not bytes, as per P4 program (packet-only counter)
@@ -1715,7 +1725,7 @@ TEST_F(IndirectCounterTest, ReadAll) {
   counter_data->set_packet_count(0);
   for (size_t i = 0; i < c_size; i++) {
     const auto &entry = entities.Get(i).counter_entry();
-    counter_entry.set_index(i);
+    set_index(&counter_entry, i);
     ASSERT_TRUE(MessageDifferencer::Equals(counter_entry, entry));
   }
 }


### PR DESCRIPTION
This ensures that we can distinguish between an unset index (wildcard
read / write) and a zero index (first entry in the resource index).

Fixes #309