### PR TITLE
Update code to use ID prefixes defined in p4info.proto

### DIFF
--- a/CLI/counter_commands.c
+++ b/CLI/counter_commands.c
@@ -37,7 +37,11 @@ extern pi_session_handle_t sess;
 #define NEXT_ENTRY_TOKEN "NEXT_ENTRY"
 
 static char *complete_counter(const char *text, int state) {
-  return complete_one_name(text, state, PI_COUNTER_ID);
+  static pi_res_type_id_t counter_types[] = {PI_COUNTER_ID,
+                                             PI_DIRECT_COUNTER_ID};
+  return complete_one_name(text, state,
+                           sizeof(counter_types) / sizeof(pi_res_type_id_t),
+                           counter_types);
 }
 
 static void print_counter_data(const pi_counter_data_t *counter_data) {
@@ -178,7 +182,7 @@ static pi_cli_status_t store_direct_counter_config(
   pi_p4_id_t direct_t_id = pi_p4info_counter_get_direct(p4info_curr, c_id);
   if (direct_t_id == PI_INVALID_ID) {
     printf("Cannot hold resource spec with " NEXT_ENTRY_TOKEN
-           " for none-direct resources.\n");
+           " for non-direct resources.\n");
     return PI_CLI_STATUS_ERROR;
   }
   pi_counter_data_t *counter_data_copy = malloc(sizeof(*counter_data));

--- a/CLI/meter_commands.c
+++ b/CLI/meter_commands.c
@@ -1,3 +1,4 @@
+
 /* Copyright 2013-present Barefoot Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +38,9 @@ extern pi_session_handle_t sess;
 #define NEXT_ENTRY_TOKEN "NEXT_ENTRY"
 
 static char *complete_meter(const char *text, int state) {
-  return complete_one_name(text, state, PI_METER_ID);
+  static pi_res_type_id_t meter_types[] = {PI_METER_ID, PI_DIRECT_METER_ID};
+  return complete_one_name(
+      text, state, sizeof(meter_types) / sizeof(pi_res_type_id_t), meter_types);
 }
 
 static const char *meter_unit_to_string(pi_meter_unit_t unit) {

--- a/CLI/utils.h
+++ b/CLI/utils.h
@@ -40,11 +40,11 @@ void parse_kv_pair(char *s, char **k, char **v);
 
 int param_to_bytes(const char *param, char *bytes, size_t bitwidth);
 
-char *complete_p4_res(const char *text, int len, int state,
-                      pi_res_type_id_t res_type);
-
-// meant to be used when the completion only involves one resource name
-char *complete_one_name(const char *text, int state, pi_res_type_id_t res_type);
+// meant to be used when the completion only involves one resource name;
+// multiple resource types can be provided (e.g. direct & indirect) and the
+// completion function will iterate over all resources for each provided type.
+char *complete_one_name(const char *text, int state, size_t num_res_types,
+                        const pi_res_type_id_t *res_types);
 
 void print_hexstr(const char *bytes, size_t nbytes);
 

--- a/include/PI/int/pi_int.h
+++ b/include/PI/int/pi_int.h
@@ -43,8 +43,16 @@ static inline pi_p4_id_t pi_make_counter_id(uint16_t index) {
   return (PI_COUNTER_ID << 24) | index;
 }
 
+static inline pi_p4_id_t pi_make_direct_counter_id(uint16_t index) {
+  return (PI_DIRECT_COUNTER_ID << 24) | index;
+}
+
 static inline pi_p4_id_t pi_make_meter_id(uint16_t index) {
   return (PI_METER_ID << 24) | index;
+}
+
+static inline pi_p4_id_t pi_make_direct_meter_id(uint16_t index) {
+  return (PI_DIRECT_METER_ID << 24) | index;
 }
 
 #define PI_GET_TYPE_ID(id) ((id) >> 24)

--- a/include/PI/p4info/counters.h
+++ b/include/PI/p4info/counters.h
@@ -56,6 +56,11 @@ pi_p4_id_t pi_p4info_counter_begin(const pi_p4info_t *p4info);
 pi_p4_id_t pi_p4info_counter_next(const pi_p4info_t *p4info, pi_p4_id_t id);
 pi_p4_id_t pi_p4info_counter_end(const pi_p4info_t *p4info);
 
+pi_p4_id_t pi_p4info_direct_counter_begin(const pi_p4info_t *p4info);
+pi_p4_id_t pi_p4info_direct_counter_next(const pi_p4info_t *p4info,
+                                         pi_p4_id_t id);
+pi_p4_id_t pi_p4info_direct_counter_end(const pi_p4info_t *p4info);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/PI/p4info/meters.h
+++ b/include/PI/p4info/meters.h
@@ -62,6 +62,11 @@ pi_p4_id_t pi_p4info_meter_begin(const pi_p4info_t *p4info);
 pi_p4_id_t pi_p4info_meter_next(const pi_p4info_t *p4info, pi_p4_id_t id);
 pi_p4_id_t pi_p4info_meter_end(const pi_p4info_t *p4info);
 
+pi_p4_id_t pi_p4info_direct_meter_begin(const pi_p4info_t *p4info);
+pi_p4_id_t pi_p4info_direct_meter_next(const pi_p4info_t *p4info,
+                                       pi_p4_id_t id);
+pi_p4_id_t pi_p4info_direct_meter_end(const pi_p4info_t *p4info);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/PI/pi_base.h
+++ b/include/PI/pi_base.h
@@ -124,7 +124,9 @@ typedef struct pi_p4info_s pi_p4info_t;
 #define PI_ACT_PROF_ID 0x11
 
 #define PI_COUNTER_ID 0x12
-#define PI_METER_ID 0x13
+#define PI_DIRECT_COUNTER_ID 0x13
+#define PI_METER_ID 0x14
+#define PI_DIRECT_METER_ID 0x15
 
 #define PI_RES_TYPE_MAX 0x100
 
@@ -137,7 +139,9 @@ bool pi_is_table_id(pi_p4_id_t id);
 bool pi_is_act_prof_id(pi_p4_id_t id);
 
 bool pi_is_counter_id(pi_p4_id_t id);
+bool pi_is_direct_counter_id(pi_p4_id_t id);
 bool pi_is_meter_id(pi_p4_id_t id);
+bool pi_is_direct_meter_id(pi_p4_id_t id);
 
 #ifdef __cplusplus
 }

--- a/proto/PI/proto/util.h
+++ b/proto/PI/proto/util.h
@@ -21,6 +21,8 @@
 #ifndef PI_PROTO_UTIL_H_
 #define PI_PROTO_UTIL_H_
 
+#include <p4/config/p4info.pb.h>
+
 #include <cstdint>
 
 namespace pi {
@@ -31,23 +33,9 @@ namespace util {
 
 using p4_id_t = uint32_t;
 
-// we use the same integral value as the PI internally, but this is not a
-// requirement
-enum class P4ResourceType {
-  INVALID = 0x00,
-
-  ACTION = 0x01,
-  TABLE = 0x02,
-  ACTION_PROFILE = 0x11,
-  COUNTER = 0x12,
-  METER = 0x13,
-
-  INVALID_MAX = 0x100,
-};
-
 constexpr p4_id_t invalid_id() { return 0; }
 
-P4ResourceType resource_type_from_id(p4_id_t p4_id);
+p4::config::P4Ids::Prefix resource_type_from_id(p4_id_t p4_id);
 
 }  // namespace util
 

--- a/proto/demo_grpc/simple_router.json
+++ b/proto/demo_grpc/simple_router.json
@@ -1,7 +1,7 @@
 {
   "program" : "simple_router.p4",
   "__meta__" : {
-    "version" : [2, 7],
+    "version" : [2, 18],
     "compiler" : "https://github.com/p4lang/p4c"
   },
   "header_types" : [
@@ -83,17 +83,8 @@
         ["drop", 1, false],
         ["recirculate_port", 16, false],
         ["packet_length", 32, false],
-        ["enq_timestamp", 32, false],
-        ["enq_qdepth", 19, false],
-        ["deq_timedelta", 32, false],
-        ["deq_qdepth", 19, false],
-        ["ingress_global_timestamp", 48, false],
-        ["lf_field_list", 32, false],
-        ["mcast_grp", 16, false],
-        ["resubmit_flag", 1, false],
-        ["egress_rid", 16, false],
         ["checksum_error", 1, false],
-        ["_padding", 4, false]
+        ["_padding", 3, false]
       ]
     }
   ],
@@ -230,11 +221,13 @@
           ],
           "transitions" : [
             {
+              "type" : "hexstr",
               "value" : "0x0800",
               "mask" : null,
               "next_state" : "parse_ipv4"
             },
             {
+              "type" : "hexstr",
               "value" : "0x0806",
               "mask" : null,
               "next_state" : "parse_arp"
@@ -321,6 +314,7 @@
           ],
           "transitions" : [
             {
+              "type" : "hexstr",
               "value" : "0x0000000000000000",
               "mask" : null,
               "next_state" : "parse_cpu_header"
@@ -341,6 +335,7 @@
       ]
     }
   ],
+  "parse_vsets" : [],
   "deparsers" : [
     {
       "name" : "deparser",
@@ -999,6 +994,7 @@
           "key" : [
             {
               "match_type" : "lpm",
+              "name" : "ipv4.dstAddr",
               "target" : ["ipv4", "dstAddr"],
               "mask" : null
             }
@@ -1035,6 +1031,7 @@
           "key" : [
             {
               "match_type" : "exact",
+              "name" : "routing_metadata.nhop_ipv4",
               "target" : ["routing_metadata", "nhop_ipv4"],
               "mask" : null
             }
@@ -1075,14 +1072,11 @@
           "expression" : {
             "type" : "expression",
             "value" : {
-              "op" : "==",
-              "left" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
                 "type" : "field",
                 "value" : ["cpu_header", "$valid$"]
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
               }
             }
           },
@@ -1101,14 +1095,11 @@
           "expression" : {
             "type" : "expression",
             "value" : {
-              "op" : "==",
-              "left" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
                 "type" : "field",
                 "value" : ["arp", "$valid$"]
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
               }
             }
           },
@@ -1131,14 +1122,11 @@
               "left" : {
                 "type" : "expression",
                 "value" : {
-                  "op" : "==",
-                  "left" : {
+                  "op" : "d2b",
+                  "left" : null,
+                  "right" : {
                     "type" : "field",
                     "value" : ["ipv4", "$valid$"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x01"
                   }
                 }
               },
@@ -1180,6 +1168,7 @@
           "key" : [
             {
               "match_type" : "exact",
+              "name" : "standard_metadata.egress_port",
               "target" : ["standard_metadata", "egress_port"],
               "mask" : null
             }
@@ -1213,20 +1202,24 @@
           "source_info" : {
             "filename" : "simple_router.p4",
             "line" : 242,
-            "column" : 12,
-            "source_fragment" : "valid(cpu_header)"
+            "column" : 8,
+            "source_fragment" : "not"
           },
           "expression" : {
             "type" : "expression",
             "value" : {
-              "op" : "!=",
-              "left" : {
-                "type" : "field",
-                "value" : ["cpu_header", "$valid$"]
-              },
+              "op" : "not",
+              "left" : null,
               "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
+                "type" : "expression",
+                "value" : {
+                  "op" : "d2b",
+                  "left" : null,
+                  "right" : {
+                    "type" : "field",
+                    "value" : ["cpu_header", "$valid$"]
+                  }
+                }
               }
             }
           },
@@ -1242,54 +1235,25 @@
       "id" : 0,
       "target" : ["ipv4", "hdrChecksum"],
       "type" : "generic",
-      "calculation" : "calc"
+      "calculation" : "calc",
+      "if_cond" : {
+        "type" : "bool",
+        "value" : true
+      }
     },
     {
       "name" : "cksum_0",
       "id" : 1,
       "target" : ["ipv4", "hdrChecksum"],
       "type" : "generic",
-      "calculation" : "calc_0"
+      "calculation" : "calc_0",
+      "if_cond" : {
+        "type" : "bool",
+        "value" : true
+      }
     }
   ],
   "force_arith" : [],
   "extern_instances" : [],
-  "field_aliases" : [
-    [
-      "queueing_metadata.enq_timestamp",
-      ["standard_metadata", "enq_timestamp"]
-    ],
-    [
-      "queueing_metadata.enq_qdepth",
-      ["standard_metadata", "enq_qdepth"]
-    ],
-    [
-      "queueing_metadata.deq_timedelta",
-      ["standard_metadata", "deq_timedelta"]
-    ],
-    [
-      "queueing_metadata.deq_qdepth",
-      ["standard_metadata", "deq_qdepth"]
-    ],
-    [
-      "intrinsic_metadata.ingress_global_timestamp",
-      ["standard_metadata", "ingress_global_timestamp"]
-    ],
-    [
-      "intrinsic_metadata.lf_field_list",
-      ["standard_metadata", "lf_field_list"]
-    ],
-    [
-      "intrinsic_metadata.mcast_grp",
-      ["standard_metadata", "mcast_grp"]
-    ],
-    [
-      "intrinsic_metadata.resubmit_flag",
-      ["standard_metadata", "resubmit_flag"]
-    ],
-    [
-      "intrinsic_metadata.egress_rid",
-      ["standard_metadata", "egress_rid"]
-    ]
-  ]
+  "field_aliases" : []
 }

--- a/proto/demo_grpc/simple_router_wcounter.json
+++ b/proto/demo_grpc/simple_router_wcounter.json
@@ -1,7 +1,7 @@
 {
   "program" : "simple_router_wcounter.p4",
   "__meta__" : {
-    "version" : [2, 7],
+    "version" : [2, 18],
     "compiler" : "https://github.com/p4lang/p4c"
   },
   "header_types" : [
@@ -84,17 +84,8 @@
         ["drop", 1, false],
         ["recirculate_port", 16, false],
         ["packet_length", 32, false],
-        ["enq_timestamp", 32, false],
-        ["enq_qdepth", 19, false],
-        ["deq_timedelta", 32, false],
-        ["deq_qdepth", 19, false],
-        ["ingress_global_timestamp", 48, false],
-        ["lf_field_list", 32, false],
-        ["mcast_grp", 16, false],
-        ["resubmit_flag", 1, false],
-        ["egress_rid", 16, false],
         ["checksum_error", 1, false],
-        ["_padding", 4, false]
+        ["_padding", 3, false]
       ]
     }
   ],
@@ -231,11 +222,13 @@
           ],
           "transitions" : [
             {
+              "type" : "hexstr",
               "value" : "0x0800",
               "mask" : null,
               "next_state" : "parse_ipv4"
             },
             {
+              "type" : "hexstr",
               "value" : "0x0806",
               "mask" : null,
               "next_state" : "parse_arp"
@@ -322,6 +315,7 @@
           ],
           "transitions" : [
             {
+              "type" : "hexstr",
               "value" : "0x0000000000000000",
               "mask" : null,
               "next_state" : "parse_cpu_header"
@@ -342,6 +336,7 @@
       ]
     }
   ],
+  "parse_vsets" : [],
   "deparsers" : [
     {
       "name" : "deparser",
@@ -518,7 +513,13 @@
                 }
               }
             }
-          ]
+          ],
+          "source_info" : {
+            "filename" : "simple_router_wcounter.p4",
+            "line" : 194,
+            "column" : 21,
+            "source_fragment" : "standard_metadata.egress_port"
+          }
         },
         {
           "op" : "count",
@@ -1052,6 +1053,7 @@
           "key" : [
             {
               "match_type" : "lpm",
+              "name" : "ipv4.dstAddr",
               "target" : ["ipv4", "dstAddr"],
               "mask" : null
             }
@@ -1088,6 +1090,7 @@
           "key" : [
             {
               "match_type" : "exact",
+              "name" : "routing_metadata.nhop_ipv4",
               "target" : ["routing_metadata", "nhop_ipv4"],
               "mask" : null
             }
@@ -1128,14 +1131,11 @@
           "expression" : {
             "type" : "expression",
             "value" : {
-              "op" : "==",
-              "left" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
                 "type" : "field",
                 "value" : ["cpu_header", "$valid$"]
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
               }
             }
           },
@@ -1154,14 +1154,11 @@
           "expression" : {
             "type" : "expression",
             "value" : {
-              "op" : "==",
-              "left" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
                 "type" : "field",
                 "value" : ["arp", "$valid$"]
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
               }
             }
           },
@@ -1184,14 +1181,11 @@
               "left" : {
                 "type" : "expression",
                 "value" : {
-                  "op" : "==",
-                  "left" : {
+                  "op" : "d2b",
+                  "left" : null,
+                  "right" : {
                     "type" : "field",
                     "value" : ["ipv4", "$valid$"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x01"
                   }
                 }
               },
@@ -1233,6 +1227,7 @@
           "key" : [
             {
               "match_type" : "exact",
+              "name" : "standard_metadata.egress_port",
               "target" : ["standard_metadata", "egress_port"],
               "mask" : null
             }
@@ -1266,20 +1261,24 @@
           "source_info" : {
             "filename" : "simple_router_wcounter.p4",
             "line" : 249,
-            "column" : 12,
-            "source_fragment" : "valid(cpu_header)"
+            "column" : 8,
+            "source_fragment" : "not"
           },
           "expression" : {
             "type" : "expression",
             "value" : {
-              "op" : "!=",
-              "left" : {
-                "type" : "field",
-                "value" : ["cpu_header", "$valid$"]
-              },
+              "op" : "not",
+              "left" : null,
               "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
+                "type" : "expression",
+                "value" : {
+                  "op" : "d2b",
+                  "left" : null,
+                  "right" : {
+                    "type" : "field",
+                    "value" : ["cpu_header", "$valid$"]
+                  }
+                }
               }
             }
           },
@@ -1295,54 +1294,25 @@
       "id" : 0,
       "target" : ["ipv4", "hdrChecksum"],
       "type" : "generic",
-      "calculation" : "calc"
+      "calculation" : "calc",
+      "if_cond" : {
+        "type" : "bool",
+        "value" : true
+      }
     },
     {
       "name" : "cksum_0",
       "id" : 1,
       "target" : ["ipv4", "hdrChecksum"],
       "type" : "generic",
-      "calculation" : "calc_0"
+      "calculation" : "calc_0",
+      "if_cond" : {
+        "type" : "bool",
+        "value" : true
+      }
     }
   ],
   "force_arith" : [],
   "extern_instances" : [],
-  "field_aliases" : [
-    [
-      "queueing_metadata.enq_timestamp",
-      ["standard_metadata", "enq_timestamp"]
-    ],
-    [
-      "queueing_metadata.enq_qdepth",
-      ["standard_metadata", "enq_qdepth"]
-    ],
-    [
-      "queueing_metadata.deq_timedelta",
-      ["standard_metadata", "deq_timedelta"]
-    ],
-    [
-      "queueing_metadata.deq_qdepth",
-      ["standard_metadata", "deq_qdepth"]
-    ],
-    [
-      "intrinsic_metadata.ingress_global_timestamp",
-      ["standard_metadata", "ingress_global_timestamp"]
-    ],
-    [
-      "intrinsic_metadata.lf_field_list",
-      ["standard_metadata", "lf_field_list"]
-    ],
-    [
-      "intrinsic_metadata.mcast_grp",
-      ["standard_metadata", "mcast_grp"]
-    ],
-    [
-      "intrinsic_metadata.resubmit_flag",
-      ["standard_metadata", "resubmit_flag"]
-    ],
-    [
-      "intrinsic_metadata.egress_rid",
-      ["standard_metadata", "egress_rid"]
-    ]
-  ]
+  "field_aliases" : []
 }

--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -225,9 +225,8 @@ ActionProfMgr::group_delete(const p4::ActionProfileGroup &group,
 
 bool
 ActionProfMgr::check_p4_action_id(pi_p4_id_t p4_id) const {
-  using pi::proto::util::P4ResourceType;
   using pi::proto::util::resource_type_from_id;
-  return (resource_type_from_id(p4_id) == P4ResourceType::ACTION)
+  return (resource_type_from_id(p4_id) == p4::config::P4Ids::ACTION)
       && pi_p4info_is_valid_id(p4info, p4_id);
 }
 

--- a/proto/src/util.cpp
+++ b/proto/src/util.cpp
@@ -18,8 +18,6 @@
  *
  */
 
-#include <PI/pi_base.h>
-
 #include <PI/proto/util.h>
 
 namespace pi {
@@ -28,21 +26,29 @@ namespace proto {
 
 namespace util {
 
-P4ResourceType
+p4::config::P4Ids::Prefix
 resource_type_from_id(p4_id_t p4_id) {
   switch (p4_id >> 24) {
-    case PI_ACTION_ID:
-      return P4ResourceType::ACTION;
-    case PI_TABLE_ID:
-      return P4ResourceType::TABLE;
-    case PI_ACT_PROF_ID:
-      return P4ResourceType::ACTION_PROFILE;
-    case PI_COUNTER_ID:
-      return P4ResourceType::COUNTER;
-    case PI_METER_ID:
-      return P4ResourceType::METER;
+    case static_cast<p4_id_t>(p4::config::P4Ids::UNSPECIFIED):
+      return p4::config::P4Ids::UNSPECIFIED;
+    case static_cast<p4_id_t>(p4::config::P4Ids::ACTION):
+      return p4::config::P4Ids::ACTION;
+    case static_cast<p4_id_t>(p4::config::P4Ids::TABLE):
+      return p4::config::P4Ids::TABLE;
+    case static_cast<p4_id_t>(p4::config::P4Ids::VALUE_SET):
+      return p4::config::P4Ids::VALUE_SET;
+    case static_cast<p4_id_t>(p4::config::P4Ids::ACTION_PROFILE):
+      return p4::config::P4Ids::ACTION_PROFILE;
+    case static_cast<p4_id_t>(p4::config::P4Ids::COUNTER):
+      return p4::config::P4Ids::COUNTER;
+    case static_cast<p4_id_t>(p4::config::P4Ids::DIRECT_COUNTER):
+      return p4::config::P4Ids::DIRECT_COUNTER;
+    case static_cast<p4_id_t>(p4::config::P4Ids::METER):
+      return p4::config::P4Ids::METER;
+    case static_cast<p4_id_t>(p4::config::P4Ids::DIRECT_METER):
+      return p4::config::P4Ids::DIRECT_METER;
     default:
-      return P4ResourceType::INVALID;
+      return p4::config::P4Ids::UNSPECIFIED;
   }
 }
 

--- a/proto/tests/mock_switch.cpp
+++ b/proto/tests/mock_switch.cpp
@@ -151,7 +151,7 @@ class DummyResource {
 
 class DummyMeter : public DummyResource<DummyMeter, pi_meter_spec_t> {
  public:
-  static constexpr pi_res_type_id_t res_type = PI_METER_ID;
+  static constexpr pi_res_type_id_t direct_res_type = PI_DIRECT_METER_ID;
 
   static pi_meter_spec_t get_default() {
     return {0, 0, 0, 0, PI_METER_UNIT_DEFAULT, PI_METER_TYPE_DEFAULT};
@@ -160,7 +160,7 @@ class DummyMeter : public DummyResource<DummyMeter, pi_meter_spec_t> {
 
 class DummyCounter : public DummyResource<DummyCounter, pi_counter_data_t> {
  public:
-  static constexpr pi_res_type_id_t res_type = PI_COUNTER_ID;
+  static constexpr pi_res_type_id_t direct_res_type = PI_DIRECT_COUNTER_ID;
 
   static pi_counter_data_t get_default() {
     return {PI_COUNTER_UNIT_PACKETS | PI_COUNTER_UNIT_BYTES, 0u, 0u};
@@ -251,11 +251,11 @@ class DummyTable {
       auto *configs = table_entry->direct_res_config->configs;
       for (size_t i = 0; i < table_entry->direct_res_config->num_configs; i++) {
         pi_p4_id_t res_id = configs[i].res_id;
-        if (pi_is_counter_id(res_id)) {
+        if (pi_is_direct_counter_id(res_id)) {
           counters[res_id]->write(
               entry_counter,
               static_cast<const pi_counter_data_t *>(configs[i].config));
-        } else if (pi_is_meter_id(res_id)) {
+        } else if (pi_is_direct_meter_id(res_id)) {
           meters[res_id]->write(
               entry_counter,
               static_cast<const pi_meter_spec_t *>(configs[i].config));
@@ -348,7 +348,8 @@ class DummyTable {
     size_t s = 0;
     PIDirectResMsgSizeFn msg_size_fn;
     PIDirectResEmitFn emit_fn;
-    pi_direct_res_get_fns(T::res_type, &msg_size_fn, &emit_fn, NULL, NULL);
+    pi_direct_res_get_fns(
+        T::direct_res_type, &msg_size_fn, &emit_fn, NULL, NULL);
     for (auto it = first; it != last; ++it) {
       s += emit_p4_id(dst + s, it->first);
       typename T::config_type config;
@@ -641,9 +642,9 @@ class DummySwitch {
       auto *res_ids = pi_p4info_table_get_direct_resources(
           p4info, table_id, &num_direct_resources);
       for (size_t i = 0; i < num_direct_resources; i++) {
-        if (pi_is_counter_id(res_ids[i]))
+        if (pi_is_direct_counter_id(res_ids[i]))
           table.add_counter(res_ids[i], &counters[res_ids[i]]);
-        else if (pi_is_meter_id(res_ids[i]))
+        else if (pi_is_direct_meter_id(res_ids[i]))
           table.add_meter(res_ids[i], &meters[res_ids[i]]);
         else
           assert(0 && "Unsupported direct resource id");

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -248,7 +248,7 @@ p4::config::P4Info DeviceMgrTest::p4info_proto;
 constexpr const char *DeviceMgrTest::invalid_p4_id_error_str;
 
 TEST_F(DeviceMgrTest, ResourceTypeFromId) {
-  using Type = pi::proto::util::P4ResourceType;
+  using Type = p4::config::P4Ids;
   using pi::proto::util::resource_type_from_id;
   auto a_id = pi_p4info_action_id_from_name(p4info, "actionA");
   ASSERT_EQ(Type::ACTION, resource_type_from_id(a_id));
@@ -256,11 +256,15 @@ TEST_F(DeviceMgrTest, ResourceTypeFromId) {
   ASSERT_EQ(Type::TABLE, resource_type_from_id(t_id));
   auto act_prof_id = pi_p4info_act_prof_id_from_name(p4info, "ActProfWS");
   ASSERT_EQ(Type::ACTION_PROFILE, resource_type_from_id(act_prof_id));
-  auto c_id = pi_p4info_counter_id_from_name(p4info, "ExactOne_counter");
+  auto dc_id = pi_p4info_counter_id_from_name(p4info, "ExactOne_counter");
+  ASSERT_EQ(Type::DIRECT_COUNTER, resource_type_from_id(dc_id));
+  auto dm_id = pi_p4info_meter_id_from_name(p4info, "ExactOne_meter");
+  ASSERT_EQ(Type::DIRECT_METER, resource_type_from_id(dm_id));
+  auto c_id = pi_p4info_counter_id_from_name(p4info, "CounterA");
   ASSERT_EQ(Type::COUNTER, resource_type_from_id(c_id));
-  auto m_id = pi_p4info_meter_id_from_name(p4info, "ExactOne_meter");
+  auto m_id = pi_p4info_meter_id_from_name(p4info, "MeterA");
   ASSERT_EQ(Type::METER, resource_type_from_id(m_id));
-  ASSERT_EQ(Type::INVALID,
+  ASSERT_EQ(Type::UNSPECIFIED,
             resource_type_from_id(pi::proto::util::invalid_id()));
 }
 

--- a/src/p4info/act_profs_int.h
+++ b/src/p4info/act_profs_int.h
@@ -38,9 +38,6 @@ void pi_p4info_act_prof_add(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
 void pi_p4info_act_prof_add_table(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
                                   pi_p4_id_t table_id);
 
-typedef struct cJSON cJSON;
-void pi_p4info_act_prof_serialize(cJSON *root, const pi_p4info_t *p4info);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/p4info/actions_int.h
+++ b/src/p4info/actions_int.h
@@ -38,9 +38,6 @@ void pi_p4info_action_add_param(pi_p4info_t *p4info, pi_p4_id_t action_id,
                                 pi_p4_id_t param_id, const char *name,
                                 size_t bitwidth);
 
-typedef struct cJSON cJSON;
-void pi_p4info_action_serialize(cJSON *root, const pi_p4info_t *p4info);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/p4info/counters_int.h
+++ b/src/p4info/counters_int.h
@@ -28,16 +28,16 @@ extern "C" {
 #endif
 
 void pi_p4info_counter_init(pi_p4info_t *p4info, size_t num_counters);
+void pi_p4info_direct_counter_init(pi_p4info_t *p4info,
+                                   size_t num_direct_counters);
 
 void pi_p4info_counter_add(pi_p4info_t *p4info, pi_p4_id_t counter_id,
                            const char *name,
                            pi_p4info_counter_unit_t counter_unit, size_t size);
-
-void pi_p4info_counter_make_direct(pi_p4info_t *p4info, pi_p4_id_t counter_id,
-                                   pi_p4_id_t direct_table_id);
-
-typedef struct cJSON cJSON;
-void pi_p4info_counter_serialize(cJSON *root, const pi_p4info_t *p4info);
+void pi_p4info_direct_counter_add(pi_p4info_t *p4info, pi_p4_id_t counter_id,
+                                  const char *name,
+                                  pi_p4info_counter_unit_t counter_unit,
+                                  size_t size, pi_p4_id_t direct_table_id);
 
 #ifdef __cplusplus
 }

--- a/src/p4info/meters.c
+++ b/src/p4info/meters.c
@@ -43,7 +43,8 @@ typedef struct _meter_data_s {
 
 static _meter_data_t *get_meter(const pi_p4info_t *p4info,
                                 pi_p4_id_t meter_id) {
-  assert(PI_GET_TYPE_ID(meter_id) == PI_METER_ID);
+  assert(PI_GET_TYPE_ID(meter_id) == PI_METER_ID ||
+         PI_GET_TYPE_ID(meter_id) == PI_DIRECT_METER_ID);
   return p4info_get_at(p4info, meter_id);
 }
 
@@ -59,9 +60,9 @@ static void free_meter_data(void *data) {
   p4info_common_destroy(&meter->common);
 }
 
-void pi_p4info_meter_serialize(cJSON *root, const pi_p4info_t *p4info) {
+static void meter_serialize(cJSON *root, const vector_t *meters,
+                            const char *node_name) {
   cJSON *mArray = cJSON_CreateArray();
-  const vector_t *meters = p4info->meters->vec;
   for (size_t i = 0; i < vector_size(meters); i++) {
     _meter_data_t *meter = vector_at(meters, i);
     cJSON *mObject = cJSON_CreateObject();
@@ -77,7 +78,18 @@ void pi_p4info_meter_serialize(cJSON *root, const pi_p4info_t *p4info) {
 
     cJSON_AddItemToArray(mArray, mObject);
   }
-  cJSON_AddItemToObject(root, "meters", mArray);
+  cJSON_AddItemToObject(root, node_name, mArray);
+}
+
+static void pi_p4info_meter_serialize(cJSON *root, const pi_p4info_t *p4info) {
+  const vector_t *meters = p4info->meters->vec;
+  meter_serialize(root, meters, "meters");
+}
+
+static void pi_p4info_direct_meter_serialize(cJSON *root,
+                                             const pi_p4info_t *p4info) {
+  const vector_t *direct_meters = p4info->direct_meters->vec;
+  meter_serialize(root, direct_meters, "direct_meters");
 }
 
 void pi_p4info_meter_init(pi_p4info_t *p4info, size_t num_meters) {
@@ -85,9 +97,18 @@ void pi_p4info_meter_init(pi_p4info_t *p4info, size_t num_meters) {
                   retrieve_name, free_meter_data, pi_p4info_meter_serialize);
 }
 
-void pi_p4info_meter_add(pi_p4info_t *p4info, pi_p4_id_t meter_id,
-                         const char *name, pi_p4info_meter_unit_t meter_unit,
-                         pi_p4info_meter_type_t meter_type, size_t size) {
+void pi_p4info_direct_meter_init(pi_p4info_t *p4info,
+                                 size_t num_direct_meters) {
+  p4info_init_res(p4info, PI_DIRECT_METER_ID, num_direct_meters,
+                  sizeof(_meter_data_t), retrieve_name, free_meter_data,
+                  pi_p4info_direct_meter_serialize);
+}
+
+static _meter_data_t *meter_add(pi_p4info_t *p4info, pi_p4_id_t meter_id,
+                                const char *name,
+                                pi_p4info_meter_unit_t meter_unit,
+                                pi_p4info_meter_type_t meter_type,
+                                size_t size) {
   _meter_data_t *meter = p4info_add_res(p4info, meter_id, name);
   meter->name = strdup(name);
   meter->meter_id = meter_id;
@@ -95,19 +116,30 @@ void pi_p4info_meter_add(pi_p4info_t *p4info, pi_p4_id_t meter_id,
   meter->meter_type = meter_type;
   meter->direct_table = PI_INVALID_ID;
   meter->size = size;
+  return meter;
 }
 
-void pi_p4info_meter_make_direct(pi_p4info_t *p4info, pi_p4_id_t meter_id,
-                                 pi_p4_id_t direct_table_id) {
-  _meter_data_t *meter = get_meter(p4info, meter_id);
-  // TODO(antonin): cannot make direct twice, improve
-  assert(meter->direct_table == PI_INVALID_ID);
+void pi_p4info_meter_add(pi_p4info_t *p4info, pi_p4_id_t meter_id,
+                         const char *name, pi_p4info_meter_unit_t meter_unit,
+                         pi_p4info_meter_type_t meter_type, size_t size) {
+  meter_add(p4info, meter_id, name, meter_unit, meter_type, size);
+}
+
+void pi_p4info_direct_meter_add(pi_p4info_t *p4info, pi_p4_id_t meter_id,
+                                const char *name,
+                                pi_p4info_meter_unit_t meter_unit,
+                                pi_p4info_meter_type_t meter_type, size_t size,
+                                pi_p4_id_t direct_table_id) {
+  _meter_data_t *meter =
+      meter_add(p4info, meter_id, name, meter_unit, meter_type, size);
   meter->direct_table = direct_table_id;
 }
 
 pi_p4_id_t pi_p4info_meter_id_from_name(const pi_p4info_t *p4info,
                                         const char *name) {
-  return p4info_name_map_get(&p4info->meters->name_map, name);
+  pi_p4_id_t id = p4info_name_map_get(&p4info->meters->name_map, name);
+  if (id != PI_INVALID_ID) return id;
+  return p4info_name_map_get(&p4info->direct_meters->name_map, name);
 }
 
 const char *pi_p4info_meter_name_from_id(const pi_p4info_t *p4info,
@@ -150,4 +182,17 @@ pi_p4_id_t pi_p4info_meter_next(const pi_p4info_t *p4info, pi_p4_id_t id) {
 
 pi_p4_id_t pi_p4info_meter_end(const pi_p4info_t *p4info) {
   return pi_p4info_any_end(p4info, PI_METER_ID);
+}
+
+pi_p4_id_t pi_p4info_direct_meter_begin(const pi_p4info_t *p4info) {
+  return pi_p4info_any_begin(p4info, PI_DIRECT_METER_ID);
+}
+
+pi_p4_id_t pi_p4info_direct_meter_next(const pi_p4info_t *p4info,
+                                       pi_p4_id_t id) {
+  return pi_p4info_any_next(p4info, id);
+}
+
+pi_p4_id_t pi_p4info_direct_meter_end(const pi_p4info_t *p4info) {
+  return pi_p4info_any_end(p4info, PI_DIRECT_METER_ID);
 }

--- a/src/p4info/meters_int.h
+++ b/src/p4info/meters_int.h
@@ -28,16 +28,16 @@ extern "C" {
 #endif
 
 void pi_p4info_meter_init(pi_p4info_t *p4info, size_t num_meters);
+void pi_p4info_direct_meter_init(pi_p4info_t *p4info, size_t num_direct_meters);
 
 void pi_p4info_meter_add(pi_p4info_t *p4info, pi_p4_id_t meter_id,
                          const char *name, pi_p4info_meter_unit_t meter_unit,
                          pi_p4info_meter_type_t meter_type, size_t size);
-
-void pi_p4info_meter_make_direct(pi_p4info_t *p4info, pi_p4_id_t meter_id,
-                                 pi_p4_id_t direct_table_id);
-
-typedef struct cJSON cJSON;
-void pi_p4info_meter_serialize(cJSON *root, const pi_p4info_t *p4info);
+void pi_p4info_direct_meter_add(pi_p4info_t *p4info, pi_p4_id_t meter_id,
+                                const char *name,
+                                pi_p4info_meter_unit_t meter_unit,
+                                pi_p4info_meter_type_t meter_type, size_t size,
+                                pi_p4_id_t direct_table_id);
 
 #ifdef __cplusplus
 }

--- a/src/p4info/p4info.c
+++ b/src/p4info/p4info.c
@@ -39,7 +39,9 @@ pi_status_t pi_empty_config(pi_p4info_t **p4info) {
   p4info_->tables = &p4info_->resources[PI_TABLE_ID];
   p4info_->act_profs = &p4info_->resources[PI_ACT_PROF_ID];
   p4info_->counters = &p4info_->resources[PI_COUNTER_ID];
+  p4info_->direct_counters = &p4info_->resources[PI_DIRECT_COUNTER_ID];
   p4info_->meters = &p4info_->resources[PI_METER_ID];
+  p4info_->direct_meters = &p4info_->resources[PI_DIRECT_METER_ID];
 
   *p4info = p4info_;
   return PI_STATUS_SUCCESS;

--- a/src/p4info/p4info_struct.h
+++ b/src/p4info/p4info_struct.h
@@ -66,7 +66,9 @@ struct pi_p4info_s {
   pi_p4info_res_t *tables;
   pi_p4info_res_t *act_profs;
   pi_p4info_res_t *counters;
+  pi_p4info_res_t *direct_counters;
   pi_p4info_res_t *meters;
+  pi_p4info_res_t *direct_meters;
 };
 
 static inline size_t num_res(const pi_p4info_t *p4info,

--- a/src/p4info/tables_int.h
+++ b/src/p4info/tables_int.h
@@ -54,9 +54,6 @@ void pi_p4info_table_add_direct_resource(pi_p4info_t *p4info,
                                          pi_p4_id_t table_id,
                                          pi_p4_id_t direct_res_id);
 
-typedef struct cJSON cJSON;
-void pi_p4info_table_serialize(cJSON *root, const pi_p4info_t *p4info);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/pi.c
+++ b/src/pi.c
@@ -95,12 +95,13 @@ static size_t direct_res_meter_retrieve(const char *src, void *config) {
 
 static void register_std_direct_res() {
   pi_status_t status;
-  status = pi_direct_res_register(
-      PI_COUNTER_ID, direct_res_counter_msg_size, direct_res_counter_emit,
-      sizeof(pi_counter_data_t), direct_res_counter_retrieve);
+  status =
+      pi_direct_res_register(PI_DIRECT_COUNTER_ID, direct_res_counter_msg_size,
+                             direct_res_counter_emit, sizeof(pi_counter_data_t),
+                             direct_res_counter_retrieve);
   assert(status == PI_STATUS_SUCCESS);
   status = pi_direct_res_register(
-      PI_METER_ID, direct_res_meter_msg_size, direct_res_meter_emit,
+      PI_DIRECT_METER_ID, direct_res_meter_msg_size, direct_res_meter_emit,
       sizeof(pi_meter_spec_t), direct_res_meter_retrieve);
   assert(status == PI_STATUS_SUCCESS);
 }
@@ -230,7 +231,15 @@ bool pi_is_counter_id(pi_p4_id_t id) {
   return PI_GET_TYPE_ID(id) == PI_COUNTER_ID;
 }
 
+bool pi_is_direct_counter_id(pi_p4_id_t id) {
+  return PI_GET_TYPE_ID(id) == PI_DIRECT_COUNTER_ID;
+}
+
 bool pi_is_meter_id(pi_p4_id_t id) { return PI_GET_TYPE_ID(id) == PI_METER_ID; }
+
+bool pi_is_direct_meter_id(pi_p4_id_t id) {
+  return PI_GET_TYPE_ID(id) == PI_DIRECT_METER_ID;
+}
 
 pi_status_t pi_direct_res_register(pi_res_type_id_t res_type,
                                    PIDirectResMsgSizeFn msg_size_fn,

--- a/targets/bmv2/pi_tables_imp.cpp
+++ b/targets/bmv2/pi_tables_imp.cpp
@@ -309,14 +309,14 @@ void set_direct_resources(const pi_p4info_t *p4info, pi_dev_id_t dev_id,
     pi_direct_res_config_one_t *config = &direct_res_config->configs[i];
     pi_res_type_id_t type = PI_GET_TYPE_ID(config->res_id);
     switch (type) {
-      case PI_COUNTER_ID:
+      case PI_DIRECT_COUNTER_ID:
         {
           auto value = pibmv2::convert_from_counter_data(
               reinterpret_cast<pi_counter_data_t *>(config->config));
           client.c->bm_mt_write_counter(0, t_name, entry_handle, value);
         }
         break;
-      case PI_METER_ID:
+      case PI_DIRECT_METER_ID:
         {
           auto rates = pibmv2::convert_from_meter_spec(
               reinterpret_cast<pi_meter_spec_t *>(config->config));

--- a/tests/testdata/unittest.p4
+++ b/tests/testdata/unittest.p4
@@ -15,7 +15,7 @@
 
 // To re-generate the P4Info (unittest.p4info.txt) and the static table entries
 // (unittest.entries.txt), run:
-// p4test unittest.p4 --p4-16 --p4runtime-format text --p4runtime-file unittest.p4info.txt --p4runtime-entries-file unittest.entries.txt
+// p4test unittest.p4 --std p4-16 --p4runtime-format text --p4runtime-file unittest.p4info.txt --p4runtime-entries-file unittest.entries.txt
 
 #include <v1model.p4>
 

--- a/tests/testdata/unittest.p4info.txt
+++ b/tests/testdata/unittest.p4info.txt
@@ -20,8 +20,8 @@ tables {
     id: 16800567
     annotations: "@defaultonly()"
   }
-  direct_resource_ids: 301991082
-  direct_resource_ids: 318772168
+  direct_resource_ids: 318768298
+  direct_resource_ids: 352326600
   size: 512
 }
 tables {
@@ -291,7 +291,7 @@ counters {
 }
 direct_counters {
   preamble {
-    id: 301991082
+    id: 318768298
     name: "ExactOne_counter"
     alias: "ExactOne_counter"
   }
@@ -302,7 +302,7 @@ direct_counters {
 }
 meters {
   preamble {
-    id: 318820171
+    id: 335597387
     name: "MeterA"
     alias: "MeterA"
   }
@@ -313,7 +313,7 @@ meters {
 }
 direct_meters {
   preamble {
-    id: 318772168
+    id: 352326600
     name: "ExactOne_meter"
     alias: "ExactOne_meter"
   }


### PR DESCRIPTION
This required major changes in the PI p4info code: because we group all
resources of the same type based on the ID prefix value, we had to
split-up direct & indirect versions of counters & meters. At the same
time, we tried to keep as much common code as possible between the
direct & indirect versions, and tried to limit the impact on the PI
public interface. As a result, the implementation does look hacky in
places (id_from_name functions in particular).