### PR TITLE
Add definition of id prefixes to p4info.proto as enum

### DIFF
--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -47,58 +47,58 @@ message Documentation {
 // Top-level package documentation describing the forwarding pipeline config
 // Can be used to manage multiple P4 packages.
 message PkgInfo {
-    // a definitive name for this configuration, e.g. switch.p4_v1.0
-    string name = 1;
-    // configuration version, free-format string
-    string version = 2;
-    // brief and detailed descriptions
-    Documentation doc = 3;
-    // Miscellaneous metadata, free-form; a way to extend PkgInfo
-    repeated string annotations = 4;
-    // the target architecture, e.g. "psa"
-    string arch = 5;
-    // organization which produced the configuration, e.g. "p4.org"
-    string organization = 6;
-    // contact info for support,e.g. "tech-support@acme.org"
-    string contact = 7;
-    // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
-    string url = 8;
+  // a definitive name for this configuration, e.g. switch.p4_v1.0
+  string name = 1;
+  // configuration version, free-format string
+  string version = 2;
+  // brief and detailed descriptions
+  Documentation doc = 3;
+  // Miscellaneous metadata, free-form; a way to extend PkgInfo
+  repeated string annotations = 4;
+  // the target architecture, e.g. "psa"
+  string arch = 5;
+  // organization which produced the configuration, e.g. "p4.org"
+  string organization = 6;
+  // contact info for support,e.g. "tech-support@acme.org"
+  string contact = 7;
+  // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
+  string url = 8;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
 // values are siblings of their type, not children of it"
 message P4Ids {
-    // ids are allocated in such a way that it is possible based on an id to
-    // deduce the resource type (e.g. table, action, counter, ...). The
-    // most-significant byte of the 32-bit id encodes the resource type. The
-    // purpose of this enum is to define which value is used as the
-    // most-significant byte for each resource type. The P4 compiler must use
-    // these values when allocating ids for P4 objects. Other users of P4Info
-    // can refer to this enum to identify a resource type based on its id.
-    enum Prefix {
-        UNSPECIFIED = 0;
+  // ids are allocated in such a way that it is possible based on an id to
+  // deduce the resource type (e.g. table, action, counter, ...). The
+  // most-significant byte of the 32-bit id encodes the resource type. The
+  // purpose of this enum is to define which value is used as the
+  // most-significant byte for each resource type. The P4 compiler must use
+  // these values when allocating ids for P4 objects. Other users of P4Info can
+  // refer to this enum to identify a resource type based on its id.
+  enum Prefix {
+    UNSPECIFIED = 0;
 
-        // P4 language built-ins
-        ACTION = 0x01;
-        TABLE = 0x02;
-        VALUE_SET = 0x03;
+    // P4 language built-ins
+    ACTION = 0x01;
+    TABLE = 0x02;
+    VALUE_SET = 0x03;
 
-        // PSA externs
-        PSA_EXTERNS_START = 0x10;
-        ACTION_PROFILE = 0x11;
-        COUNTER = 0x12;
-        DIRECT_COUNTER = 0x13;
-        METER = 0x14;
-        DIRECT_METER = 0x15;
+    // PSA externs
+    PSA_EXTERNS_START = 0x10;
+    ACTION_PROFILE = 0x11;
+    COUNTER = 0x12;
+    DIRECT_COUNTER = 0x13;
+    METER = 0x14;
+    DIRECT_METER = 0x15;
 
-        // externs for other architectures (vendor extensions)
-        OTHER_EXTERNS_START = 0x80;
+    // externs for other architectures (vendor extensions)
+    OTHER_EXTERNS_START = 0x80;
 
-        // max value for an unsigned 8-bit byte
-        MAX = 0xff;
-        // requires protoc >= 3.5.0
-        // reserved 0x100 to max;
-    }
+    // max value for an unsigned 8-bit byte
+    MAX = 0xff;
+    // requires protoc >= 3.5.0
+    // reserved 0x100 to max;
+  }
 }
 
 message Preamble {

--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -65,6 +65,40 @@ message PkgInfo {
     string url = 8;
 }
 
+// wrapping the enum in a message to avoid name collisions in C++, where "enum
+// values are siblings of their type, not children of it"
+message P4Ids {
+    // ids are allocated in such a way that it is possible based on an id to
+    // deduce the resource type (e.g. table, action, counter, ...). The
+    // most-significant byte of the 32-bit id encodes the resource type. The
+    // purpose of this enum is to define which value is used as the
+    // most-significant byte for each resource type. The P4 compiler must use
+    // these values when allocating ids for P4 objects. Other users of P4Info
+    // can refer to this enum to identify a resource type based on its id.
+    enum Prefix {
+        UNSPECIFIED = 0;
+
+        // P4 language built-ins
+        ACTION = 0x01;
+        TABLE = 0x02;
+        VALUE_SET = 0x03;
+
+        // PSA externs
+        PSA_EXTERNS_START = 0x10;
+        ACTION_PROFILE = 0x11;
+        COUNTER = 0x12;
+        METER = 0x13;
+
+        // externs for other architectures (vendor extensions)
+        OTHER_EXTERNS_START = 0x80;
+
+        // max value for an unsigned 8-bit byte
+        MAX = 0xff;
+        // requires protoc >= 3.5.0
+        // reserved 0x100 to max;
+    }
+}
+
 message Preamble {
   // ids share the same number-space; e.g. table ids cannot overlap with counter
   // ids. Even though this is irrelevant to this proto definition, the ids are

--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -87,7 +87,9 @@ message P4Ids {
         PSA_EXTERNS_START = 0x10;
         ACTION_PROFILE = 0x11;
         COUNTER = 0x12;
-        METER = 0x13;
+        DIRECT_COUNTER = 0x13;
+        METER = 0x14;
+        DIRECT_METER = 0x15;
 
         // externs for other architectures (vendor extensions)
         OTHER_EXTERNS_START = 0x80;


### PR DESCRIPTION
Historically ids have shared the same number-space (i.e. all ids for
top-level objects are unique). Furthermore, the compiler has been
allocating ids in such a way that it is possible to deduce the object
types (e.g. table, action, ...) based on the value of the
most-significant byte of the id.

We decided that it was a bad idea to change that scheme and break
existing implementations of P4Runtime. However, it was also decided that
we should add an enum to p4info.proto so that these 1-byte values are
documented in code somewhere. The compiler should use these values when
allocating ids for the P4 objects.