### PR TITLE
Add missing include file path

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -99,7 +99,8 @@ cpp_out/gnmi/gnmi.pb.h \
 grpc_out/gnmi/gnmi.grpc.pb.h
 
 AM_CPPFLAGS = -Icpp_out -Igrpc_out \
--I$(top_srcdir)/../include
+-I$(top_srcdir)/../include \
+-I$(top_srcdir)
 
 BUILT_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
 


### PR DESCRIPTION
When trying to build PI in a separate build directory, we hit a compilation error, unable to include PI/proto/util.h. Including the missing proto path fixes the issue.