### PR TITLE
Proposal for PSA Digest support in P4 Runtime

### DIFF
--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -33,6 +33,7 @@ message P4Info {
   repeated ControllerPacketMetadata controller_packet_metadata = 9;
   repeated ValueSet value_sets = 10;
   repeated Register registers = 11;
+  repeated Digest digests = 12;
   repeated Extern externs = 100;
   P4TypeInfo type_info = 200;
 }
@@ -275,4 +276,9 @@ message Register {
   Preamble preamble = 1;
   P4DataTypeSpec type_spec = 2;
   int32 size = 3;
+}
+
+message Digest {
+  Preamble preamble = 1;
+  P4DataTypeSpec type_spec = 2;
 }

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -405,8 +405,9 @@ message DigestEntry {
   uint32 digest_id = 1;
   // a DigestList message is streamed when the following conditions are met:
   //   - there is at least one digest ready
-  //   - the oldest digest in the list has been waiting for at least timeout_ns
-  //     nanoseconds or we have gathered max_list_size digests already
+  //   - the oldest digest in the list has been waiting for at least
+  //     max_timeout_ns nanoseconds or we have gathered max_list_size digests
+  //     already
   message Config {
     int64 max_timeout_ns = 1;  // max timeout for outstanding digest data
     int32 max_list_size = 2;  // max size for a digest list
@@ -435,7 +436,7 @@ message PacketOut {
 
 // Used by the controller to ack a DigestList message. To avoid flooding the
 // controller, the switch must not generate digest notifications for the same
-// data until a DigestLickAck message with the same list_id is received or the
+// data until a DigestListAck message with the same list_id is received or the
 // ack timeout (ack_timeout_ns field in DigestEntry.Config) expires.
 message DigestListAck {
   uint32 digest_id = 1;
@@ -465,6 +466,9 @@ message DigestList {
   // List of entries: each call to the Digest<T>::pack() method corresponds to
   // one entry and we can have as little as one entry.
   repeated P4Data data = 3;
+  // Timestamp at which the server generated the message (in nanoseconds since
+  // Epoch)
+  int64 timestamp = 4;
 }
 
 // Any metadata associated with Packet-IO (controller Packet-In or Packet-Out)

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -102,6 +102,7 @@ message Entity {
     PacketReplicationEngineEntry packet_replication_engine_entry = 9;
     ValueSetEntry value_set_entry = 10;
     RegisterEntry register_entry = 11;
+    DigestEntry digest_entry = 12;
   }
 }
 
@@ -399,11 +400,27 @@ message RegisterEntry {
   P4Data data = 3;
 }
 
+// Used to configure the digest extern only, not to stream digests or acks
+message DigestEntry {
+  uint32 digest_id = 1;
+  // a DigestList message is streamed when the following conditions are met:
+  //   - there is at least one digest ready
+  //   - the oldest digest in the list has been waiting for at least timeout_ns
+  //     nanoseconds or we have gathered max_list_size digests already
+  message Config {
+    int64 max_timeout_ns = 1;  // max timeout for outstanding digest data
+    int32 max_list_size = 2;  // max size for a digest list
+    int64 ack_timeout_ns = 3;  // timeout for DigestListAck message
+  }
+  Config config = 2;
+}
+
 //------------------------------------------------------------------------------
 message StreamMessageRequest {
   oneof update {
     MasterArbitrationUpdate arbitration = 1;
     PacketOut packet = 2;
+    DigestListAck digest_ack = 3;
   }
 }
 
@@ -416,10 +433,20 @@ message PacketOut {
   repeated PacketMetadata metadata = 2;
 }
 
+// Used by the controller to ack a DigestList message. To avoid flooding the
+// controller, the switch must not generate digest notifications for the same
+// data until a DigestLickAck message with the same list_id is received or the
+// ack timeout (ack_timeout_ns field in DigestEntry.Config) expires.
+message DigestListAck {
+  uint32 digest_id = 1;
+  uint64 list_id = 2;
+}
+
 message StreamMessageResponse {
   oneof update {
     MasterArbitrationUpdate arbitration = 1;
     PacketIn packet = 2;
+    DigestList digest = 3;
   }
 }
 
@@ -430,6 +457,14 @@ message PacketIn {
   // @controller_header("packet_in").
   // At most one P4 header can have this annotation.
   repeated PacketMetadata metadata = 2;
+}
+
+message DigestList {
+  uint32 digest_id = 1;  // identifies the digest extern instance
+  uint64 list_id = 2;  // identifies a list of entries, used by receiver to ack
+  // List of entries: each call to the Digest<T>::pack() method corresponds to
+  // one entry and we can have as little as one entry.
+  repeated P4Data data = 3;
 }
 
 // Any metadata associated with Packet-IO (controller Packet-In or Packet-Out)


### PR DESCRIPTION
We introduce a DigestList message in the StreamMessageRequest (for
notifications) and a DigestListAck message in the StreamMessageResponse
(for acks). The ack is necessary to avoid flooding the channel with
notifications for the same learned data.

The DigestEntry Write entity is only used for configuring the digest.