### PR TITLE
Support reading direct resources with p4.TableEntry

### DIFF
--- a/include/PI/int/pi_int.h
+++ b/include/PI/int/pi_int.h
@@ -47,7 +47,7 @@ static inline pi_p4_id_t pi_make_meter_id(uint16_t index) {
   return (PI_METER_ID << 24) | index;
 }
 
-#define PI_GET_TYPE_ID(id) (id >> 24)
+#define PI_GET_TYPE_ID(id) ((id) >> 24)
 
 // TODO(antonin): find a better location
 static inline size_t get_match_key_size_one_field(
@@ -93,11 +93,14 @@ struct pi_table_fetch_res_s {
   size_t curr;
   size_t entries_size;
   char *entries;
-  // just pointers to entries byte array
-  struct pi_match_key_s *match_keys;
-  struct pi_action_data_s *action_datas;
-  struct pi_entry_properties_s *properties;
-  // direct resources
+
+  // byte buffer to store structs used to represent entries in contiguous memory
+  // includes pointers to entries byte buffer
+  char *data;
+  // size reserved for each entry in data byte buffer
+  size_t data_size_per_entry;
+  size_t num_direct_resources;
+  size_t max_size_of_direct_resources;
 };
 
 struct pi_act_prof_fetch_res_s {

--- a/include/PI/p4info/tables.h
+++ b/include/PI/p4info/tables.h
@@ -115,6 +115,9 @@ bool pi_p4info_table_is_direct_resource_of(const pi_p4info_t *p4info,
                                            pi_p4_id_t table_id,
                                            pi_p4_id_t direct_res_id);
 
+size_t pi_p4info_table_num_direct_resources(const pi_p4info_t *p4info,
+                                            pi_p4_id_t table_id);
+
 const pi_p4_id_t *pi_p4info_table_get_direct_resources(
     const pi_p4info_t *p4info, pi_p4_id_t table_id,
     size_t *num_direct_resources);

--- a/include/PI/pi.h
+++ b/include/PI/pi.h
@@ -120,7 +120,7 @@ pi_status_t pi_packetout_send(pi_dev_id_t dev_id, const char *pkt, size_t size);
 // TODO(antonin): move this to pi_tables?
 // When adding a table entry, the configuration for direct resources associated
 // with the entry can be provided. The config is then passed as a generic void *
-// pointer. For the sake of the messaging system, we need a way to seriralize /
+// pointer. For the sake of the messaging system, we need a way to serialize /
 // de-serialize the config, thus the need for these:
 // size when serialized
 typedef size_t (*PIDirectResMsgSizeFn)(const void *config);

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -221,6 +221,15 @@ class DeviceMgrTest : public ::testing::Test {
     return mgr.read_one(entity, response);
   }
 
+  DeviceMgr::Status read_table_entry(p4::TableEntry *table_entry,
+                                     p4::ReadResponse *response) {
+    p4::Entity entity;
+    entity.set_allocated_table_entry(table_entry);
+    auto status = mgr.read_one(entity, response);
+    entity.release_table_entry();
+    return status;
+  }
+
   static constexpr const char *input_path =
            TESTDATADIR "/" "unittest.p4info.txt";
   static pi_p4info_t *p4info;
@@ -1358,16 +1367,34 @@ TEST_F(DirectMeterTest, WriteAndRead) {
     ASSERT_EQ(status.code(), Code::OK);
   }
 
+  // read with DirectMeterEntry
   EXPECT_CALL(*mock, meter_read_direct(m_id, entry_h, _));
-  p4::ReadResponse response;
   {
+    p4::ReadResponse response;
     auto status = read_meter(&meter_entry, &response);
     ASSERT_EQ(status.code(), Code::OK);
+    const auto &entities = response.entities();
+    ASSERT_EQ(1, entities.size());
+    const auto &read_entry = entities.Get(0).direct_meter_entry();
+    EXPECT_TRUE(MessageDifferencer::Equals(meter_entry, read_entry));
   }
-  const auto &entities = response.entities();
-  ASSERT_EQ(1, entities.size());
-  const auto &read_meter_entry = entities.Get(0).direct_meter_entry();
-  EXPECT_TRUE(MessageDifferencer::Equals(meter_entry, read_meter_entry));
+
+  // read with TableEntry
+  EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
+  {
+    p4::ReadResponse response;
+    p4::Entity entity;
+    auto table_entry = entity.mutable_table_entry();
+    table_entry->set_table_id(t_id);
+    table_entry->mutable_meter_config();
+    auto status = mgr.read_one(entity, &response);
+
+    ASSERT_EQ(status.code(), Code::OK);
+    const auto &entities = response.entities();
+    ASSERT_EQ(1, entities.size());
+    const auto &read_entry = entities.Get(0).table_entry();
+    EXPECT_TRUE(MessageDifferencer::Equals(config, read_entry.meter_config()));
+  }
 }
 
 TEST_F(DirectMeterTest, WriteInTableEntry) {
@@ -1551,19 +1578,38 @@ TEST_F(DirectCounterTest, WriteAndRead) {
     auto status = write_counter(&counter_entry);
     ASSERT_EQ(status.code(), Code::OK);
   }
+
+  // read with DirectCounterEntry
   EXPECT_CALL(*mock, counter_read_direct(c_id, entry_h, _, _));
-  p4::ReadResponse response;
   {
+    p4::ReadResponse response;
     auto status = read_counter(&counter_entry, &response);
     ASSERT_EQ(status.code(), Code::OK);
+    const auto &entities = response.entities();
+    ASSERT_EQ(1, entities.size());
+    const auto &read_entry = entities.Get(0).direct_counter_entry();
+    EXPECT_TRUE(MessageDifferencer::Equals(entry, read_entry.table_entry()));
+    EXPECT_EQ(read_entry.data().byte_count(), 0);
+    EXPECT_EQ(read_entry.data().packet_count(), 3);
   }
-  const auto &entities = response.entities();
-  ASSERT_EQ(1, entities.size());
-  const auto &read_counter_entry = entities.Get(0).direct_counter_entry();
-  EXPECT_TRUE(MessageDifferencer::Equals(entry,
-                                         read_counter_entry.table_entry()));
-  EXPECT_EQ(read_counter_entry.data().byte_count(), 0);
-  EXPECT_EQ(read_counter_entry.data().packet_count(), 3);
+
+  // read with TableEntry
+  EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
+  {
+    p4::ReadResponse response;
+    p4::Entity entity;
+    auto table_entry = entity.mutable_table_entry();
+    table_entry->set_table_id(t_id);
+    table_entry->mutable_counter_data();
+    auto status = mgr.read_one(entity, &response);
+
+    ASSERT_EQ(status.code(), Code::OK);
+    const auto &entities = response.entities();
+    ASSERT_EQ(1, entities.size());
+    const auto &read_entry = entities.Get(0).table_entry();
+    EXPECT_EQ(read_entry.counter_data().byte_count(), 0);
+    EXPECT_EQ(read_entry.counter_data().packet_count(), 3);
+  }
 }
 
 TEST_F(DirectCounterTest, InvalidTableEntry) {
@@ -1822,7 +1868,7 @@ TEST_F(MatchKeyFormatTest, BadLeadingZeros) {
 }
 
 
-#define EXPECT_ONE_TABLE_ENTRY(repsonse, expected_entry) \
+#define EXPECT_ONE_TABLE_ENTRY(response, expected_entry) \
   do {                                                   \
     const auto &entities = response.entities();          \
     ASSERT_EQ(1, entities.size());                       \

--- a/src/p4info/tables.c
+++ b/src/p4info/tables.c
@@ -459,6 +459,12 @@ bool pi_p4info_table_is_direct_resource_of(const pi_p4info_t *p4info,
   return false;
 }
 
+size_t pi_p4info_table_num_direct_resources(const pi_p4info_t *p4info,
+                                            pi_p4_id_t table_id) {
+  _table_data_t *table = get_table(p4info, table_id);
+  return table->num_direct_resources;
+}
+
 const pi_p4_id_t *pi_p4info_table_get_direct_resources(
     const pi_p4info_t *p4info, pi_p4_id_t table_id,
     size_t *num_direct_resources) {

--- a/targets/bmv2/pi_tables_imp.cpp
+++ b/targets/bmv2/pi_tables_imp.cpp
@@ -639,6 +639,7 @@ pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
   data_size += entries.size() * sizeof(s_pi_action_entry_type_t);
   data_size += entries.size() * sizeof(uint32_t);  // for priority
   data_size += entries.size() * sizeof(uint32_t);  // for properties
+  data_size += entries.size() * sizeof(uint32_t);  // for direct resources
 
   res->mkey_nbytes = pi_p4info_table_match_key_size(p4info, table_id);
   data_size += entries.size() * res->mkey_nbytes;
@@ -743,7 +744,8 @@ pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
         break;
     }
 
-    data += emit_uint32(data, 0);
+    data += emit_uint32(data, 0);  // properties
+    data += emit_uint32(data, 0);  // TODO(antonin): direct resources
   }
 
   return PI_STATUS_SUCCESS;


### PR DESCRIPTION
We now support reading direct resources when reading a `TableEntry` with P4Runtime. The values will only be included in the `TableEntry` message if the corresponding fields are not unset, which is inconsistent with one of the comments in p4runtime.proto, which specifies that "The counter_data field will always be set in a read table entry if the table contains a direct counter." (I cannot remember the rationale for this rule)

In order to support this in P4Runtime, support also had to be added to the PI library, and in particular `pi_table_entries_fetch`.