### PR TITLE
Null check for invalid params

### DIFF
--- a/src/p4info/actions.c
+++ b/src/p4info/actions.c
@@ -249,11 +249,11 @@ size_t pi_p4info_action_param_bitwidth(const pi_p4info_t *p4info,
                                        pi_p4_id_t action_id,
                                        pi_p4_id_t param_id) {
   _action_data_t *action = get_action(p4info, action_id);
-  _action_param_data_t * param = get_param_data_at(action, param_id);
-  if (param == 0)
-      return (size_t)(-1);
+  _action_param_data_t *param = get_param_data_at(action, param_id);
+  if (param == NULL)
+    return (size_t)(-1);
   else
-      return param->bitwidth;
+    return param->bitwidth;
 }
 
 char pi_p4info_action_param_byte0_mask(const pi_p4info_t *p4info,

--- a/src/p4info/actions.c
+++ b/src/p4info/actions.c
@@ -249,7 +249,11 @@ size_t pi_p4info_action_param_bitwidth(const pi_p4info_t *p4info,
                                        pi_p4_id_t action_id,
                                        pi_p4_id_t param_id) {
   _action_data_t *action = get_action(p4info, action_id);
-  return get_param_data_at(action, param_id)->bitwidth;
+  _action_param_data_t * param = get_param_data_at(action, param_id);
+  if (param == 0)
+      return (size_t)(-1);
+  else
+      return param->bitwidth;
 }
 
 char pi_p4info_action_param_byte0_mask(const pi_p4info_t *p4info,


### PR DESCRIPTION
P4RT/GRPC client code can mistakenly set an invalid param ID for an action, causing the server code to crash. E.g. on the controller side:

         pi_p4_id_t set_id = pi_p4info_action_param_id_from_name(p4info, a_id, "invalid_id");
         param->set_param_id(set_id);

The server side doesn't check for null and seg faults instead of returning an error
