### PR TITLE
Add support for P4Runtime RECONCILE_AND_COMMIT

### DIFF
--- a/CLI/table_dump.c
+++ b/CLI/table_dump.c
@@ -138,8 +138,8 @@ static pi_cli_status_t dump_entries(pi_p4_id_t t_id,
     }
 
     uint32_t priority = pi_match_key_get_priority(entry.match_key);
-    // TODO(antonin): bmv2 quirk, for tables with no priority, -1 is returned
-    if (priority != (uint32_t)-1) printf("Priority: %u\n", priority);
+    // TODO(antonin): 0 means no priority?
+    if (priority != 0) printf("Priority: %u\n", priority);
 
     print_action_entry(&entry.entry);
   }

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,12 @@ ENV PI_DEPS automake \
             g++ \
             libboost-dev \
             libboost-system-dev \
+            libboost-thread-dev \
             libtool \
             pkg-config \
             libjudy-dev
 ENV PI_RUNTIME_DEPS libboost-system1.58.0 \
+                    libboost-thread1.58.0 \
                     libjudydebian1 \
                     python
 

--- a/Dockerfile.bmv2
+++ b/Dockerfile.bmv2
@@ -29,6 +29,7 @@ ENV PI_DEPS automake \
             g++-6 \
             libboost-dev \
             libboost-system-dev \
+            libboost-thread-dev \
             libtool \
             libtool-bin \
             pkg-config \
@@ -39,6 +40,7 @@ ENV PI_DEPS automake \
             doxygen \
             valgrind
 ENV PI_RUNTIME_DEPS libboost-system1.58.0 \
+                    libboost-thread1.58.0 \
                     libjudydebian1 \
                     libpcap0.8 \
                     python

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -47,6 +47,13 @@ AS_IF([test "$PYTHON" != :], [
 ])
 AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
 
+AX_BOOST_BASE([1.54.0], [], [AC_MSG_ERROR(
+              [Please install boost >= 1.54.0 (thread and system)])])
+AX_BOOST_THREAD
+AX_BOOST_SYSTEM
+AC_SUBST([BOOST_THREAD_LIB])
+AC_SUBST([BOOST_SYSTEM_LIB])
+
 want_bmv2=no
 AC_ARG_WITH([bmv2],
     AS_HELP_STRING([--with-bmv2], [Build for bmv2 target]),
@@ -59,7 +66,6 @@ AC_CHECK_LIB([microhttpd], [MHD_start_daemon], [], [
     AC_MSG_WARN([microhttpd library not found, will not compile demo])
     with_proto_demo=no
 ])
-# TODO(antonin): demo also uses boost_system
 
 AM_CONDITIONAL([WITH_PROTO_DEMO], [test "$with_proto_demo" = yes])
 

--- a/proto/demo_grpc/Makefile.am
+++ b/proto/demo_grpc/Makefile.am
@@ -57,5 +57,5 @@ $(top_builddir)/../src/libpip4info.la \
 $(top_builddir)/libpiprotogrpc.la \
 $(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/p4info/libpiconvertproto.la \
--lmicrohttpd -lboost_system \
+-lmicrohttpd $(BOOST_SYSTEM_LIB) \
 $(PROTOBUF_LIBS) $(GRPC_LIBS)

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -31,7 +31,8 @@ $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \
 $(top_builddir)/p4info/libpiconvertproto.la \
 $(top_builddir)/libpiprotobuf.la \
 $(top_builddir)/../src/libpip4info.la \
-$(top_builddir)/third_party/libfmt.la
+$(top_builddir)/third_party/libfmt.la \
+$(BOOST_THREAD_LIB)
 
 nobase_include_HEADERS = \
 PI/frontends/proto/device_mgr.h \

--- a/proto/m4/ax_boost_base.m4
+++ b/proto/m4/ax_boost_base.m4
@@ -1,0 +1,272 @@
+# ===========================================================================
+#       http://www.gnu.org/software/autoconf-archive/ax_boost_base.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_BASE([MINIMUM-VERSION], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+#
+# DESCRIPTION
+#
+#   Test for the Boost C++ libraries of a particular version (or newer)
+#
+#   If no path to the installed boost library is given the macro searchs
+#   under /usr, /usr/local, /opt and /opt/local and evaluates the
+#   $BOOST_ROOT environment variable. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_CPPFLAGS) / AC_SUBST(BOOST_LDFLAGS)
+#
+#   And sets:
+#
+#     HAVE_BOOST
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Peter Adolphs
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 23
+
+AC_DEFUN([AX_BOOST_BASE],
+[
+AC_ARG_WITH([boost],
+  [AS_HELP_STRING([--with-boost@<:@=ARG@:>@],
+    [use Boost library from a standard location (ARG=yes),
+     from the specified location (ARG=<path>),
+     or disable it (ARG=no)
+     @<:@ARG=yes@:>@ ])],
+    [
+    if test "$withval" = "no"; then
+        want_boost="no"
+    elif test "$withval" = "yes"; then
+        want_boost="yes"
+        ac_boost_path=""
+    else
+        want_boost="yes"
+        ac_boost_path="$withval"
+    fi
+    ],
+    [want_boost="yes"])
+
+
+AC_ARG_WITH([boost-libdir],
+        AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
+        [Force given directory for boost libraries. Note that this will override library path detection, so use this parameter only if default library detection fails and you know exactly where your boost libraries are located.]),
+        [
+        if test -d "$withval"
+        then
+                ac_boost_lib_path="$withval"
+        else
+                AC_MSG_ERROR(--with-boost-libdir expected directory name)
+        fi
+        ],
+        [ac_boost_lib_path=""]
+)
+
+if test "x$want_boost" = "xyes"; then
+    boost_lib_version_req=ifelse([$1], ,1.20.0,$1)
+    boost_lib_version_req_shorten=`expr $boost_lib_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
+    boost_lib_version_req_major=`expr $boost_lib_version_req : '\([[0-9]]*\)'`
+    boost_lib_version_req_minor=`expr $boost_lib_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
+    boost_lib_version_req_sub_minor=`expr $boost_lib_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+    if test "x$boost_lib_version_req_sub_minor" = "x" ; then
+        boost_lib_version_req_sub_minor="0"
+        fi
+    WANT_BOOST_VERSION=`expr $boost_lib_version_req_major \* 100000 \+  $boost_lib_version_req_minor \* 100 \+ $boost_lib_version_req_sub_minor`
+    AC_MSG_CHECKING(for boostlib >= $boost_lib_version_req)
+    succeeded=no
+
+    dnl On 64-bit systems check for system libraries in both lib64 and lib.
+    dnl The former is specified by FHS, but e.g. Debian does not adhere to
+    dnl this (as it rises problems for generic multi-arch support).
+    dnl The last entry in the list is chosen by default when no libraries
+    dnl are found, e.g. when only header-only libraries are installed!
+    libsubdirs="lib"
+    ax_arch=`uname -m`
+    case $ax_arch in
+      x86_64|ppc64|s390x|sparc64|aarch64)
+        libsubdirs="lib64 lib lib64"
+        ;;
+    esac
+
+    dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give
+    dnl them priority over the other paths since, if libs are found there, they
+    dnl are almost assuredly the ones desired.
+    AC_REQUIRE([AC_CANONICAL_HOST])
+    libsubdirs="lib/${host_cpu}-${host_os} $libsubdirs"
+
+    case ${host_cpu} in
+      i?86)
+        libsubdirs="lib/i386-${host_os} $libsubdirs"
+        ;;
+    esac
+
+    dnl first we check the system location for boost libraries
+    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl or if you install boost with RPM
+    if test "$ac_boost_path" != ""; then
+        BOOST_CPPFLAGS="-I$ac_boost_path/include"
+        for ac_boost_path_tmp in $libsubdirs; do
+                if test -d "$ac_boost_path"/"$ac_boost_path_tmp" ; then
+                        BOOST_LDFLAGS="-L$ac_boost_path/$ac_boost_path_tmp"
+                        break
+                fi
+        done
+    elif test "$cross_compiling" != yes; then
+        for ac_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
+            if test -d "$ac_boost_path_tmp/include/boost" && test -r "$ac_boost_path_tmp/include/boost"; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$ac_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                BOOST_LDFLAGS="-L$ac_boost_path_tmp/$libsubdir"
+                BOOST_CPPFLAGS="-I$ac_boost_path_tmp/include"
+                break;
+            fi
+        done
+    fi
+
+    dnl overwrite ld flags if we have required special directory with
+    dnl --with-boost-libdir parameter
+    if test "$ac_boost_lib_path" != ""; then
+       BOOST_LDFLAGS="-L$ac_boost_lib_path"
+    fi
+
+    CPPFLAGS_SAVED="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+    export CPPFLAGS
+
+    LDFLAGS_SAVED="$LDFLAGS"
+    LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+    export LDFLAGS
+
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH(C++)
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <boost/version.hpp>
+    ]], [[
+    #if BOOST_VERSION >= $WANT_BOOST_VERSION
+    // Everything is okay
+    #else
+    #  error Boost version is too old
+    #endif
+    ]])],[
+        AC_MSG_RESULT(yes)
+    succeeded=yes
+    found_system=yes
+        ],[
+        ])
+    AC_LANG_POP([C++])
+
+
+
+    dnl if we found no boost with system layout we search for boost libraries
+    dnl built and installed without the --layout=system option or for a staged(not installed) version
+    if test "x$succeeded" != "xyes"; then
+        _version=0
+        if test "$ac_boost_path" != ""; then
+            if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
+                for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
+                    _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                    V_CHECK=`expr $_version_tmp \> $_version`
+                    if test "$V_CHECK" = "1" ; then
+                        _version=$_version_tmp
+                    fi
+                    VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                    BOOST_CPPFLAGS="-I$ac_boost_path/include/boost-$VERSION_UNDERSCORE"
+                done
+            fi
+        else
+            if test "$cross_compiling" != yes; then
+                for ac_boost_path in /usr /usr/local /opt /opt/local ; do
+                    if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
+                        for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
+                            _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                            V_CHECK=`expr $_version_tmp \> $_version`
+                            if test "$V_CHECK" = "1" ; then
+                                _version=$_version_tmp
+                                best_path=$ac_boost_path
+                            fi
+                        done
+                    fi
+                done
+
+                VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
+                if test "$ac_boost_lib_path" = ""; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$best_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$best_path/$libsubdir"
+                fi
+            fi
+
+            if test "x$BOOST_ROOT" != "x"; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$BOOST_ROOT/stage/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                if test -d "$BOOST_ROOT" && test -r "$BOOST_ROOT" && test -d "$BOOST_ROOT/stage/$libsubdir" && test -r "$BOOST_ROOT/stage/$libsubdir"; then
+                    version_dir=`expr //$BOOST_ROOT : '.*/\(.*\)'`
+                    stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
+                        stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
+                    V_CHECK=`expr $stage_version_shorten \>\= $_version`
+                    if test "$V_CHECK" = "1" -a "$ac_boost_lib_path" = "" ; then
+                        AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
+                        BOOST_CPPFLAGS="-I$BOOST_ROOT"
+                        BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
+                    fi
+                fi
+            fi
+        fi
+
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
+
+        AC_LANG_PUSH(C++)
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        @%:@include <boost/version.hpp>
+        ]], [[
+        #if BOOST_VERSION >= $WANT_BOOST_VERSION
+        // Everything is okay
+        #else
+        #  error Boost version is too old
+        #endif
+        ]])],[
+            AC_MSG_RESULT(yes)
+        succeeded=yes
+        found_system=yes
+            ],[
+            ])
+        AC_LANG_POP([C++])
+    fi
+
+    if test "$succeeded" != "yes" ; then
+        if test "$_version" = "0" ; then
+            AC_MSG_NOTICE([[We could not detect the boost libraries (version $boost_lib_version_req_shorten or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
+        else
+            AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
+        fi
+        # execute ACTION-IF-NOT-FOUND (if present):
+        ifelse([$3], , :, [$3])
+    else
+        AC_SUBST(BOOST_CPPFLAGS)
+        AC_SUBST(BOOST_LDFLAGS)
+        AC_DEFINE(HAVE_BOOST,,[define if the Boost library is available])
+        # execute ACTION-IF-FOUND (if present):
+        ifelse([$2], , :, [$2])
+    fi
+
+    CPPFLAGS="$CPPFLAGS_SAVED"
+    LDFLAGS="$LDFLAGS_SAVED"
+fi
+
+])

--- a/proto/m4/ax_boost_system.m4
+++ b/proto/m4/ax_boost_system.m4
@@ -1,0 +1,120 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_system.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_SYSTEM
+#
+# DESCRIPTION
+#
+#   Test for System library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_SYSTEM_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_SYSTEM
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2008 Michael Tindal
+#   Copyright (c) 2008 Daniel Casimiro <dan.casimiro@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 17
+
+AC_DEFUN([AX_BOOST_SYSTEM],
+[
+        AC_ARG_WITH([boost-system],
+        AS_HELP_STRING([--with-boost-system@<:@=special-lib@:>@],
+                   [use the System library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-system=boost_system-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+                want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_system_lib=""
+        else
+                    want_boost="yes"
+                        ax_boost_user_system_lib="$withval"
+                                fi
+        ],
+        [want_boost="yes"]
+        )
+
+        if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+                CPPFLAGS_SAVED="$CPPFLAGS"
+                        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+                                            export CPPFLAGS
+
+                                                   LDFLAGS_SAVED="$LDFLAGS"
+                                                        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+                                                                          export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::System library is available,
+                                                            ax_cv_boost_system,
+        [AC_LANG_PUSH([C++])
+                         CXXFLAGS_SAVE=$CXXFLAGS
+
+                                         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
+                                   [[boost::system::system_category]])],
+                   ax_cv_boost_system=yes, ax_cv_boost_system=no)
+                                                 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+                ])
+                        if test "x$ax_cv_boost_system" = "xyes"; then
+                                AC_SUBST(BOOST_CPPFLAGS)
+
+                                                AC_DEFINE(HAVE_BOOST_SYSTEM,,[define if the Boost::System library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+                                             LDFLAGS_SAVE=$LDFLAGS
+            if test "x$ax_boost_user_system_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+                                            AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
+                                 [link_system="no"])
+                                                        done
+                if test "x$link_system" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_system* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+                                            AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
+                                 [link_system="no"])
+                                                        done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_system_lib boost_system-$ax_boost_user_system_lib; do
+                                   AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
+                                   [link_system="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+                        if test "x$link_system" = "xno"; then
+                                                AC_MSG_ERROR(Could not link against $ax_lib !)
+                                                                       fi
+                                                                        fi
+
+                                                                                CPPFLAGS="$CPPFLAGS_SAVED"
+                                                                                LDFLAGS="$LDFLAGS_SAVED"
+                                                                                fi
+])

--- a/proto/m4/ax_boost_thread.m4
+++ b/proto/m4/ax_boost_thread.m4
@@ -1,0 +1,149 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_THREAD
+#
+# DESCRIPTION
+#
+#   Test for Thread library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_THREAD_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_THREAD
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Michael Tindal
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 27
+
+AC_DEFUN([AX_BOOST_THREAD],
+[
+        AC_ARG_WITH([boost-thread],
+        AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+                want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_thread_lib=""
+        else
+                    want_boost="yes"
+                        ax_boost_user_thread_lib="$withval"
+                                fi
+        ],
+        [want_boost="yes"]
+        )
+
+        if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+                CPPFLAGS_SAVED="$CPPFLAGS"
+                        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+                                            export CPPFLAGS
+
+                                                   LDFLAGS_SAVED="$LDFLAGS"
+                                                        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+                                                                          export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::Thread library is available,
+                                                            ax_cv_boost_thread,
+        [AC_LANG_PUSH([C++])
+                         CXXFLAGS_SAVE=$CXXFLAGS
+
+                                         if test "x$host_os" = "xsolaris" ; then
+                                                              CXXFLAGS="-pthreads $CXXFLAGS"
+                                                                                         elif test "x$host_os" = "xmingw32" ; then
+                                                                                                                CXXFLAGS="-mthreads $CXXFLAGS"
+                                                                                                                                         else
+                                                                                                                                                                CXXFLAGS="-pthread $CXXFLAGS"
+                                                                                                                                                                                         fi
+                                                                                                                                                                                                         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
+                                   [[boost::thread_group thrds;
+                                   return 0;]])],
+                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+                                                 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+                ])
+                        if test "x$ax_cv_boost_thread" = "xyes"; then
+           if test "x$host_os" = "xsolaris" ; then
+                     BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+                                                  elif test "x$host_os" = "xmingw32" ; then
+                                                              BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+                                                                                           else
+                                                                                                          BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+                                                                                                                                      fi
+
+                                                                                                                                                AC_SUBST(BOOST_CPPFLAGS)
+
+                                                                                                                                                                AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+                                             LDFLAGS_SAVE=$LDFLAGS
+                        case "x$host_os" in
+                          *bsd* )
+                               LDFLAGS="-pthread $LDFLAGS"
+                          break;
+                          ;;
+                        esac
+            if test "x$ax_boost_user_thread_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+                                            AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+                                                        done
+                if test "x$link_thread" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+                                            AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+                                                        done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
+                                   AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                   [link_thread="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+                        if test "x$link_thread" = "xno"; then
+                                                AC_MSG_ERROR(Could not link against $ax_lib !)
+                        else
+                           case "x$host_os" in
+                              *bsd* )
+                                                BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                              break;
+                              ;;
+                           esac
+
+                                        fi
+                                                fi
+
+                                                        CPPFLAGS="$CPPFLAGS_SAVED"
+                                                        LDFLAGS="$LDFLAGS_SAVED"
+                                                        fi
+])

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -21,6 +21,7 @@ TESTS = \
 test_p4info_convert \
 test_proto_fe \
 test_proto_fe_packet_io \
+test_proto_fe_set_pipeline_config \
 test_server_no_pipeline_config \
 test_server_gnmi \
 test_server_arbitration \
@@ -50,6 +51,8 @@ matchers.cpp
 test_proto_fe_SOURCES = $(proto_fe_common_source) test_proto_fe.cpp
 test_proto_fe_packet_io_SOURCES = $(proto_fe_common_source) \
 test_proto_fe_packet_io.cpp
+test_proto_fe_set_pipeline_config_SOURCES =$(proto_fe_common_source) \
+test_proto_fe_set_pipeline_config.cpp
 
 # this is an awful hack and a big time saver :)
 # thanks to this, I do not need to implement all of the _pi_* functions, only
@@ -57,6 +60,7 @@ test_proto_fe_packet_io.cpp
 # this for unit tests
 test_proto_fe_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_proto_fe_packet_io_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
+test_proto_fe_set_pipeline_config_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 
 mock_switch_libs = \
 $(top_builddir)/p4info/libpiconvertproto.la \
@@ -73,6 +77,7 @@ $(PROTOBUF_LIBS)
 
 test_proto_fe_LDADD = $(proto_fe_libs)
 test_proto_fe_packet_io_LDADD = $(proto_fe_libs)
+test_proto_fe_set_pipeline_config_LDADD = $(proto_fe_libs)
 
 test_server_common_source = $(proto_fe_common_source) \
 server/utils.h
@@ -107,6 +112,7 @@ check_PROGRAMS = \
 test_p4info_convert \
 test_proto_fe \
 test_proto_fe_packet_io \
+test_proto_fe_set_pipeline_config \
 test_server_no_pipeline_config \
 test_server_gnmi \
 test_server_arbitration \

--- a/proto/tests/mock_switch.cpp
+++ b/proto/tests/mock_switch.cpp
@@ -623,6 +623,13 @@ class DummySwitch {
     this->p4info = p4info;
   }
 
+  void reset() {
+    tables.clear();
+    action_profs.clear();
+    counters.clear();
+    meters.clear();
+  }
+
  private:
   DummyTable &get_table(pi_p4_id_t table_id) {
     auto t_it = tables.find(table_id);
@@ -774,6 +781,11 @@ DummySwitchMock::set_p4info(const pi_p4info_t *p4info) {
   sw->set_p4info(p4info);
 }
 
+void
+DummySwitchMock::reset() {
+  sw->reset();
+}
+
 namespace {
 
 // here we implement the _pi_* methods which are needed for our tests
@@ -783,13 +795,20 @@ pi_status_t _pi_init(void *) { return PI_STATUS_SUCCESS; }
 
 pi_status_t _pi_destroy() { return PI_STATUS_SUCCESS; }
 
-pi_status_t _pi_assign_device(pi_dev_id_t, const pi_p4info_t *,
+pi_status_t _pi_assign_device(pi_dev_id_t dev_id, const pi_p4info_t *p4info,
                               pi_assign_extra_t *) {
+  auto *sw = DeviceResolver::get_switch(dev_id);
+  sw->reset();
+  sw->set_p4info(p4info);
   return PI_STATUS_SUCCESS;
 }
 
-pi_status_t _pi_update_device_start(pi_dev_id_t, const pi_p4info_t *,
+pi_status_t _pi_update_device_start(pi_dev_id_t dev_id,
+                                    const pi_p4info_t *p4info,
                                     const char *, size_t) {
+  auto *sw = DeviceResolver::get_switch(dev_id);
+  sw->reset();
+  sw->set_p4info(p4info);
   return PI_STATUS_SUCCESS;
 }
 

--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -69,6 +69,8 @@ class DummySwitchMock {
 
   void set_p4info(const pi_p4info_t *p4info);
 
+  void reset();
+
   MOCK_METHOD4(table_entry_add,
                pi_status_t(pi_p4_id_t, const pi_match_key_t *,
                            const pi_table_entry_t *, pi_entry_handle_t *));

--- a/proto/tests/test_proto_fe_set_pipeline_config.cpp
+++ b/proto/tests/test_proto_fe_set_pipeline_config.cpp
@@ -1,0 +1,175 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <gmock/gmock.h>
+
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+
+#include <fstream>  // std::ifstream
+#include <string>
+
+#include "PI/frontends/cpp/tables.h"
+#include "PI/frontends/proto/device_mgr.h"
+#include "PI/int/pi_int.h"
+#include "PI/pi.h"
+
+#include "p4info_to_and_from_proto.h"
+
+#include "google/rpc/code.pb.h"
+
+#include "matchers.h"
+#include "mock_switch.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+namespace {
+
+using pi::fe::proto::DeviceMgr;
+using Code = ::google::rpc::Code;
+
+using ::testing::_;
+using ::testing::AnyNumber;
+
+class DeviceMgrSetPipelineConfigTest : public ::testing::Test {
+ public:
+  DeviceMgrSetPipelineConfigTest()
+      : mock(wrapper.sw()), device_id(wrapper.device_id()), mgr(device_id) { }
+
+  static void SetUpTestCase() {
+    DeviceMgr::init(256);
+  }
+
+  static void TearDownTestCase() {
+    DeviceMgr::destroy();
+  }
+
+  p4::config::P4Info read_p4info(const std::string &p4info_path) {
+    p4::config::P4Info p4info_proto;
+    std::ifstream istream(p4info_path);
+    google::protobuf::io::IstreamInputStream istream_(&istream);
+    google::protobuf::TextFormat::Parse(&istream_, &p4info_proto);
+    return p4info_proto;
+  }
+
+  DeviceMgr::Status set_pipeline_config(
+      p4::config::P4Info *p4info_proto,
+      p4::SetForwardingPipelineConfigRequest_Action action) {
+    p4::ForwardingPipelineConfig config;
+    config.set_allocated_p4info(p4info_proto);
+    auto status = mgr.pipeline_config_set(action, config);
+    config.release_p4info();
+    return status;
+  }
+
+  DeviceMgr::Status add_entry(p4::TableEntry *entry) {
+    p4::WriteRequest request;
+    auto update = request.add_updates();
+    update->set_type(p4::Update_Type_INSERT);
+    auto entity = update->mutable_entity();
+    entity->set_allocated_table_entry(entry);
+    auto status = mgr.write(request);
+    entity->release_table_entry();
+    return status;
+  }
+
+  DummySwitchWrapper wrapper{};
+  DummySwitchMock *mock;
+  device_id_t device_id;
+  DeviceMgr mgr;
+};
+
+TEST_F(DeviceMgrSetPipelineConfigTest, Reconcile) {
+  constexpr const char *p4info_path_1 =
+      TESTDATADIR "/" "reconcile_1.p4info.txt";
+  constexpr const char *p4info_path_2 =
+      TESTDATADIR "/" "reconcile_2.p4info.txt";
+  constexpr const char *p4info_path_3 =
+      TESTDATADIR "/" "reconcile_3.p4info.txt";
+  auto p4info_proto_1 = read_p4info(p4info_path_1);
+  auto p4info_proto_2 = read_p4info(p4info_path_2);
+  auto p4info_proto_3 = read_p4info(p4info_path_3);
+
+  pi_p4info_t *p4info_1;
+  pi::p4info::p4info_proto_reader(p4info_proto_1, &p4info_1);
+  auto t_id = pi_p4info_table_id_from_name(p4info_1, "T1");
+  auto a_id = pi_p4info_action_id_from_name(p4info_1, "actionA");
+
+  EXPECT_CALL(*mock, table_entries_fetch(t_id, _)).Times(AnyNumber());
+
+  {
+    auto status = set_pipeline_config(
+        &p4info_proto_1,
+        p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
+    ASSERT_EQ(status.code(), Code::OK);
+  }
+
+  EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
+  {
+    p4::TableEntry t_entry;
+    t_entry.set_table_id(t_id);
+    auto *mf = t_entry.add_match();
+    mf->set_field_id(1);
+    auto *mf_exact = mf->mutable_exact();
+    mf_exact->set_value("\xab");
+    auto *entry = t_entry.mutable_action();
+    auto *action = entry->mutable_action();
+    action->set_action_id(a_id);
+    auto param = action->add_params();
+    param->set_param_id(1);
+    param->set_value("\xab");
+    auto status = add_entry(&t_entry);
+    ASSERT_EQ(status.code(), Code::OK);
+  }
+
+  // config_1 => config_2 is valid
+  {
+    EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
+    auto status = set_pipeline_config(
+        &p4info_proto_2,
+        p4::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT);
+    ASSERT_EQ(status.code(), Code::OK);
+  }
+
+  // check that table entry is still present
+  {
+    p4::ReadResponse response;
+    p4::Entity entity;
+    auto t_entry = entity.mutable_table_entry();
+    t_entry->set_table_id(t_id);
+    auto status = mgr.read_one(entity, &response);
+    ASSERT_EQ(status.code(), Code::OK);
+    EXPECT_EQ(response.entities_size(), 1);
+  }
+
+  // config_2 => config_3 is invalid
+  {
+    auto status = set_pipeline_config(
+        &p4info_proto_3,
+        p4::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT);
+    ASSERT_NE(status.code(), Code::OK);
+  }
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi

--- a/targets/bmv2/pi_tables_imp.cpp
+++ b/targets/bmv2/pi_tables_imp.cpp
@@ -674,7 +674,12 @@ pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
   for (const auto &e : entries) {
     data += emit_entry_handle(data, e.entry_handle);
     const auto &options = e.options;
-    if (options.__isset.priority) {
+    // TODO(antonin): temporary hack; for match types which do not require a
+    // priority, bmv2 actually returns -1 instead of not setting the field, but
+    // the PI tends to expect 0, which is a problem for looking up entry state
+    // in the PI software. A more robust solution may be to ignore this value in
+    // the PI based on the key match type.
+    if (options.__isset.priority && options.priority != -1) {
       data += emit_uint32(data, options.priority);
     } else {
       data += emit_uint32(data, 0);

--- a/tests/testdata/reconcile_1.p4info.txt
+++ b/tests/testdata/reconcile_1.p4info.txt
@@ -1,0 +1,40 @@
+tables {
+  preamble {
+    id: 33582705
+    name: "T1"
+    alias: "T1"
+  }
+  match_fields {
+    id: 1
+    name: "mf1"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16783703
+  }
+  action_refs {
+    id: 16800567
+    annotations: "@defaultonly()"
+  }
+  size: 64
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16783703
+    name: "actionA"
+    alias: "actionA"
+  }
+  params {
+    id: 1
+    name: "p1"
+    bitwidth: 8
+  }
+}

--- a/tests/testdata/reconcile_2.p4info.txt
+++ b/tests/testdata/reconcile_2.p4info.txt
@@ -1,0 +1,55 @@
+tables {
+  preamble {
+    id: 33582705
+    name: "T2"
+    alias: "T2"
+  }
+  match_fields {
+    id: 1
+    name: "mf1"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16783703
+  }
+  action_refs {
+    id: 16783704
+  }
+  action_refs {
+    id: 16800567
+    annotations: "@defaultonly()"
+  }
+  size: 64
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16783703
+    name: "actionA"
+    alias: "actionA"
+  }
+  params {
+    id: 1
+    name: "p1"
+    bitwidth: 8
+  }
+}
+actions {
+  preamble {
+    id: 16783703
+    name: "actionB"
+    alias: "actionB"
+  }
+  params {
+    id: 1
+    name: "p1"
+    bitwidth: 8
+  }
+}

--- a/tests/testdata/reconcile_3.p4info.txt
+++ b/tests/testdata/reconcile_3.p4info.txt
@@ -1,0 +1,35 @@
+tables {
+  preamble {
+    id: 33582705
+    name: "T3"
+    alias: "T3"
+  }
+  match_fields {
+    id: 1
+    name: "mf1"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16783703
+  }
+  action_refs {
+    id: 16800567
+    annotations: "@defaultonly()"
+  }
+  size: 64
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16783703
+    name: "actionA"
+    alias: "actionA"
+  }
+}


### PR DESCRIPTION
As an action mode for SetForwardingPipelineConfig in reference
implementation.

We use a pretty naive implementation: we read all entries using a
wildcard read, perform the update sequence then write all entries back.

This commit is also the perfect opportunity to introduce proper
top-level locking to synchronize all RPCs. This introduces a dependency
on the Boost thread library as we want to use a shared mutex (not
available in the C++11 standard library). We allow concurrent Write
calls; however Read and SetForwardingPipelineConfig get an exclusive
lock. These Read / Write semantics are as agreed on for P4Runtime by the
P4 API WG.