### PR TITLE
Add support for idle timeout for table entries in P4Runtime

### DIFF
--- a/proto/p4/config/p4info.proto
+++ b/proto/p4/config/p4info.proto
@@ -192,7 +192,15 @@ message Table {
   // added in the future
   repeated uint32 direct_resource_ids = 7;
   int64 size = 8;  // max number of entries in table
-  bool with_entry_timeout = 9;  // entry ageing is enabled for table
+  // this enum can be extended in the future with other behaviors, such as
+  // "HARD_EVICTION"
+  enum IdleTimeoutBehavior {
+    UNSPECIFIED = 0;
+    NO_TIMEOUT = 1;
+    NOTIFY_CONTROL = 2;
+  }
+  // is idle timeout supported for this table?
+  IdleTimeoutBehavior idle_timeout_behavior = 9;
   // table with static P4 entries, cannot be modified at runtime
   bool is_const_table = 10;
 }

--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -168,6 +168,18 @@ message TableEntry {
   // default action of the table. If true, the "match" field must be empty and
   // the "action" field must be populated with a valid direct action.
   bool is_default_action = 8;
+  // The TTL for the entry, in nanoseconds. A value of 0 means that the table
+  // entry never "expires".
+  int64 idle_timeout_ns = 9;
+  message IdleTimeout {
+    // Time elapsed - in nanoseconds - since the table entry was last "hit" as
+    // part of a dataplane table lookup.
+    int64 elapsed_ns = 1;
+  }
+  // Table wite: this field should be left unset.
+  // Table read: if the table supports idle timeout and time_since_last_hit is
+  // set in the request, this field will be set in the response.
+  IdleTimeout time_since_last_hit = 10;
 }
 
 // field_match_type ::= exact | ternary | lpm | range | valid
@@ -448,6 +460,7 @@ message StreamMessageResponse {
     MasterArbitrationUpdate arbitration = 1;
     PacketIn packet = 2;
     DigestList digest = 3;
+    IdleTimeoutNotification idle_timeout_notification = 4;
   }
 }
 
@@ -507,6 +520,13 @@ message Role {
   // (default case), it implies all P4 objects and control behaviors are in scope,
   // i.e. full pipeline access.
   google.protobuf.Any config = 2;
+}
+
+message IdleTimeoutNotification {
+  repeated TableEntry table_entry = 1;
+  // Timestamp at which the server generated the message (in nanoseconds since
+  // Epoch)
+  int64 timestamp = 2;
 }
 
 message Uint128 {


### PR DESCRIPTION
Necessary changes to p4info.proto and p4runtime.proto to support idle
timeout for table entries. A table supports idle timeout if the
idle_timeout_behavior field in the corresponding P4Info Table message is
set to NOTIFY_CONTROL (we assume that this information comes from the P4
table definition, either as a table attribute or as an annotation).

When a table supports idle timeout, the P4Runtime client can specifiy a
TTL for each TableEntry. This TTL value will be returned to the client
during a Read operation. If an entry hasn't been hit in the last TTL
nanoseconds, a notification is sent to the client on the
StreamChannel. After a notification is sent, the P4Runtime server resets
the timer for this entry, which means a new notification will be sent
after another TTL nanoseconds if the entry is not hit. This means that
it is ok if notifications are "lost" or if the server drops
notifications because the channel / client is too busy.

When reading a TableEntry, the client can elect to read the elapsed time
(in nanoseconds) since the entry was last hit in the data-plane. We use
a protobuf message for this field in order to enable the client to
choose whether this value should be read and returned in the
response. This is consistent with what we do for direct resource fields.

We use a repeated field of TableEntry in the notification message so
that the server can coalesce notifications in one message when
appropriate (we need to define what appropriate means in the spec).

This may not be the most comprehensive proposal, but I believe it is
sufficient for P4Runtime v1.0 as it covers the general use case.

Fixes #265