### PR TITLE
Support for arbitrary type serialization in P4Runtime

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -18,6 +18,7 @@ PROTOFLAGS = -I$(abs_srcdir) -I$(abs_builddir)
 
 # Absolute paths are needed here for 'make distcheck' to work properly
 protos = \
+$(abs_srcdir)/p4/p4types.proto \
 $(abs_srcdir)/p4/p4runtime.proto \
 $(abs_srcdir)/p4/config/p4info.proto \
 $(abs_srcdir)/google/rpc/status.proto \
@@ -28,6 +29,7 @@ $(abs_srcdir)/gnmi/gnmi.proto
 # Somehow, using an absolute path above prevents me from using EXTRA_DIST =
 # $(protos)
 EXTRA_DIST = \
+p4/p4types.proto \
 p4/p4runtime.proto \
 p4/config/p4info.proto \
 google/rpc/status.proto \
@@ -36,6 +38,8 @@ p4/tmp/p4config.proto \
 gnmi/gnmi.proto
 
 proto_cpp_files = \
+cpp_out/p4/p4types.pb.cc \
+cpp_out/p4/p4types.pb.h \
 cpp_out/p4/p4runtime.pb.cc \
 cpp_out/p4/p4runtime.pb.h \
 cpp_out/p4/config/p4info.pb.cc \
@@ -50,6 +54,8 @@ cpp_out/gnmi/gnmi.pb.cc \
 cpp_out/gnmi/gnmi.pb.h
 
 proto_grpc_files = \
+grpc_out/p4/p4types.grpc.pb.cc \
+grpc_out/p4/p4types.grpc.pb.h \
 grpc_out/p4/p4runtime.grpc.pb.cc \
 grpc_out/p4/p4runtime.grpc.pb.h \
 grpc_out/p4/config/p4info.grpc.pb.cc \
@@ -65,6 +71,8 @@ grpc_out/gnmi/gnmi.grpc.pb.h
 
 includep4dir = $(includedir)/p4/
 nodist_includep4_HEADERS = \
+cpp_out/p4/p4types.pb.h \
+grpc_out/p4/p4types.grpc.pb.h \
 cpp_out/p4/p4runtime.pb.h \
 grpc_out/p4/p4runtime.grpc.pb.h
 
@@ -98,6 +106,7 @@ BUILT_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
 if HAVE_GRPC_PY_PLUGIN
 p4pydir = $(pythondir)/p4
 nodist_p4py_PYTHON = \
+py_out/p4/p4types_pb2.py \
 py_out/p4/p4runtime_pb2.py \
 py_out/p4/__init__.py
 

--- a/proto/docs/p4runtime_type_serialization.md
+++ b/proto/docs/p4runtime_type_serialization.md
@@ -1,0 +1,96 @@
+# Arbitary P4_16 type serialization in P4Runtime
+
+## Problem statement
+The P4_16 language includes more complex types than just bitstrings or even
+headers (see [P4_16
+specification](https://p4.org/p4-spec/docs/P4-16-v1.0.0-spec.html#sec-p4-type)). Most
+of these complex data types can be exposed to the control-plane through table
+key expressions, value set lookup expressions, register (PSA extern type) value
+types, etc. Not supporting these more compex types can be very limiting. For
+example, the following P4_16 objects involve complex types that need to be
+exposed in P4Runtime in order to support runtime operations on these objects.
+
+```
+value_set<tuple<bit<16>, bit<8> > > pvs_complex;
+state parse_ipv4 {
+   packet.extract<ipv4_t>(hdr.ipv4);
+   transition select({ hdr.ipv4.version, hdr.ipv4.protocol }){
+       pvs_complex: parse_inner;
+       default: accept;
+   }
+}
+```
+
+```
+header_union ip_t {
+   ipv4_t ipv4;
+   ipv6_t ipv6;
+}
+Register<ip_t, bit<32> >(128) register_ip;
+```
+
+One solution would be to use only bitstrings (`bytes` type) in p4runtime.proto
+and to define a custom serialization format for complex P4_16 types. The
+serialization would maybe be trivial for header types but would require some
+work for header unions, stacks, etc. Rather than coming-up with a serialization
+format from scratch, we decided to use a Protobuf representation for all P4_16
+types, since the P4Runtime service already uses Protobuf messages.
+
+## P4 type specifications in p4info.proto
+In order for the P4Runtime client to generate correctly-formatted messages and
+for the P4Runtime service implementation to validate them, P4Info needs to
+specify the type of each P4 expression which is exposed to the control-plane. In
+the register example above, client and server need to know that each element of
+the register has type `ip_t`, which is a header union with 2 possible headers:
+`ipv4` with type `ipv4_t` and `ipv6` with type `ipv6`. Similarly, they need to
+know the field layout of both these header types.
+
+To achieve this we introduce 2 main protobuf messages: `P4TypeInfo` and
+`P4DataTypeSpec`.
+
+`P4TypeInfo` is a top-level member of `P4Info` and includes Protobuf maps
+storing the type specification for all the named types in the P4_16
+program. These named types are `struct`, `header`, `header_union` and `enum`;
+for each of these we have a type specification message, respectively
+`P4StructTypeSpec`, `P4HeaderTypeSpec`, `P4HeaderUnionTypeSpec` and
+`P4EnumTypeSpec`. We support P4 annotations for named types, which is useful to
+identify well-known headers, such as IPv4 or IPv6. `P4TypeInfo` also include the
+list of parser errors for the program, as a `P4ErrorTypeSpec` message.
+
+`P4DataTypeSpec` is meant to be used in `P4Info`, everywhere where the P4Runtime
+client can provide a value for a P4_16 expression. `P4DataTypeSpec` describes
+the compile-time of the expression as a Protobuf `oneof`, which is a `string` in
+case of a named type (`struct`, `header`, `header_union` or `enum`), an empty
+Protobuf message for `bool` and `error`, and a Protobuf message for other
+anonymous types (`bit<W>`, `int<W>`, `varbit<W>`, `tuple` or `stack`). The
+"bitstring" types (`bit<W>`, `int<W>` and `varbit<W>`) are grouped together in
+the `P4BitstringLikeTypeSpec` message, since they are the only sub-types allowed
+in headers and values with one of these types are represented similarly in
+P4Runtime (with binary strings).
+
+## P4 data in p4runtime.proto
+P4Runtime uses the `P4Data` message to represent values with arbitrary
+types. The P4Runtime client must generate correct `P4Data` messages based on the
+type specification information included in `P4Info`. The `P4Data` message was
+designed to introduce little overhead compared to using binary strings in the
+most common case (P4_16 `bit<W>` type).
+
+Just like its `P4Info` counterpart `P4DataTypeSpec`, `P4Data` uses a `oneof` to
+represent all possible values.
+
+### `enum` and `error`
+We currently use human-readable `string` in `P4Data` to represent `enum` and
+`error` values. Indeed, the current P4_16 specification does not specify any
+mechanism through which integer values are assigned to `enum` and `error`
+members -whether automatically by the compiler or by letting the programmer pick
+values. We may switch to an `int32` representation if the P4 language is updated
+to specify the underlying representation of enums, in which case we would also
+include a mapping from name to integer value in the `P4TypeInfo` message.
+
+## Trade-off for v1.0 release
+For the v1.0 release of P4Runtime, the Working Group has decided not to replace
+occurences of `bytes` with `P4Data` in the `FieldMatch` message, which is used
+to represent table and value set entries. This is to avoid breaking
+already-existing implementations of P4Runtime. However `P4Data` is used whenever
+appropriate for PSA externs and we encourage the use of `P4Data` in
+architecture-specific extensions.

--- a/proto/docs/p4runtime_type_serialization.md
+++ b/proto/docs/p4runtime_type_serialization.md
@@ -72,7 +72,7 @@ For all P4_16 compound types (`tuple`, `struct`, `header`, and `header_union`),
 the order of members in the `repeated` field of the Protobuf type specification
 is guaranteed to be the same as the order of the members in the corresponding
 P4_16 declaration. The same goes for the order of members of an `enum` or
-members of `error`, as well as for the order of entries is a `stack`.
+members of `error`, as well as for the order of entries in a `stack`.
 
 ## P4 data in p4runtime.proto
 P4Runtime uses the `P4Data` message to represent values with arbitrary

--- a/proto/docs/p4runtime_type_serialization.md
+++ b/proto/docs/p4runtime_type_serialization.md
@@ -68,6 +68,12 @@ the `P4BitstringLikeTypeSpec` message, since they are the only sub-types allowed
 in headers and values with one of these types are represented similarly in
 P4Runtime (with binary strings).
 
+For all P4_16 compound types (`tuple`, `struct`, `header`, and `header_union`),
+the order of members in the `repeated` field of the Protobuf type specification
+is guaranteed to be the same as the order of the members in the corresponding
+P4_16 declaration. The same goes for the order of members of an `enum` or
+members of `error`, as well as for the order of entries is a `stack`.
+
 ## P4 data in p4runtime.proto
 P4Runtime uses the `P4Data` message to represent values with arbitrary
 types. The P4Runtime client must generate correct `P4Data` messages based on the
@@ -77,6 +83,12 @@ most common case (P4_16 `bit<W>` type).
 
 Just like its `P4Info` counterpart `P4DataTypeSpec`, `P4Data` uses a `oneof` to
 represent all possible values.
+
+The order of `members` in `P4StructLike`, the order of `bitstrings` in
+`P4Header`, and the order of `entries` in `P4HeaderStack` and
+`P4HeaderUnionStack` must match the order in the corresponding `p4info.proto`
+type specification and hence the order in the corresponding P4_16 type
+declaration.
 
 ### `enum` and `error`
 We currently use human-readable `string` in `P4Data` to represent `enum` and
@@ -91,6 +103,7 @@ include a mapping from name to integer value in the `P4TypeInfo` message.
 For the v1.0 release of P4Runtime, the Working Group has decided not to replace
 occurences of `bytes` with `P4Data` in the `FieldMatch` message, which is used
 to represent table and value set entries. This is to avoid breaking
-already-existing implementations of P4Runtime. However `P4Data` is used whenever
-appropriate for PSA externs and we encourage the use of `P4Data` in
+already-existing implementations of P4Runtime. Similarly it has been decided to
+keep using `bytes` to provide action parameter values. However `P4Data` is used
+whenever appropriate for PSA externs and we encourage the use of `P4Data` in
 architecture-specific extensions.

--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 
 import "google/protobuf/any.proto";
+import "p4/p4types.proto";
 
 // This package and its contents are a work-in-progress.
 
@@ -31,7 +32,9 @@ message P4Info {
   repeated DirectMeter direct_meters = 8;
   repeated ControllerPacketMetadata controller_packet_metadata = 9;
   repeated ValueSet value_sets = 10;
+  repeated Register registers = 11;
   repeated Extern externs = 100;
+  P4TypeInfo type_info = 200;
 }
 
 message Documentation {
@@ -265,5 +268,11 @@ message ValueSet {
   int32 bitwidth = 2;
   // The value set size should be extracted from the @size annotation into the
   // field below. The @size annotation will also appear in the preamble.
+  int32 size = 3;
+}
+
+message Register {
+  Preamble preamble = 1;
+  P4DataTypeSpec type_spec = 2;
   int32 size = 3;
 }

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
 import "p4/config/p4info.proto";
+import "p4/p4types.proto";
 
 // P4_14 spec: http://p4.org/wp-content/uploads/2015/04/p4-latest.pdf
 
@@ -100,6 +101,7 @@ message Entity {
     DirectCounterEntry direct_counter_entry = 8;
     PacketReplicationEngineEntry packet_replication_engine_entry = 9;
     ValueSetEntry value_set_entry = 10;
+    RegisterEntry register_entry = 11;
   }
 }
 
@@ -389,6 +391,12 @@ message CloneSessionEntry {
 message ValueSetEntry {
   uint32 value_set_id = 1;
   repeated FieldMatch match = 2;
+}
+
+message RegisterEntry {
+  uint32 register_id = 1;
+  Index index = 2;
+  P4Data data = 3;
 }
 
 //------------------------------------------------------------------------------

--- a/proto/p4/p4types.proto
+++ b/proto/p4/p4types.proto
@@ -1,0 +1,207 @@
+// Copyright 2013-present Barefoot Networks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package p4;
+
+// P4 type specs ---------------------------------------------------------------
+
+// From the P4_16 spec:
+/* |--------------------|--------------------------------------------|
+ * |                    | Container type                             |
+ * | Element type       |-----------|--------------|-----------------|
+ * |                    | header    | header_union | struct or tuple |
+ * |--------------------|-----------|--------------|-----------------|
+ * | bit<W>             | allowed   | error        | allowed         |
+ * | int<W>             | allowed   | error        | allowed         |
+ * | varbit<W>          | allowed   | error        | allowed         |
+ * | int                | error     | error        | error           |
+ * | void               | error     | error        | error           |
+ * | error              | error     | error        | allowed         |
+ * | match_kind         | error     | error        | error           |
+ * | bool               | error     | error        | allowed         |
+ * | enum               | error     | error        | allowed         |
+ * | header             | error     | allowed      | allowed         |
+ * | header stack       | error     | error        | allowed         |
+ * | header_union       | error     | error        | allowed         |
+ * | struct             | error     | error        | allowed         |
+ * | tuple              | error     | error        | allowed         |
+ * |--------------------|-----------|--------------|-----------------|
+ */
+
+// These P4 types (struct, header_type, header_union and enum) are guaranteed to
+// be "named" (e.g. you cannot use an anonymous struct to declare a variable,
+// like in C). Instead of duplicating the type spec for these every time the
+// type is used, we include the type spec once in this P4TypeInfo message and
+// refer to the types by name in the P4DataTypeSpec message. We also support
+// annotations for these type specs which can be useful, e.g. to identify
+// well-known headers (such as ipv4).
+message P4TypeInfo {
+  map<string, P4StructTypeSpec> structs = 1;
+  map<string, P4HeaderTypeSpec> headers = 2;
+  map<string, P4HeaderUnionTypeSpec> header_unions = 3;
+  map<string, P4EnumTypeSpec> enums = 4;
+  P4ErrorTypeSpec error = 5;
+}
+
+// Describes a P4_16 type.
+message P4DataTypeSpec {
+  oneof type_spec {
+    P4BitstringLikeTypeSpec bitstring = 1;
+    P4BoolType bool = 2;
+    // From the P4_16 spec: "A tuple is similar to a struct, in that it holds
+    // multiple values. Unlike a struct type, tuples have no named fields."
+    P4TupleTypeSpec tuple = 3;
+    P4NamedType struct = 4;
+    P4NamedType header = 5;
+    P4NamedType header_union = 6;
+    P4HeaderStackTypeSpec header_stack = 7;
+    P4HeaderUnionStackTypeSpec header_union_stack = 8;
+    P4NamedType enum = 9;
+    P4ErrorType error = 10;
+  }
+}
+
+message P4NamedType {
+  string name = 1;
+}
+
+// Empty message as no type information needed, just used as a placeholder in
+// the oneof to identify boolean types.
+message P4BoolType { }
+
+message P4ErrorType { }
+
+message P4BitstringLikeTypeSpec {
+  oneof type_spec {
+    P4BitTypeSpec bit = 1;  // bit<W>
+    P4IntTypeSpec int = 2;  // int<W>
+    P4VarbitTypeSpec varbit = 3;  // varbit<W>
+  }
+  // Useful to identify well-know types, such as IP address or Ethernet MAC
+  // address.
+  repeated string annotations = 4;
+}
+
+message P4BitTypeSpec {
+  int32 bitwidth = 1;
+}
+
+message P4IntTypeSpec {
+  int32 bitwidth = 1;
+}
+
+message P4VarbitTypeSpec {
+  int32 max_bitwidth = 1;
+}
+
+message P4TupleTypeSpec {
+  repeated P4DataTypeSpec members = 1;
+}
+
+message P4StructTypeSpec {
+  message Member {
+    string name = 1;
+    P4DataTypeSpec type_spec = 2;
+  }
+  repeated Member members = 1;
+  repeated string annotations = 2;
+}
+
+message P4HeaderTypeSpec {
+  message Member {
+    string name = 1;
+    P4BitstringLikeTypeSpec type_spec = 2;
+  }
+  repeated Member members = 1;
+  repeated string annotations = 2;
+}
+
+message P4HeaderUnionTypeSpec {
+  message Member {
+    string name = 1;
+    P4NamedType header = 2;
+  }
+  repeated Member members = 1;
+  repeated string annotations = 2;
+}
+
+message P4HeaderStackTypeSpec {
+  P4NamedType header = 1;
+  int32 size = 2;
+}
+
+message P4HeaderUnionStackTypeSpec {
+  P4NamedType header_union = 1;
+  int32 size = 2;
+}
+
+// As of today, P4_16 enum members have no integer value assigned to
+// them. Future versions of this protobuf interface may use integer values for
+// enums in P4Data, which means the repeated field would be replaced by a map in
+// this message (mapping from member names to integer values). This is dependent
+// on future versions of the P4 language.
+message P4EnumTypeSpec {
+  repeated string members = 1;
+  repeated string annotations = 2;
+}
+
+// Similar to an enum, but there is always one and only one instance per P4
+// program.
+message P4ErrorTypeSpec {
+  repeated string members = 1;
+}
+
+// End of P4 type specs --------------------------------------------------------
+
+message P4Data {
+  oneof data {
+    bytes bitstring = 1;  // for bit<W>, int<W>, varbit<W>
+    bool bool = 2;
+    P4StructLike tuple = 3;
+    P4StructLike struct = 4;
+    P4Header header = 5;
+    P4HeaderUnion header_union = 6;
+    P4HeaderStack header_stack = 7;
+    P4HeaderUnionStack header_union_stack = 8;
+    // Could be replaced with integer values in future versions.
+    string enum = 9;
+    string error = 10;
+  }
+}
+
+message P4StructLike {
+  repeated P4Data members = 1;
+}
+
+message P4Header {
+  bool is_valid = 1;
+  repeated bytes bitstrings = 2;
+}
+
+message P4HeaderUnion {
+  // An empty string indicates that none of the union members are valid and
+  // valid_header must therefore be unset.
+  string valid_header_name = 1;
+  P4Header valid_header = 2;
+}
+
+message P4HeaderStack {
+  repeated P4Header entries = 1;
+}
+
+message P4HeaderUnionStack {
+  repeated P4HeaderUnion entries = 1;
+}

--- a/proto/p4/p4types.proto
+++ b/proto/p4/p4types.proto
@@ -154,7 +154,11 @@ message P4HeaderUnionStackTypeSpec {
 // this message (mapping from member names to integer values). This is dependent
 // on future versions of the P4 language.
 message P4EnumTypeSpec {
-  repeated string members = 1;
+  message Member {
+    string name = 1;
+    repeated string annotations = 2;
+  }
+  repeated Member members = 1;
   repeated string annotations = 2;
 }
 

--- a/proto/p4/p4types.proto
+++ b/proto/p4/p4types.proto
@@ -42,12 +42,12 @@ package p4;
  */
 
 // These P4 types (struct, header_type, header_union and enum) are guaranteed to
-// be "named" (e.g. you cannot use an anonymous struct to declare a variable,
-// like in C). Instead of duplicating the type spec for these every time the
-// type is used, we include the type spec once in this P4TypeInfo message and
-// refer to the types by name in the P4DataTypeSpec message. We also support
-// annotations for these type specs which can be useful, e.g. to identify
-// well-known headers (such as ipv4).
+// have a fully-qualified name (e.g. you cannot use an anonymous struct to
+// declare a variable like in C). Instead of duplicating the type spec for these
+// every time the type is used, we include the type spec once in this P4TypeInfo
+// message and refer to the types by name in the P4DataTypeSpec message. We also
+// support annotations for these type specs which can be useful, e.g. to
+// identify well-known headers (such as ipv4).
 message P4TypeInfo {
   map<string, P4StructTypeSpec> structs = 1;
   map<string, P4HeaderTypeSpec> headers = 2;
@@ -61,8 +61,6 @@ message P4DataTypeSpec {
   oneof type_spec {
     P4BitstringLikeTypeSpec bitstring = 1;
     P4BoolType bool = 2;
-    // From the P4_16 spec: "A tuple is similar to a struct, in that it holds
-    // multiple values. Unlike a struct type, tuples have no named fields."
     P4TupleTypeSpec tuple = 3;
     P4NamedType struct = 4;
     P4NamedType header = 5;
@@ -90,7 +88,7 @@ message P4BitstringLikeTypeSpec {
     P4IntTypeSpec int = 2;  // int<W>
     P4VarbitTypeSpec varbit = 3;  // varbit<W>
   }
-  // Useful to identify well-know types, such as IP address or Ethernet MAC
+  // Useful to identify well-known types, such as IP address or Ethernet MAC
   // address.
   repeated string annotations = 4;
 }
@@ -107,6 +105,8 @@ message P4VarbitTypeSpec {
   int32 max_bitwidth = 1;
 }
 
+// From the P4_16 spec: "A tuple is similar to a struct, in that it holds
+// multiple values. Unlike a struct type, tuples have no named fields."
 message P4TupleTypeSpec {
   repeated P4DataTypeSpec members = 1;
 }


### PR DESCRIPTION
Adds support for arbitrary P4_16 types in P4Runtime, as discussed at the
03/21/2018 WG meeting (refer to minutes).

The changes incur minimal overhead for the most-common case (`bit<W>` in
P4, for which we use a binary string in P4Runtime), and enable us to
support complex types in lookup expressions and PSA externs such as
Register and Digest.

We include some documentation for the type specifications (P4Info) and
value representations (P4Runtime) which can be merged in the main
P4Info/P4Runtime specification in the future (before the v1.0 release).

To avoid breaking existing implementations, we do not use the new P4Data
representation for tables and value-sets.