### PR TITLE
Add major version number to P4Runtime protobuf packages

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -18,9 +18,10 @@ PROTOFLAGS = -I$(abs_srcdir) -I$(abs_builddir)
 
 # Absolute paths are needed here for 'make distcheck' to work properly
 protos = \
-$(abs_srcdir)/p4/p4types.proto \
-$(abs_srcdir)/p4/p4runtime.proto \
-$(abs_srcdir)/p4/config/p4info.proto \
+$(abs_srcdir)/p4/v1/p4data.proto \
+$(abs_srcdir)/p4/v1/p4runtime.proto \
+$(abs_srcdir)/p4/config/v1/p4info.proto \
+$(abs_srcdir)/p4/config/v1/p4types.proto \
 $(abs_srcdir)/google/rpc/status.proto \
 $(abs_srcdir)/google/rpc/code.proto \
 $(abs_srcdir)/p4/tmp/p4config.proto \
@@ -29,21 +30,24 @@ $(abs_srcdir)/gnmi/gnmi.proto
 # Somehow, using an absolute path above prevents me from using EXTRA_DIST =
 # $(protos)
 EXTRA_DIST = \
-p4/p4types.proto \
-p4/p4runtime.proto \
-p4/config/p4info.proto \
+p4/v1/p4data.proto \
+p4/v1/p4runtime.proto \
+p4/config/v1/p4info.proto \
+p4/config/v1/p4types.proto \
 google/rpc/status.proto \
 google/rpc/code.proto \
 p4/tmp/p4config.proto \
 gnmi/gnmi.proto
 
 proto_cpp_files = \
-cpp_out/p4/p4types.pb.cc \
-cpp_out/p4/p4types.pb.h \
-cpp_out/p4/p4runtime.pb.cc \
-cpp_out/p4/p4runtime.pb.h \
-cpp_out/p4/config/p4info.pb.cc \
-cpp_out/p4/config/p4info.pb.h \
+cpp_out/p4/v1/p4data.pb.cc \
+cpp_out/p4/v1/p4data.pb.h \
+cpp_out/p4/v1/p4runtime.pb.cc \
+cpp_out/p4/v1/p4runtime.pb.h \
+cpp_out/p4/config/v1/p4info.pb.cc \
+cpp_out/p4/config/v1/p4info.pb.h \
+cpp_out/p4/config/v1/p4types.pb.cc \
+cpp_out/p4/config/v1/p4types.pb.h \
 cpp_out/google/rpc/status.pb.cc \
 cpp_out/google/rpc/status.pb.h \
 cpp_out/google/rpc/code.pb.cc \
@@ -54,12 +58,14 @@ cpp_out/gnmi/gnmi.pb.cc \
 cpp_out/gnmi/gnmi.pb.h
 
 proto_grpc_files = \
-grpc_out/p4/p4types.grpc.pb.cc \
-grpc_out/p4/p4types.grpc.pb.h \
-grpc_out/p4/p4runtime.grpc.pb.cc \
-grpc_out/p4/p4runtime.grpc.pb.h \
-grpc_out/p4/config/p4info.grpc.pb.cc \
-grpc_out/p4/config/p4info.grpc.pb.h \
+grpc_out/p4/v1/p4data.grpc.pb.cc \
+grpc_out/p4/v1/p4data.grpc.pb.h \
+grpc_out/p4/v1/p4runtime.grpc.pb.cc \
+grpc_out/p4/v1/p4runtime.grpc.pb.h \
+grpc_out/p4/config/v1/p4info.grpc.pb.cc \
+grpc_out/p4/config/v1/p4info.grpc.pb.h \
+grpc_out/p4/config/v1/p4types.grpc.pb.cc \
+grpc_out/p4/config/v1/p4types.grpc.pb.h \
 grpc_out/google/rpc/status.grpc.pb.cc \
 grpc_out/google/rpc/status.grpc.pb.h \
 grpc_out/google/rpc/code.grpc.pb.cc \
@@ -69,17 +75,19 @@ grpc_out/p4/tmp/p4config.grpc.pb.h \
 grpc_out/gnmi/gnmi.grpc.pb.cc \
 grpc_out/gnmi/gnmi.grpc.pb.h
 
-includep4dir = $(includedir)/p4/
+includep4dir = $(includedir)/p4/v1/
 nodist_includep4_HEADERS = \
-cpp_out/p4/p4types.pb.h \
-grpc_out/p4/p4types.grpc.pb.h \
-cpp_out/p4/p4runtime.pb.h \
-grpc_out/p4/p4runtime.grpc.pb.h
+cpp_out/p4/v1/p4data.pb.h \
+grpc_out/p4/v1/p4data.grpc.pb.h \
+cpp_out/p4/v1/p4runtime.pb.h \
+grpc_out/p4/v1/p4runtime.grpc.pb.h
 
-includep4configdir = $(includedir)/p4/config/
+includep4configdir = $(includedir)/p4/config/v1/
 nodist_includep4config_HEADERS = \
-cpp_out/p4/config/p4info.pb.h \
-grpc_out/p4/config/p4info.grpc.pb.h
+cpp_out/p4/config/v1/p4info.pb.h \
+grpc_out/p4/config/v1/p4info.grpc.pb.h \
+cpp_out/p4/config/v1/p4types.pb.h \
+grpc_out/p4/config/v1/p4types.grpc.pb.h
 
 includep4tmpdir = $(includedir)/p4/tmp/
 nodist_includep4tmp_HEADERS = \
@@ -105,16 +113,17 @@ AM_CPPFLAGS = -Icpp_out -Igrpc_out \
 BUILT_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
 
 if HAVE_GRPC_PY_PLUGIN
-p4pydir = $(pythondir)/p4
+p4pydir = $(pythondir)/p4/v1
 nodist_p4py_PYTHON = \
-py_out/p4/p4types_pb2.py \
-py_out/p4/p4runtime_pb2.py \
-py_out/p4/__init__.py
+py_out/p4/v1/p4data_pb2.py \
+py_out/p4/v1/p4runtime_pb2.py \
+py_out/p4/v1/__init__.py
 
-p4configpydir = $(pythondir)/p4/config
+p4configpydir = $(pythondir)/p4/config/v1
 nodist_p4configpy_PYTHON = \
-py_out/p4/config/p4info_pb2.py \
-py_out/p4/config/__init__.py
+py_out/p4/config/v1/p4info_pb2.py \
+py_out/p4/config/v1/p4types_pb2.py \
+py_out/p4/config/v1/__init__.py
 
 # this one is temporary
 p4tmppydir = $(pythondir)/p4/tmp
@@ -163,7 +172,7 @@ if HAVE_GRPC_PY_PLUGIN
 # plugin inserts code into the proto-generated files). But maybe I am just using
 # an old version of the Python plugin.
 	$(PROTOC) $^ --python_out $(builddir)/py_out $(PROTOFLAGS) --grpc_out $(builddir)/py_out --plugin=protoc-gen-grpc=$(GRPC_PY_PLUGIN)
-	@touch $(builddir)/py_out/p4/__init__.py $(builddir)/py_out/p4/config/__init__.py $(builddir)/py_out/p4/tmp/__init__.py
+	@touch $(builddir)/py_out/p4/v1/__init__.py $(builddir)/py_out/p4/config/v1/__init__.py $(builddir)/py_out/p4/tmp/__init__.py
 	@touch $(builddir)/py_out/google/__init__.py $(builddir)/py_out/google/rpc/__init__.py $(builddir)/py_out/gnmi/__init__.py
 endif
 	@mv -f proto_files.tmp $@

--- a/proto/PI/proto/util.h
+++ b/proto/PI/proto/util.h
@@ -21,7 +21,7 @@
 #ifndef PI_PROTO_UTIL_H_
 #define PI_PROTO_UTIL_H_
 
-#include <p4/config/p4info.pb.h>
+#include <p4/config/v1/p4info.pb.h>
 
 #include <cstdint>
 
@@ -35,7 +35,7 @@ using p4_id_t = uint32_t;
 
 constexpr p4_id_t invalid_id() { return 0; }
 
-p4::config::P4Ids::Prefix resource_type_from_id(p4_id_t p4_id);
+p4::config::v1::P4Ids::Prefix resource_type_from_id(p4_id_t p4_id);
 
 }  // namespace util
 

--- a/proto/demo_grpc/simple_router_mgr.cpp
+++ b/proto/demo_grpc/simple_router_mgr.cpp
@@ -35,8 +35,8 @@
 
 #include "google/rpc/code.pb.h"
 
-namespace p4rt = ::p4::v1;
-namespace p4config = ::p4::config::v1;
+namespace p4v1 = ::p4::v1;
+namespace p4configv1 = ::p4::config::v1;
 
 using grpc::ClientContext;
 using grpc::Status;
@@ -143,12 +143,12 @@ struct CounterQueryHandler : public MgrHandler {
   CounterQueryHandler(SimpleRouterMgr *mgr,
                       const std::string &counter_name,
                       size_t index,
-                      std::promise<p4rt::CounterData> &promise)
+                      std::promise<p4v1::CounterData> &promise)
       : MgrHandler(mgr), counter_name(counter_name), index(index),
         promise(promise) { }
 
   void operator()() {
-    p4rt::CounterData d;
+    p4v1::CounterData d;
     int rc = simple_router_mgr->query_counter_(counter_name, index, &d);
     if (rc) {
       d.set_packet_count(
@@ -159,7 +159,7 @@ struct CounterQueryHandler : public MgrHandler {
 
   std::string counter_name;
   size_t index;
-  std::promise<p4rt::CounterData> &promise;
+  std::promise<p4v1::CounterData> &promise;
 };
 
 struct ConfigUpdateHandler : public MgrHandler {
@@ -185,13 +185,13 @@ class StreamChannelSyncClient {
   StreamChannelSyncClient(SimpleRouterMgr *simple_router_mgr,
                           std::shared_ptr<Channel> channel)
       : simple_router_mgr(simple_router_mgr),
-        stub_(p4rt::P4Runtime::NewStub(channel)) {
+        stub_(p4v1::P4Runtime::NewStub(channel)) {
     stream = stub_->StreamChannel(&context);
   }
 
   void recv_packet_in() {
     recv_thread = std::thread([this]() {
-        p4rt::StreamMessageResponse packet_in;
+        p4v1::StreamMessageResponse packet_in;
         while (stream->Read(&packet_in)) {
           std::cout << "Received packet in bro!\n";
           const auto &packet = packet_in.packet();
@@ -205,32 +205,32 @@ class StreamChannelSyncClient {
 
   void send_init(int device_id) {
     std::cout << "Sending init\n";
-    p4rt::StreamMessageRequest packet_out_init;
+    p4v1::StreamMessageRequest packet_out_init;
     packet_out_init.mutable_arbitration()->set_device_id(device_id);
     stream->Write(packet_out_init);
   }
 
   void send_packet_out(std::string bytes) {
     std::cout << "Sending packet out\n";
-    p4rt::StreamMessageRequest packet_out;
+    p4v1::StreamMessageRequest packet_out;
     packet_out.mutable_packet()->set_payload(std::move(bytes));
     stream->Write(packet_out);
   }
 
  private:
   SimpleRouterMgr *simple_router_mgr{nullptr};
-  std::unique_ptr<p4rt::P4Runtime::Stub> stub_;
+  std::unique_ptr<p4v1::P4Runtime::Stub> stub_;
   std::thread recv_thread;
   ClientContext context;
-  std::unique_ptr<ClientReaderWriter<p4rt::StreamMessageRequest,
-                                     p4rt::StreamMessageResponse> > stream;
+  std::unique_ptr<ClientReaderWriter<p4v1::StreamMessageRequest,
+                                     p4v1::StreamMessageResponse> > stream;
 };
 
 SimpleRouterMgr::SimpleRouterMgr(int dev_id,
                                  boost::asio::io_service &io_service,
                                  std::shared_ptr<Channel> channel)
     : dev_id(dev_id), io_service(io_service),
-      pi_stub_(p4rt::P4Runtime::NewStub(channel)),
+      pi_stub_(p4v1::P4Runtime::NewStub(channel)),
       packet_io_client(new StreamChannelSyncClient(this, channel)) {
 }
 
@@ -241,7 +241,7 @@ SimpleRouterMgr::assign(const std::string &config_buffer,
                         const std::string *p4info_buffer) {
   if (assigned) return 0;
 
-  p4config::P4Info p4info_proto;
+  p4configv1::P4Info p4info_proto;
   if (!p4info_buffer) {
     pi_add_config(config_buffer.c_str(), PI_CONFIG_TYPE_BMV2_JSON, &p4info);
     p4info_proto = pi::p4info::p4info_serialize_to_proto(p4info);
@@ -251,10 +251,10 @@ SimpleRouterMgr::assign(const std::string &config_buffer,
     pi::p4info::p4info_proto_reader(p4info_proto, &p4info);
   }
 
-  p4rt::SetForwardingPipelineConfigRequest request;
+  p4v1::SetForwardingPipelineConfigRequest request;
   request.set_device_id(dev_id);
   request.set_action(
-      p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
+      p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
   auto config = request.mutable_config();
   config->set_allocated_p4info(&p4info_proto);
   p4::tmp::P4DeviceConfig device_config;
@@ -267,7 +267,7 @@ SimpleRouterMgr::assign(const std::string &config_buffer,
   device_config.set_device_data(config_buffer);
   device_config.SerializeToString(config->mutable_p4_device_config());
 
-  p4rt::SetForwardingPipelineConfigResponse rep;
+  p4v1::SetForwardingPipelineConfigResponse rep;
   ClientContext context;
   auto status = pi_stub_->SetForwardingPipelineConfig(&context, request, &rep);
   config->release_p4info();
@@ -298,15 +298,15 @@ std::string uint_to_string<uint32_t>(uint32_t i) {
 }  // namespace
 
 int
-SimpleRouterMgr::add_one_entry(p4rt::TableEntry *match_action_entry) {
-  p4rt::WriteRequest request;
+SimpleRouterMgr::add_one_entry(p4v1::TableEntry *match_action_entry) {
+  p4v1::WriteRequest request;
   request.set_device_id(dev_id);
   auto update = request.add_updates();
-  update->set_type(p4rt::Update_Type_INSERT);
+  update->set_type(p4v1::Update_Type_INSERT);
   auto entity = update->mutable_entity();
   entity->set_allocated_table_entry(match_action_entry);
 
-  p4rt::WriteResponse rep;
+  p4v1::WriteResponse rep;
   ClientContext context;
   Status status = pi_stub_->Write(&context, request, &rep);
 
@@ -323,7 +323,7 @@ SimpleRouterMgr::add_route_(uint32_t prefix, int pLen, uint32_t nhop,
     pi_p4_id_t t_id = pi_p4info_table_id_from_name(p4info, "ipv4_lpm");
     pi_p4_id_t a_id = pi_p4info_action_id_from_name(p4info, "set_nhop");
 
-    p4rt::TableEntry match_action_entry;
+    p4v1::TableEntry match_action_entry;
     match_action_entry.set_table_id(t_id);
 
     auto mf = match_action_entry.add_match();
@@ -374,7 +374,7 @@ SimpleRouterMgr::add_arp_entry(uint32_t addr,
   pi_p4_id_t t_id = pi_p4info_table_id_from_name(p4info, "forward");
   pi_p4_id_t a_id = pi_p4info_action_id_from_name(p4info, "set_dmac");
 
-  p4rt::TableEntry match_action_entry;
+  p4v1::TableEntry match_action_entry;
   match_action_entry.set_table_id(t_id);
 
   auto mf = match_action_entry.add_match();
@@ -403,7 +403,7 @@ SimpleRouterMgr::assign_mac_addr(uint16_t port,
   pi_p4_id_t t_id = pi_p4info_table_id_from_name(p4info, "send_frame");
   pi_p4_id_t a_id = pi_p4info_action_id_from_name(p4info, "rewrite_mac");
 
-  p4rt::TableEntry match_action_entry;
+  p4v1::TableEntry match_action_entry;
   match_action_entry.set_table_id(t_id);
 
   auto mf = match_action_entry.add_match();
@@ -428,8 +428,8 @@ SimpleRouterMgr::assign_mac_addr(uint16_t port,
 
 int
 SimpleRouterMgr::set_one_default_entry(pi_p4_id_t t_id,
-                                       p4rt::Action *action) {
-  p4rt::TableEntry match_action_entry;
+                                       p4v1::Action *action) {
+  p4v1::TableEntry match_action_entry;
   match_action_entry.set_table_id(t_id);
   auto entry = match_action_entry.mutable_action();
   entry->set_allocated_action(action);
@@ -445,7 +445,7 @@ SimpleRouterMgr::set_default_entries() {
   {
     pi_p4_id_t t_id = pi_p4info_table_id_from_name(p4info, "forward");
     pi_p4_id_t a_id = pi_p4info_action_id_from_name(p4info, "_drop");
-    p4rt::TableEntry match_action_entry;
+    p4v1::TableEntry match_action_entry;
     match_action_entry.set_table_id(t_id);
 
     auto mf = match_action_entry.add_match();
@@ -626,12 +626,12 @@ SimpleRouterMgr::add_iface(uint16_t port_num, uint32_t ip_addr,
 int
 SimpleRouterMgr::query_counter(const std::string &counter_name, size_t index,
                                uint64_t *packets, uint64_t *bytes) {
-  std::promise<p4rt::CounterData> promise;
+  std::promise<p4v1::CounterData> promise;
   auto future = promise.get_future();
   CounterQueryHandler h(this, counter_name, index, promise);
   post_event(std::move(h));
   future.wait();
-  p4rt::CounterData counter_data = future.get();
+  p4v1::CounterData counter_data = future.get();
   if (counter_data.packet_count() ==
       std::numeric_limits<decltype(counter_data.packet_count())>::max()) {
     return 1;
@@ -643,7 +643,7 @@ SimpleRouterMgr::query_counter(const std::string &counter_name, size_t index,
 
 int
 SimpleRouterMgr::query_counter_(const std::string &counter_name, size_t index,
-                                p4rt::CounterData *counter_data) {
+                                p4v1::CounterData *counter_data) {
   pi_p4_id_t counter_id = pi_p4info_counter_id_from_name(p4info,
                                                          counter_name.c_str());
   if (counter_id == PI_INVALID_ID) {
@@ -651,7 +651,7 @@ SimpleRouterMgr::query_counter_(const std::string &counter_name, size_t index,
     return 1;
   }
 
-  p4rt::ReadRequest request;
+  p4v1::ReadRequest request;
   request.set_device_id(dev_id);
   auto entity = request.add_entities();
   auto counter_entry = entity->mutable_counter_entry();
@@ -659,7 +659,7 @@ SimpleRouterMgr::query_counter_(const std::string &counter_name, size_t index,
   auto index_msg = counter_entry->mutable_index();
   index_msg->set_index(index);
 
-  p4rt::ReadResponse rep;
+  p4v1::ReadResponse rep;
   ClientContext context;
   auto reader = pi_stub_->Read(&context, request);
   while (reader->Read(&rep)) {
@@ -693,7 +693,7 @@ SimpleRouterMgr::update_config_(const std::string &config_buffer,
                                 const std::string *p4info_buffer) {
   std::cout << "Updating config\n";
 
-  p4config::P4Info p4info_proto;
+  p4configv1::P4Info p4info_proto;
   pi_p4info_t *p4info_new;
   if (!p4info_buffer) {
     pi_add_config(config_buffer.c_str(), PI_CONFIG_TYPE_BMV2_JSON, &p4info_new);
@@ -708,16 +708,16 @@ SimpleRouterMgr::update_config_(const std::string &config_buffer,
   if (p4info_prev) pi_destroy_config(p4info_prev);
 
   {
-    p4rt::SetForwardingPipelineConfigRequest request;
+    p4v1::SetForwardingPipelineConfigRequest request;
     request.set_device_id(dev_id);
     request.set_action(
-        p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE);
+        p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE);
     auto config = request.mutable_config();
     config->set_allocated_p4info(&p4info_proto);
     p4::tmp::P4DeviceConfig device_config;
     device_config.set_device_data(config_buffer);
     device_config.SerializeToString(config->mutable_p4_device_config());
-    p4rt::SetForwardingPipelineConfigResponse rep;
+    p4v1::SetForwardingPipelineConfigResponse rep;
     ClientContext context;
     auto status = pi_stub_->SetForwardingPipelineConfig(
         &context, request, &rep);
@@ -731,10 +731,10 @@ SimpleRouterMgr::update_config_(const std::string &config_buffer,
   // static_config_(UpdateMode::CONTROLLER_STATE);
 
   {
-    p4rt::SetForwardingPipelineConfigRequest request;
+    p4v1::SetForwardingPipelineConfigRequest request;
     request.set_device_id(dev_id);
-    request.set_action(p4rt::SetForwardingPipelineConfigRequest_Action_COMMIT);
-    p4rt::SetForwardingPipelineConfigResponse rep;
+    request.set_action(p4v1::SetForwardingPipelineConfigRequest_Action_COMMIT);
+    p4v1::SetForwardingPipelineConfigResponse rep;
     ClientContext context;
     auto status = pi_stub_->SetForwardingPipelineConfig(
         &context, request, &rep);

--- a/proto/demo_grpc/simple_router_mgr.h
+++ b/proto/demo_grpc/simple_router_mgr.h
@@ -26,7 +26,7 @@
 
 #include <grpc++/grpc++.h>
 
-#include "p4/p4runtime.grpc.pb.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
 
 #include <iostream>
 #include <cstring>
@@ -136,9 +136,9 @@ class SimpleRouterMgr {
   void handle_arp_reply(const arp_header_t &arp_header);
   void send_arp_request(uint16_t port, uint32_t dst_addr);
 
-  int add_one_entry(p4::TableEntry *match_action_entry);
+  int add_one_entry(p4::v1::TableEntry *match_action_entry);
 
-  int set_one_default_entry(pi_p4_id_t t_id, p4::Action *action);
+  int set_one_default_entry(pi_p4_id_t t_id, p4::v1::Action *action);
 
   int add_route_(uint32_t prefix, int pLen, uint32_t nhop, uint16_t port,
                  UpdateMode udpate_mode);
@@ -149,7 +149,7 @@ class SimpleRouterMgr {
   int static_config_(UpdateMode update_mode);
 
   int query_counter_(const std::string &counter_name, size_t index,
-                     p4::CounterData *counter_data);
+                     p4::v1::CounterData *counter_data);
 
   int update_config_(const std::string &config_buffer,
                      const std::string *p4info_buffer);
@@ -163,6 +163,6 @@ class SimpleRouterMgr {
   int dev_id;
   pi_p4info_t *p4info{nullptr};
   boost::asio::io_service &io_service;
-  std::unique_ptr<p4::P4Runtime::Stub> pi_stub_;
+  std::unique_ptr<p4::v1::P4Runtime::Stub> pi_stub_;
   std::unique_ptr<StreamChannelSyncClient> packet_io_client;
 };

--- a/proto/demo_grpc/test_perf.cpp
+++ b/proto/demo_grpc/test_perf.cpp
@@ -19,7 +19,7 @@
 
 #include "p4/v1/p4runtime.grpc.pb.h"
 
-namespace p4rt = ::p4::v1;
+namespace p4v1 = ::p4::v1;
 namespace p4config = ::p4::config::v1;
 
 using grpc::Channel;
@@ -91,10 +91,10 @@ int parse_opts(int argc, char *const argv[]) {
 class P4RuntimeClient {
  public:
   P4RuntimeClient(std::shared_ptr<Channel> channel)
-      : stub_(p4rt::P4Runtime::NewStub(channel)) { }
+      : stub_(p4v1::P4Runtime::NewStub(channel)) { }
 
-  int write(const p4rt::WriteRequest &request) {
-    p4rt::WriteResponse rep;
+  int write(const p4v1::WriteRequest &request) {
+    p4v1::WriteResponse rep;
     ClientContext context;
     auto status = stub_->Write(&context, request, &rep);
     assert(status.ok());
@@ -102,14 +102,14 @@ class P4RuntimeClient {
   }
 
   int assign_device(int device_id, const pi_p4info_t *p4info) {
-    p4rt::SetForwardingPipelineConfigRequest request;
+    p4v1::SetForwardingPipelineConfigRequest request;
     request.set_device_id(device_id);
     request.set_action(
-        p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
+        p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
     auto config = request.mutable_config();
     auto p4info_proto = pi::p4info::p4info_serialize_to_proto(p4info);
     config->set_allocated_p4info(&p4info_proto);
-    p4rt::SetForwardingPipelineConfigResponse rep;
+    p4v1::SetForwardingPipelineConfigResponse rep;
     ClientContext context;
     auto status = stub_->SetForwardingPipelineConfig(&context, request, &rep);
     config->release_p4info();
@@ -118,7 +118,7 @@ class P4RuntimeClient {
   }
 
  private:
-  std::unique_ptr<p4rt::P4Runtime::Stub> stub_;
+  std::unique_ptr<p4v1::P4Runtime::Stub> stub_;
 };
 
 namespace {
@@ -142,7 +142,7 @@ std::string uint_to_string<uint32_t>(uint32_t i) {
 class StreamChannelSync {
  public:
   StreamChannelSync(std::shared_ptr<Channel> channel)
-      : stub_(p4rt::P4Runtime::NewStub(channel)) {
+      : stub_(p4v1::P4Runtime::NewStub(channel)) {
     stream = stub_->StreamChannel(&context);
   }
 
@@ -150,7 +150,7 @@ class StreamChannelSync {
   void recv_packet_in(F f) {
     stop_f = false;
     recv_thread = std::thread([this, &f]() {
-        p4rt::StreamMessageResponse packet_in;
+        p4v1::StreamMessageResponse packet_in;
         while (!stop_f && stream->Read(&packet_in)) {
           f();
         }
@@ -159,14 +159,14 @@ class StreamChannelSync {
 
   void send_init(int device_id) {
     std::cout << "Sending init\n";
-    p4rt::StreamMessageRequest packet_out_init;
+    p4v1::StreamMessageRequest packet_out_init;
     packet_out_init.mutable_arbitration()->set_device_id(device_id);
     stream->Write(packet_out_init);
   }
 
   void send_packet_out(std::string bytes) {
     std::cout << "Sending packet out\n";
-    p4rt::StreamMessageRequest packet_out;
+    p4v1::StreamMessageRequest packet_out;
     packet_out.mutable_packet()->set_payload(std::move(bytes));
     stream->Write(packet_out);
   }
@@ -179,11 +179,11 @@ class StreamChannelSync {
 
  private:
   std::atomic<bool> stop_f{false};
-  std::unique_ptr<p4rt::P4Runtime::Stub> stub_;
+  std::unique_ptr<p4v1::P4Runtime::Stub> stub_;
   std::thread recv_thread;
   ClientContext context;
-  std::unique_ptr<ClientReaderWriter<p4rt::StreamMessageRequest,
-                                     p4rt::StreamMessageResponse> > stream;
+  std::unique_ptr<ClientReaderWriter<p4v1::StreamMessageRequest,
+                                     p4v1::StreamMessageResponse> > stream;
 };
 
 class Tester {
@@ -220,13 +220,13 @@ class Tester {
       for (size_t i = 0; i < iters; i++) {
         // when arenas are enabled in p4runtime.proto
         // Arena arena;
-        // p4rt::TableWriteRequest *request =
-        //     Arena::CreateMessage<p4rt::TableWriteRequest>(&arena);
-        p4rt::WriteRequest request;
+        // p4v1::TableWriteRequest *request =
+        //     Arena::CreateMessage<p4v1::TableWriteRequest>(&arena);
+        p4v1::WriteRequest request;
         request.set_device_id(device_id);
         for (size_t j = 0; j < batch_size; j++) {
           auto update = request.add_updates();
-          update->set_type(p4rt::Update_Type_INSERT);
+          update->set_type(p4v1::Update_Type_INSERT);
           auto entity = update->mutable_entity();
           auto table_entry = entity->mutable_table_entry();
           table_entry->set_table_id(t_id);

--- a/proto/frontend/PI/frontends/proto/device_mgr.h
+++ b/proto/frontend/PI/frontends/proto/device_mgr.h
@@ -27,8 +27,8 @@
 #include <vector>
 
 #include "google/rpc/status.pb.h"
-#include "p4/config/p4info.pb.h"
-#include "p4/p4runtime.pb.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
 
 namespace pi {
 
@@ -47,7 +47,7 @@ class DeviceMgr {
   // may change when we introduce specific error namespace
   using Status = ::google::rpc::Status;
   using PacketInCb =
-      std::function<void(device_id_t, p4::PacketIn *packet, void *cookie)>;
+      std::function<void(device_id_t, p4::v1::PacketIn *packet, void *cookie)>;
 
   explicit DeviceMgr(device_id_t device_id);
 
@@ -56,18 +56,20 @@ class DeviceMgr {
   // New pipeline_config_set and pipeline_config_get methods to replace init,
   // update_start and update_end
   Status pipeline_config_set(
-      p4::SetForwardingPipelineConfigRequest_Action action,
-      const p4::ForwardingPipelineConfig &config);
+      p4::v1::SetForwardingPipelineConfigRequest_Action action,
+      const p4::v1::ForwardingPipelineConfig &config);
 
-  Status pipeline_config_get(p4::ForwardingPipelineConfig *config);
+  Status pipeline_config_get(p4::v1::ForwardingPipelineConfig *config);
 
   // New write and read methods, meant to replace all the methods below
-  Status write(const p4::WriteRequest &request);
+  Status write(const p4::v1::WriteRequest &request);
 
-  Status read(const p4::ReadRequest &request, p4::ReadResponse *response) const;
-  Status read_one(const p4::Entity &entity, p4::ReadResponse *response) const;
+  Status read(const p4::v1::ReadRequest &request,
+              p4::v1::ReadResponse *response) const;
+  Status read_one(const p4::v1::Entity &entity,
+                  p4::v1::ReadResponse *response) const;
 
-  Status packet_out_send(const p4::PacketOut &packet) const;
+  Status packet_out_send(const p4::v1::PacketOut &packet) const;
 
   void packet_in_register_cb(PacketInCb cb, void *cookie);
 

--- a/proto/frontend/src/action_helpers.cpp
+++ b/proto/frontend/src/action_helpers.cpp
@@ -23,7 +23,9 @@
 
 #include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
-#include "p4/p4runtime.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+
+namespace p4rt = ::p4::v1;
 
 namespace pi {
 
@@ -34,7 +36,7 @@ namespace proto {
 using Code = ::google::rpc::Code;
 using common::check_proto_bytestring;
 
-Status validate_action_data(pi_p4info_t *p4info, const p4::Action &action) {
+Status validate_action_data(pi_p4info_t *p4info, const p4rt::Action &action) {
   Status status;
   Code code;
   size_t exp_num_params = pi_p4info_action_num_params(

--- a/proto/frontend/src/action_helpers.cpp
+++ b/proto/frontend/src/action_helpers.cpp
@@ -25,7 +25,7 @@
 #include "google/rpc/status.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 
-namespace p4rt = ::p4::v1;
+namespace p4v1 = ::p4::v1;
 
 namespace pi {
 
@@ -36,7 +36,7 @@ namespace proto {
 using Code = ::google::rpc::Code;
 using common::check_proto_bytestring;
 
-Status validate_action_data(pi_p4info_t *p4info, const p4rt::Action &action) {
+Status validate_action_data(pi_p4info_t *p4info, const p4v1::Action &action) {
   Status status;
   Code code;
   size_t exp_num_params = pi_p4info_action_num_params(

--- a/proto/frontend/src/action_helpers.h
+++ b/proto/frontend/src/action_helpers.h
@@ -24,12 +24,7 @@
 #include <PI/pi.h>
 
 #include "google/rpc/status.pb.h"
-
-namespace p4 {
-
-class Action;
-
-}  // namespace p4
+#include "p4/v1/p4runtime.pb.h"
 
 namespace pi {
 
@@ -39,7 +34,7 @@ namespace proto {
 
 using Status = ::google::rpc::Status;
 
-Status validate_action_data(pi_p4info_t *p4info, const p4::Action &action);
+Status validate_action_data(pi_p4info_t *p4info, const p4::v1::Action &action);
 
 }  // namespace proto
 

--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -33,8 +33,8 @@
 #include "logger.h"
 #include "report_error.h"
 
-namespace p4rt = ::p4::v1;
-namespace p4config = ::p4::config::v1;
+namespace p4v1 = ::p4::v1;
+namespace p4configv1 = ::p4::config::v1;
 
 namespace pi {
 
@@ -110,7 +110,7 @@ ActionProfMgr::ActionProfMgr(pi_dev_tgt_t device_tgt, pi_p4_id_t act_prof_id,
     : device_tgt(device_tgt), act_prof_id(act_prof_id), p4info(p4info) { }
 
 Status
-ActionProfMgr::member_create(const p4rt::ActionProfileMember &member,
+ActionProfMgr::member_create(const p4v1::ActionProfileMember &member,
                              const SessionTemp &session) {
   {
     auto status = validate_action(member.action());
@@ -134,7 +134,7 @@ ActionProfMgr::member_create(const p4rt::ActionProfileMember &member,
 }
 
 Status
-ActionProfMgr::group_create(const p4rt::ActionProfileGroup &group,
+ActionProfMgr::group_create(const p4v1::ActionProfileGroup &group,
                             const SessionTemp &session) {
   Lock lock(mutex);
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
@@ -154,7 +154,7 @@ ActionProfMgr::group_create(const p4rt::ActionProfileGroup &group,
 }
 
 Status
-ActionProfMgr::member_modify(const p4rt::ActionProfileMember &member,
+ActionProfMgr::member_modify(const p4v1::ActionProfileMember &member,
                              const SessionTemp &session) {
   auto status = validate_action(member.action());
   if (IS_ERROR(status)) return status;
@@ -176,7 +176,7 @@ ActionProfMgr::member_modify(const p4rt::ActionProfileMember &member,
 // we stop as soon as there is an error, but make sure to keep consistency
 // between device and local state
 Status
-ActionProfMgr::group_modify(const p4rt::ActionProfileGroup &group,
+ActionProfMgr::group_modify(const p4v1::ActionProfileGroup &group,
                             const SessionTemp &session) {
   Lock lock(mutex);
   auto group_id = group.group_id();
@@ -191,7 +191,7 @@ ActionProfMgr::group_modify(const p4rt::ActionProfileGroup &group,
 }
 
 Status
-ActionProfMgr::member_delete(const p4rt::ActionProfileMember &member,
+ActionProfMgr::member_delete(const p4v1::ActionProfileMember &member,
                              const SessionTemp &session) {
   Lock lock(mutex);
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
@@ -209,7 +209,7 @@ ActionProfMgr::member_delete(const p4rt::ActionProfileMember &member,
 }
 
 Status
-ActionProfMgr::group_delete(const p4rt::ActionProfileGroup &group,
+ActionProfMgr::group_delete(const p4v1::ActionProfileGroup &group,
                             const SessionTemp &session) {
   Lock lock(mutex);
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
@@ -229,12 +229,12 @@ ActionProfMgr::group_delete(const p4rt::ActionProfileGroup &group,
 bool
 ActionProfMgr::check_p4_action_id(pi_p4_id_t p4_id) const {
   using pi::proto::util::resource_type_from_id;
-  return (resource_type_from_id(p4_id) == p4config::P4Ids::ACTION)
+  return (resource_type_from_id(p4_id) == p4configv1::P4Ids::ACTION)
       && pi_p4info_is_valid_id(p4info, p4_id);
 }
 
 pi::ActionData
-ActionProfMgr::construct_action_data(const p4rt::Action &action) {
+ActionProfMgr::construct_action_data(const p4v1::Action &action) {
   pi::ActionData action_data(p4info, action.action_id());
   for (const auto &p : action.params()) {
     action_data.set_arg(p.param_id(), p.value().data(), p.value().size());
@@ -243,7 +243,7 @@ ActionProfMgr::construct_action_data(const p4rt::Action &action) {
 }
 
 Status
-ActionProfMgr::validate_action(const p4rt::Action &action) {
+ActionProfMgr::validate_action(const p4v1::Action &action) {
   auto action_id = action.action_id();
   if (!check_p4_action_id(action_id))
     return make_invalid_p4_id_status();
@@ -261,12 +261,12 @@ ActionProfMgr::update_group_membership(const Id &removed_member_id) {
 
 Code
 ActionProfMgr::group_update_members(pi::ActProf &ap,
-                                    const p4rt::ActionProfileGroup &group) {
+                                    const p4v1::ActionProfileGroup &group) {
   Code code;
   std::vector<Id> new_membership(group.members().size());
   std::transform(
       group.members().begin(), group.members().end(), new_membership.begin(),
-      [](const p4rt::ActionProfileGroup::Member &m) { return m.member_id(); });
+      [](const p4v1::ActionProfileGroup::Member &m) { return m.member_id(); });
   std::sort(new_membership.begin(), new_membership.end());
   auto group_id = group.group_id();
   auto &membership = group_members.at(group_id);

--- a/proto/frontend/src/action_prof_mgr.h
+++ b/proto/frontend/src/action_prof_mgr.h
@@ -32,7 +32,7 @@
 
 #include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
-#include "p4/p4runtime.pb.h"
+#include "p4/v1/p4runtime.pb.h"
 
 #include "common.h"
 
@@ -124,22 +124,22 @@ class ActionProfMgr {
   ActionProfMgr(pi_dev_tgt_t device_tgt, pi_p4_id_t act_prof_id,
                 pi_p4info_t *p4info);
 
-  Status member_create(const p4::ActionProfileMember &member,
+  Status member_create(const p4::v1::ActionProfileMember &member,
                        const SessionTemp &session);
 
-  Status group_create(const p4::ActionProfileGroup &group,
+  Status group_create(const p4::v1::ActionProfileGroup &group,
                       const SessionTemp &session);
 
-  Status member_modify(const p4::ActionProfileMember &member,
+  Status member_modify(const p4::v1::ActionProfileMember &member,
                        const SessionTemp &session);
 
-  Status group_modify(const p4::ActionProfileGroup &group,
+  Status group_modify(const p4::v1::ActionProfileGroup &group,
                       const SessionTemp &session);
 
-  Status member_delete(const p4::ActionProfileMember &member,
+  Status member_delete(const p4::v1::ActionProfileMember &member,
                        const SessionTemp &session);
 
-  Status group_delete(const p4::ActionProfileGroup &group,
+  Status group_delete(const p4::v1::ActionProfileGroup &group,
                       const SessionTemp &session);
 
   // returns nullptr if no matching id
@@ -152,13 +152,13 @@ class ActionProfMgr {
  private:
   bool check_p4_action_id(pi_p4_id_t p4_id) const;
 
-  Status validate_action(const p4::Action &action);
-  pi::ActionData construct_action_data(const p4::Action &action);
+  Status validate_action(const p4::v1::Action &action);
+  pi::ActionData construct_action_data(const p4::v1::Action &action);
 
   // using RepeatedMembers = decltype(
-  //     static_cast<p4::ActionProfileGroup *>(nullptr)->member_id());
+  //     static_cast<p4::v1::ActionProfileGroup *>(nullptr)->member_id());
   Code group_update_members(pi::ActProf &ap,  // NOLINT(runtime/references)
-                            const p4::ActionProfileGroup &group);
+                            const p4::v1::ActionProfileGroup &group);
 
   template <typename It>
   // NOLINTNEXTLINE(runtime/references)

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -45,8 +45,9 @@
 
 #include "p4/tmp/p4config.pb.h"
 
-namespace p4rt = ::p4::v1;
-namespace p4config = ::p4::config::v1;
+namespace p4v1 = ::p4::v1;
+namespace p4configv1 = ::p4::config::v1;
+using p4configv1::P4Ids;
 
 namespace pi {
 
@@ -77,17 +78,17 @@ using P4InfoWrapper = std::unique_ptr<pi_p4info_t, decltype(p4info_deleter)>;
 
 class P4ErrorReporter {
  public:
-  void push_back(const p4rt::Error &error) {
+  void push_back(const p4v1::Error &error) {
     if (error.canonical_code() != Code::OK)
       errors.emplace_back(index, error);
     index++;
   }
 
   // TODO(antonin): remove this overload when we generalize the use of
-  // p4rt::Error in the code?
+  // p4v1::Error in the code?
   void push_back(const Status &status) {
     if (status.code() != Code::OK) {
-      p4rt::Error error;
+      p4v1::Error error;
       error.set_canonical_code(status.code());
       error.set_message(status.message());
       error.set_space("ALL-sswitch-p4org");
@@ -101,7 +102,7 @@ class P4ErrorReporter {
     if (errors.empty()) {
       status.set_code(Code::OK);
     } else {
-      p4rt::Error success;
+      p4v1::Error success;
       success.set_code(Code::OK);
       status.set_code(Code::UNKNOWN);
       size_t i = 0;
@@ -118,17 +119,17 @@ class P4ErrorReporter {
   }
 
  private:
-  std::vector<std::pair<size_t, p4rt::Error> > errors{};
+  std::vector<std::pair<size_t, p4v1::Error> > errors{};
   size_t index{0};
 };
 
-bool ternary_match_is_dont_care(const p4rt::FieldMatch::Ternary &mf) {
+bool ternary_match_is_dont_care(const p4v1::FieldMatch::Ternary &mf) {
   const auto &mask = mf.mask();
   return std::all_of(mask.begin(), mask.end(),
                      [](std::string::value_type c) { return c == 0; });
 }
 
-bool range_match_is_dont_care(const p4rt::FieldMatch::Range &mf) {
+bool range_match_is_dont_care(const p4v1::FieldMatch::Range &mf) {
   const auto &low = mf.low();
   const auto &high = mf.high();
   auto bitwidth = static_cast<size_t>(low.size() * 8);
@@ -149,7 +150,7 @@ class DeviceMgrImp {
     pi_remove_device(device_id);
   }
 
-  void p4_change(const p4config::P4Info &p4info_proto_new,
+  void p4_change(const p4configv1::P4Info &p4info_proto_new,
                  pi_p4info_t *p4info_new) {
     table_info_store.reset();
     for (auto t_id = pi_p4info_table_begin(p4info_new);
@@ -175,26 +176,26 @@ class DeviceMgrImp {
     p4info_proto.CopyFrom(p4info_proto_new);
   }
 
-  Status pipeline_config_set(p4rt::SetForwardingPipelineConfigRequest_Action a,
-                             const p4rt::ForwardingPipelineConfig &config) {
+  Status pipeline_config_set(p4v1::SetForwardingPipelineConfigRequest_Action a,
+                             const p4v1::ForwardingPipelineConfig &config) {
     pi_status_t pi_status;
-    if (a == p4rt::SetForwardingPipelineConfigRequest_Action_UNSPECIFIED) {
+    if (a == p4v1::SetForwardingPipelineConfigRequest_Action_UNSPECIFIED) {
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                           "Invalid SetForwardingPipeline action");
     }
 
     pi_p4info_t *p4info_tmp = nullptr;
     if (
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
     ) {
       if (!pi::p4info::p4info_proto_reader(config.p4info(), &p4info_tmp))
         RETURN_ERROR_STATUS(Code::UNKNOWN, "Error when importing p4info");
     }
 
-    if (a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY)
+    if (a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY)
       RETURN_OK_STATUS();
 
     p4::tmp::P4DeviceConfig p4_device_config;
@@ -232,7 +233,7 @@ class DeviceMgrImp {
 
     // This is for legacy support of bmv2
     if (
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT &&
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT &&
       p4_device_config.device_data().empty()
     ) {
       if (pi_is_device_assigned(device_id)) remove_device();
@@ -251,9 +252,9 @@ class DeviceMgrImp {
     // assign device if needed, i.e. if device hasn't been assigned yet or if
     // the reassign flag is set
     if (
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
     ) {
       if (pi_is_device_assigned(device_id) && p4_device_config.reassign())
         remove_device();
@@ -271,9 +272,9 @@ class DeviceMgrImp {
     // for reconcile, as per the P4Runtime spec, we need to preserve the
     // forwarding state if possible, which is why we do a read to store all
     // existing state.
-    p4rt::ReadResponse forwarding_state;
+    p4v1::ReadResponse forwarding_state;
     if (
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
     ) {
       auto status = save_forwarding_state(&forwarding_state);
       if (IS_ERROR(status)) {
@@ -283,9 +284,9 @@ class DeviceMgrImp {
     }
 
     if (
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_SAVE ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
     ) {
       const auto &device_data = p4_device_config.device_data();
       pi_status = pi_update_device_start(device_id, p4info_tmp,
@@ -302,12 +303,12 @@ class DeviceMgrImp {
     // for reconcile, replay the state saved before the pi_update_device_start
     // call (which itself wipes the state)
     if (
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
     ) {
-      p4rt::WriteRequest write_request;
+      p4v1::WriteRequest write_request;
       for (auto &entity : *forwarding_state.mutable_entities()) {
         auto *update = write_request.add_updates();
-        update->set_type(p4rt::Update_Type_INSERT);
+        update->set_type(p4v1::Update_Type_INSERT);
         update->set_allocated_entity(&entity);
       }
       auto status = write_(write_request);
@@ -318,9 +319,9 @@ class DeviceMgrImp {
     }
 
     if (
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_COMMIT ||
-      a == p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_COMMIT ||
+      a == p4v1::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT
     ) {
       pi_status = pi_update_device_end(device_id);
       if (pi_status != PI_STATUS_SUCCESS) {
@@ -332,7 +333,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status pipeline_config_get(p4rt::ForwardingPipelineConfig *config) {
+  Status pipeline_config_get(p4v1::ForwardingPipelineConfig *config) {
     config->mutable_p4info()->CopyFrom(p4info_proto);
     // TODO(antonin): we do not set the p4_device_config bytes field, as we do
     // not have a local copy of it; if it is needed by the controller, we will
@@ -340,39 +341,39 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status write(const p4rt::WriteRequest &request) {
+  Status write(const p4v1::WriteRequest &request) {
     auto lock = shared_lock();
     return write_(request);
   }
 
-  Status read(const p4rt::ReadRequest &request,
-              p4rt::ReadResponse *response) const {
+  Status read(const p4v1::ReadRequest &request,
+              p4v1::ReadResponse *response) const {
     auto lock = unique_lock();
     return read_(request, response);
   }
 
-  Status read_one(const p4rt::Entity &entity,
-                  p4rt::ReadResponse *response) const {
+  Status read_one(const p4v1::Entity &entity,
+                  p4v1::ReadResponse *response) const {
     auto lock = unique_lock();
     return read_one_(entity, response);
   }
 
-  Status table_write(p4rt::Update_Type update,
-                     const p4rt::TableEntry &table_entry,
+  Status table_write(p4v1::Update_Type update,
+                     const p4v1::TableEntry &table_entry,
                      const SessionTemp &session) {
-    if (!check_p4_id(table_entry.table_id(), p4config::P4Ids::TABLE))
+    if (!check_p4_id(table_entry.table_id(), P4Ids::TABLE))
       return make_invalid_p4_id_status();
 
     Status status;
     switch (update) {
-      case p4rt::Update_Type_UNSPECIFIED:
+      case p4v1::Update_Type_UNSPECIFIED:
         status.set_code(Code::INVALID_ARGUMENT);
         break;
-      case p4rt::Update_Type_INSERT:
+      case p4v1::Update_Type_INSERT:
         return table_insert(table_entry, session);
-      case p4rt::Update_Type_MODIFY:
+      case p4v1::Update_Type_MODIFY:
         return table_modify(table_entry, session);
-      case p4rt::Update_Type_DELETE:
+      case p4v1::Update_Type_DELETE:
         return table_delete(table_entry, session);
       default:
         status.set_code(Code::INVALID_ARGUMENT);
@@ -381,10 +382,10 @@ class DeviceMgrImp {
     return status;
   }
 
-  Status meter_write(p4rt::Update_Type update,
-                     const p4rt::MeterEntry &meter_entry,
+  Status meter_write(p4v1::Update_Type update,
+                     const p4v1::MeterEntry &meter_entry,
                      const SessionTemp &session) {
-    if (!check_p4_id(meter_entry.meter_id(), p4config::P4Ids::METER))
+    if (!check_p4_id(meter_entry.meter_id(), P4Ids::METER))
       return make_invalid_p4_id_status();
     if (!meter_entry.has_index()) {
       RETURN_ERROR_STATUS(
@@ -397,12 +398,12 @@ class DeviceMgrImp {
     }
     auto index = static_cast<size_t>(meter_entry.index().index());
     switch (update) {
-      case p4rt::Update_Type_UNSPECIFIED:
+      case p4v1::Update_Type_UNSPECIFIED:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
-      case p4rt::Update_Type_INSERT:
+      case p4v1::Update_Type_INSERT:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "INSERT update type not supported for meters");
-      case p4rt::Update_Type_MODIFY:
+      case p4v1::Update_Type_MODIFY:
         {
           auto status = validate_meter_spec(meter_entry.config());
           if (IS_ERROR(status)) return status;
@@ -416,7 +417,7 @@ class DeviceMgrImp {
             RETURN_ERROR_STATUS(Code::UNKNOWN, "Error when writing meter spec");
         }
         break;
-      case p4rt::Update_Type_DELETE:  // TODO(antonin): return error instead?
+      case p4v1::Update_Type_DELETE:  // TODO(antonin): return error instead?
         {
           pi_meter_spec_t pi_meter_spec =
               {0, 0, 0, 0, PI_METER_UNIT_DEFAULT, PI_METER_TYPE_DEFAULT};
@@ -434,7 +435,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status entry_handle_from_table_entry(const p4rt::TableEntry &table_entry,
+  Status entry_handle_from_table_entry(const p4v1::TableEntry &table_entry,
                                        pi_entry_handle_t *handle) const {
     pi::MatchKey match_key(p4info.get(), table_entry.table_id());
     {
@@ -451,15 +452,15 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status direct_meter_write(p4rt::Update_Type update,
-                            const p4rt::DirectMeterEntry &meter_entry,
+  Status direct_meter_write(p4v1::Update_Type update,
+                            const p4v1::DirectMeterEntry &meter_entry,
                             const SessionTemp &session) {
     if (!meter_entry.has_table_entry()) {
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                           "Missing table_entry field in DirectMeterEntry");
     }
     const auto &table_entry = meter_entry.table_entry();
-    if (!check_p4_id(table_entry.table_id(), p4config::P4Ids::TABLE))
+    if (!check_p4_id(table_entry.table_id(), P4Ids::TABLE))
       return make_invalid_p4_id_status();
     auto table_lock = table_info_store.lock_table(table_entry.table_id());
 
@@ -470,18 +471,18 @@ class DeviceMgrImp {
     }
 
     p4_id_t table_direct_meter_id = pi_get_table_direct_resource_p4_id(
-        table_entry.table_id(), p4config::P4Ids::DIRECT_METER);
+        table_entry.table_id(), P4Ids::DIRECT_METER);
     if (table_direct_meter_id == PI_INVALID_ID) {
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                           "Table has no direct meters");
     }
     switch (update) {
-      case p4rt::Update_Type_UNSPECIFIED:
+      case p4v1::Update_Type_UNSPECIFIED:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
-      case p4rt::Update_Type_INSERT:
+      case p4v1::Update_Type_INSERT:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "INSERT update type not supported for meters");
-      case p4rt::Update_Type_MODIFY:
+      case p4v1::Update_Type_MODIFY:
         {
           auto status = validate_meter_spec(meter_entry.config());
           if (IS_ERROR(status)) return status;
@@ -497,7 +498,7 @@ class DeviceMgrImp {
           }
         }
         break;
-      case p4rt::Update_Type_DELETE:  // TODO(antonin): return error instead?
+      case p4v1::Update_Type_DELETE:  // TODO(antonin): return error instead?
         {
           pi_meter_spec_t pi_meter_spec =
               {0, 0, 0, 0, PI_METER_UNIT_DEFAULT, PI_METER_TYPE_DEFAULT};
@@ -518,9 +519,9 @@ class DeviceMgrImp {
   }
 
   Status meter_read_one(p4_id_t meter_id,
-                        const p4rt::MeterEntry &meter_entry,
+                        const p4v1::MeterEntry &meter_entry,
                         const SessionTemp &session,
-                        p4rt::ReadResponse *response) const {
+                        p4v1::ReadResponse *response) const {
     assert(pi_p4info_meter_get_direct(p4info.get(), meter_id) ==
            PI_INVALID_ID);
     if (meter_entry.has_index()) {
@@ -545,9 +546,9 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status meter_read(const p4rt::MeterEntry &meter_entry,
+  Status meter_read(const p4v1::MeterEntry &meter_entry,
                     const SessionTemp &session,
-                    p4rt::ReadResponse *response) const {
+                    p4v1::ReadResponse *response) const {
     auto meter_id = meter_entry.meter_id();
     if (meter_id == 0) {  // read all entries for all meters
       for (auto m_id = pi_p4info_meter_begin(p4info.get());
@@ -559,7 +560,7 @@ class DeviceMgrImp {
         if (IS_ERROR(status)) return status;
       }
     } else {  // read for a single meter
-      if (!check_p4_id(meter_id, p4config::P4Ids::METER))
+      if (!check_p4_id(meter_id, P4Ids::METER))
         return make_invalid_p4_id_status();
       if (pi_p4info_meter_get_direct(p4info.get(), meter_id) != PI_INVALID_ID) {
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
@@ -571,9 +572,9 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status direct_meter_read_one(const p4rt::TableEntry &table_entry,
+  Status direct_meter_read_one(const p4v1::TableEntry &table_entry,
                                const SessionTemp &session,
-                               p4rt::ReadResponse *response) const {
+                               p4v1::ReadResponse *response) const {
     if (table_entry.match_size() > 0) {
       auto table_lock = table_info_store.lock_table(table_entry.table_id());
 
@@ -583,7 +584,7 @@ class DeviceMgrImp {
         if (IS_ERROR(status)) return status;
       }
       p4_id_t table_direct_meter_id = pi_get_table_direct_resource_p4_id(
-        table_entry.table_id(), p4config::P4Ids::DIRECT_METER);
+        table_entry.table_id(), P4Ids::DIRECT_METER);
       if (table_direct_meter_id == PI_INVALID_ID) {
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "Table has no direct meters");
@@ -607,9 +608,9 @@ class DeviceMgrImp {
         "Reading ALL direct meters in a table is not supported yet");
   }
 
-  Status direct_meter_read(const p4rt::DirectMeterEntry &meter_entry,
+  Status direct_meter_read(const p4v1::DirectMeterEntry &meter_entry,
                            const SessionTemp &session,
-                           p4rt::ReadResponse *response) const {
+                           p4v1::ReadResponse *response) const {
     if (!meter_entry.has_table_entry()) {
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                           "Missing table_entry field in DirectMeterEntry");
@@ -619,13 +620,13 @@ class DeviceMgrImp {
       RETURN_ERROR_STATUS(Code::UNIMPLEMENTED,
         "Reading ALL direct meters for all tables is not supported yet");
     }
-    if (!check_p4_id(table_entry.table_id(), p4config::P4Ids::TABLE))
+    if (!check_p4_id(table_entry.table_id(), P4Ids::TABLE))
       return make_invalid_p4_id_status();
     return direct_meter_read_one(table_entry, session, response);
   }
 
   Code parse_match_key(p4_id_t table_id, const pi_match_key_t *match_key,
-                       p4rt::TableEntry *entry) const {
+                       p4v1::TableEntry *entry) const {
     auto num_match_fields = pi_p4info_table_num_match_fields(
         p4info.get(), table_id);
     MatchKeyReader mk_reader(match_key);
@@ -689,7 +690,7 @@ class DeviceMgrImp {
   }
 
   Code parse_action_data(const pi_action_data_t *pi_action_data,
-                         p4rt::Action *action) const {
+                         p4v1::Action *action) const {
     ActionDataReader reader(pi_action_data);
     auto action_id = reader.get_action_id();
     action->set_action_id(action_id);
@@ -705,7 +706,7 @@ class DeviceMgrImp {
   }
 
   Code parse_action_entry(p4_id_t table_id, const pi_table_entry_t *pi_entry,
-                          p4rt::TableEntry *entry) const {
+                          p4v1::TableEntry *entry) const {
     if (pi_entry->entry_type == PI_ACTION_ENTRY_TYPE_NONE) return Code::OK;
 
     auto table_action = entry->mutable_action();
@@ -732,9 +733,9 @@ class DeviceMgrImp {
   }
 
   Status table_read_one(p4_id_t table_id,
-                        const p4rt::TableEntry &requested_entry,
+                        const p4v1::TableEntry &requested_entry,
                         const SessionTemp &session,
-                        p4rt::ReadResponse *response) const {
+                        p4v1::ReadResponse *response) const {
     pi::MatchKey expected_match_key(p4info.get(), table_id);
     if (requested_entry.match_size() > 0) {
       auto status = construct_match_key(requested_entry, &expected_match_key);
@@ -833,9 +834,9 @@ class DeviceMgrImp {
   }
 
   // TODO(antonin): full filtering on the match key, action, ...
-  Status table_read(const p4rt::TableEntry &table_entry,
+  Status table_read(const p4v1::TableEntry &table_entry,
                     const SessionTemp &session,
-                    p4rt::ReadResponse *response) const {
+                    p4v1::ReadResponse *response) const {
     if (table_entry.table_id() == 0) {  // read all entries for all tables
       for (auto t_id = pi_p4info_table_begin(p4info.get());
            t_id != pi_p4info_table_end(p4info.get());
@@ -844,7 +845,7 @@ class DeviceMgrImp {
         if (IS_ERROR(status)) return status;
       }
     } else {  // read for a single table
-      if (!check_p4_id(table_entry.table_id(), p4config::P4Ids::TABLE))
+      if (!check_p4_id(table_entry.table_id(), P4Ids::TABLE))
         return make_invalid_p4_id_status();
       auto status = table_read_one(
           table_entry.table_id(), table_entry, session, response);
@@ -853,11 +854,10 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status action_profile_member_write(p4rt::Update_Type update,
-                                     const p4rt::ActionProfileMember &member,
+  Status action_profile_member_write(p4v1::Update_Type update,
+                                     const p4v1::ActionProfileMember &member,
                                      const SessionTemp &session) {
-    if (!check_p4_id(member.action_profile_id(),
-                     p4config::P4Ids::ACTION_PROFILE))
+    if (!check_p4_id(member.action_profile_id(), P4Ids::ACTION_PROFILE))
       return make_invalid_p4_id_status();
     auto action_prof_mgr = get_action_prof_mgr(member.action_profile_id());
     if (action_prof_mgr == nullptr) {
@@ -866,13 +866,13 @@ class DeviceMgrImp {
                           member.action_profile_id());
     }
     switch (update) {
-      case p4rt::Update_Type_UNSPECIFIED:
+      case p4v1::Update_Type_UNSPECIFIED:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
-      case p4rt::Update_Type_INSERT:
+      case p4v1::Update_Type_INSERT:
         return action_prof_mgr->member_create(member, session);
-      case p4rt::Update_Type_MODIFY:
+      case p4v1::Update_Type_MODIFY:
         return action_prof_mgr->member_modify(member, session);
-      case p4rt::Update_Type_DELETE:
+      case p4v1::Update_Type_DELETE:
         return action_prof_mgr->member_delete(member, session);
       default:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
@@ -881,11 +881,10 @@ class DeviceMgrImp {
     RETURN_ERROR_STATUS(Code::UNKNOWN);  // UNREACHABLE
   }
 
-  Status action_profile_group_write(p4rt::Update_Type update,
-                                    const p4rt::ActionProfileGroup &group,
+  Status action_profile_group_write(p4v1::Update_Type update,
+                                    const p4v1::ActionProfileGroup &group,
                                     const SessionTemp &session) {
-    if (!check_p4_id(group.action_profile_id(),
-                     p4config::P4Ids::ACTION_PROFILE))
+    if (!check_p4_id(group.action_profile_id(), P4Ids::ACTION_PROFILE))
       return make_invalid_p4_id_status();
     auto action_prof_mgr = get_action_prof_mgr(group.action_profile_id());
     if (action_prof_mgr == nullptr) {
@@ -894,13 +893,13 @@ class DeviceMgrImp {
                           group.action_profile_id());
     }
     switch (update) {
-      case p4rt::Update_Type_UNSPECIFIED:
+      case p4v1::Update_Type_UNSPECIFIED:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
-      case p4rt::Update_Type_INSERT:
+      case p4v1::Update_Type_INSERT:
         return action_prof_mgr->group_create(group, session);
-      case p4rt::Update_Type_MODIFY:
+      case p4v1::Update_Type_MODIFY:
         return action_prof_mgr->group_modify(group, session);
-      case p4rt::Update_Type_DELETE:
+      case p4v1::Update_Type_DELETE:
         return action_prof_mgr->group_delete(group, session);
       default:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
@@ -984,19 +983,19 @@ class DeviceMgrImp {
 
   Status action_profile_member_read_one(p4_id_t action_profile_id,
                                         const SessionTemp &session,
-                                        p4rt::ReadResponse *response) const {
+                                        p4v1::ReadResponse *response) const {
     return action_profile_read_common(
         action_profile_id, session, response,
         [] (decltype(response) r) {
           return r->add_entities()->mutable_action_profile_member(); },
-        [] (decltype(response)) -> p4rt::ActionProfileGroup * {
+        [] (decltype(response)) -> p4v1::ActionProfileGroup * {
           return nullptr; });
   }
 
   // TODO(antonin): full filtering
-  Status action_profile_member_read(const p4rt::ActionProfileMember &member,
+  Status action_profile_member_read(const p4v1::ActionProfileMember &member,
                                     const SessionTemp &session,
-                                    p4rt::ReadResponse *response) const {
+                                    p4v1::ReadResponse *response) const {
     if (member.action_profile_id() == 0) {
       for (auto act_prof_id = pi_p4info_act_prof_begin(p4info.get());
            act_prof_id != pi_p4info_act_prof_end(p4info.get());
@@ -1006,8 +1005,7 @@ class DeviceMgrImp {
         if (IS_ERROR(status)) return status;
       }
     } else {
-      if (!check_p4_id(member.action_profile_id(),
-                       p4config::P4Ids::ACTION_PROFILE))
+      if (!check_p4_id(member.action_profile_id(), P4Ids::ACTION_PROFILE))
         return make_invalid_p4_id_status();
       auto status = action_profile_member_read_one(
           member.action_profile_id(), session, response);
@@ -1018,19 +1016,19 @@ class DeviceMgrImp {
 
   Status action_profile_group_read_one(p4_id_t action_profile_id,
                                        const SessionTemp &session,
-                                       p4rt::ReadResponse *response) const {
+                                       p4v1::ReadResponse *response) const {
     return action_profile_read_common(
         action_profile_id, session, response,
-        [] (decltype(response)) -> p4rt::ActionProfileMember * {
+        [] (decltype(response)) -> p4v1::ActionProfileMember * {
           return nullptr; },
         [] (decltype(response) r) {
           return r->add_entities()->mutable_action_profile_group(); });
   }
 
   // TODO(antonin): full filtering
-  Status action_profile_group_read(const p4rt::ActionProfileGroup &group,
+  Status action_profile_group_read(const p4v1::ActionProfileGroup &group,
                                    const SessionTemp &session,
-                                   p4rt::ReadResponse *response) const {
+                                   p4v1::ReadResponse *response) const {
     if (group.action_profile_id() == 0) {
       for (auto act_prof_id = pi_p4info_act_prof_begin(p4info.get());
            act_prof_id != pi_p4info_act_prof_end(p4info.get());
@@ -1040,8 +1038,7 @@ class DeviceMgrImp {
         if (IS_ERROR(status)) return status;
       }
     } else {
-      if (!check_p4_id(group.action_profile_id(),
-                       p4config::P4Ids::ACTION_PROFILE))
+      if (!check_p4_id(group.action_profile_id(), P4Ids::ACTION_PROFILE))
         return make_invalid_p4_id_status();
       auto status = action_profile_group_read_one(
           group.action_profile_id(), session, response);
@@ -1050,7 +1047,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status packet_out_send(const p4rt::PacketOut &packet) const {
+  Status packet_out_send(const p4v1::PacketOut &packet) const {
     return packet_io.packet_out_send(packet);
   }
 
@@ -1058,10 +1055,10 @@ class DeviceMgrImp {
     packet_io.packet_in_register_cb(std::move(cb), cookie);
   }
 
-  Status counter_write(p4rt::Update_Type update,
-                       const p4rt::CounterEntry &counter_entry,
+  Status counter_write(p4v1::Update_Type update,
+                       const p4v1::CounterEntry &counter_entry,
                        const SessionTemp &session) {
-    if (!check_p4_id(counter_entry.counter_id(), p4config::P4Ids::COUNTER))
+    if (!check_p4_id(counter_entry.counter_id(), P4Ids::COUNTER))
       return make_invalid_p4_id_status();
     if (!counter_entry.has_index()) {
       RETURN_ERROR_STATUS(
@@ -1074,12 +1071,12 @@ class DeviceMgrImp {
     }
     auto index = static_cast<size_t>(counter_entry.index().index());
     switch (update) {
-      case p4rt::Update_Type_UNSPECIFIED:
+      case p4v1::Update_Type_UNSPECIFIED:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
-      case p4rt::Update_Type_INSERT:
+      case p4v1::Update_Type_INSERT:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "INSERT update type not supported for counters");
-      case p4rt::Update_Type_MODIFY:
+      case p4v1::Update_Type_MODIFY:
         {
           auto pi_counter_data = counter_data_proto_to_pi(
               counter_entry.data(), counter_entry.counter_id());
@@ -1091,7 +1088,7 @@ class DeviceMgrImp {
             RETURN_ERROR_STATUS(Code::UNKNOWN, "Error when writing to counter");
         }
         break;
-      case p4rt::Update_Type_DELETE:  // TODO(antonin): return error instead?
+      case p4v1::Update_Type_DELETE:  // TODO(antonin): return error instead?
         {
           pi_counter_data_t pi_counter_data =
               {PI_COUNTER_UNIT_PACKETS | PI_COUNTER_UNIT_BYTES, 0u, 0u};
@@ -1109,15 +1106,15 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status direct_counter_write(p4rt::Update_Type update,
-                              const p4rt::DirectCounterEntry &counter_entry,
+  Status direct_counter_write(p4v1::Update_Type update,
+                              const p4v1::DirectCounterEntry &counter_entry,
                               const SessionTemp &session) {
     if (!counter_entry.has_table_entry()) {
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                           "Missing table_entry field in DirectCounterEntry");
     }
     const auto &table_entry = counter_entry.table_entry();
-    if (!check_p4_id(table_entry.table_id(), p4config::P4Ids::TABLE))
+    if (!check_p4_id(table_entry.table_id(), P4Ids::TABLE))
       return make_invalid_p4_id_status();
     auto table_lock = table_info_store.lock_table(table_entry.table_id());
 
@@ -1128,18 +1125,18 @@ class DeviceMgrImp {
     }
 
     p4_id_t table_direct_counter_id = pi_get_table_direct_resource_p4_id(
-        table_entry.table_id(), p4config::P4Ids::DIRECT_COUNTER);
+        table_entry.table_id(), P4Ids::DIRECT_COUNTER);
     if (table_direct_counter_id == PI_INVALID_ID) {
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                           "Table has no direct counters");
     }
     switch (update) {
-      case p4rt::Update_Type_UNSPECIFIED:
+      case p4v1::Update_Type_UNSPECIFIED:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT);
-      case p4rt::Update_Type_INSERT:
+      case p4v1::Update_Type_INSERT:
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "INSERT update type not supported for counters");
-      case p4rt::Update_Type_MODIFY:
+      case p4v1::Update_Type_MODIFY:
         {
           auto pi_counter_data = counter_data_proto_to_pi(
               counter_entry.data(), table_direct_counter_id);
@@ -1153,7 +1150,7 @@ class DeviceMgrImp {
           }
         }
         break;
-      case p4rt::Update_Type_DELETE:  // TODO(antonin): return error instead?
+      case p4v1::Update_Type_DELETE:  // TODO(antonin): return error instead?
         {
           pi_counter_data_t pi_counter_data =
               {PI_COUNTER_UNIT_PACKETS | PI_COUNTER_UNIT_BYTES, 0u, 0u};
@@ -1174,9 +1171,9 @@ class DeviceMgrImp {
   }
 
   Status counter_read_one(p4_id_t counter_id,
-                          const p4rt::CounterEntry &counter_entry,
+                          const p4v1::CounterEntry &counter_entry,
                           const SessionTemp &session,
-                          p4rt::ReadResponse *response) const {
+                          p4v1::ReadResponse *response) const {
     assert(pi_p4info_counter_get_direct(p4info.get(), counter_id) ==
            PI_INVALID_ID);
     if (counter_entry.has_index()) {
@@ -1207,9 +1204,9 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status counter_read(const p4rt::CounterEntry &counter_entry,
+  Status counter_read(const p4v1::CounterEntry &counter_entry,
                       const SessionTemp &session,
-                      p4rt::ReadResponse *response) const {
+                      p4v1::ReadResponse *response) const {
     auto counter_id = counter_entry.counter_id();
     if (counter_id == 0) {  // read all entries for all counters
       for (auto c_id = pi_p4info_counter_begin(p4info.get());
@@ -1221,7 +1218,7 @@ class DeviceMgrImp {
         if (IS_ERROR(status)) return status;
       }
     } else {  // read for a single counter
-      if (!check_p4_id(counter_id, p4config::P4Ids::COUNTER))
+      if (!check_p4_id(counter_id, P4Ids::COUNTER))
         return make_invalid_p4_id_status();
       if (pi_p4info_counter_get_direct(p4info.get(), counter_id) !=
           PI_INVALID_ID) {
@@ -1235,9 +1232,9 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status direct_counter_read_one(const p4rt::TableEntry &table_entry,
+  Status direct_counter_read_one(const p4v1::TableEntry &table_entry,
                                  const SessionTemp &session,
-                                 p4rt::ReadResponse *response) const {
+                                 p4v1::ReadResponse *response) const {
     if (table_entry.match_size() > 0) {
       auto table_lock = table_info_store.lock_table(table_entry.table_id());
 
@@ -1247,7 +1244,7 @@ class DeviceMgrImp {
         if (IS_ERROR(status)) return status;
       }
       p4_id_t table_direct_counter_id = pi_get_table_direct_resource_p4_id(
-        table_entry.table_id(), p4config::P4Ids::DIRECT_COUNTER);
+        table_entry.table_id(), P4Ids::DIRECT_COUNTER);
       if (table_direct_counter_id == PI_INVALID_ID) {
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "Table has no direct counters");
@@ -1271,9 +1268,9 @@ class DeviceMgrImp {
         "Reading ALL direct counters in a table is not supported yet");
   }
 
-  Status direct_counter_read(const p4rt::DirectCounterEntry &counter_entry,
+  Status direct_counter_read(const p4v1::DirectCounterEntry &counter_entry,
                              const SessionTemp &session,
-                             p4rt::ReadResponse *response) const {
+                             p4v1::ReadResponse *response) const {
     if (!counter_entry.has_table_entry()) {
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                           "Missing table_entry field in DirectCounterEntry");
@@ -1283,7 +1280,7 @@ class DeviceMgrImp {
       RETURN_ERROR_STATUS(Code::UNIMPLEMENTED,
         "Reading ALL direct counters for all tables is not supported yet");
     }
-    if (!check_p4_id(table_entry.table_id(), p4config::P4Ids::TABLE))
+    if (!check_p4_id(table_entry.table_id(), P4Ids::TABLE))
       return make_invalid_p4_id_status();
     return direct_counter_read_one(table_entry, session, response);
   }
@@ -1300,8 +1297,8 @@ class DeviceMgrImp {
 
  private:
   // internal version of read, which does not acquire an exclusive lock
-  Status read_(const p4rt::ReadRequest &request,
-               p4rt::ReadResponse *response) const {
+  Status read_(const p4v1::ReadRequest &request,
+               p4v1::ReadResponse *response) const {
     Status status;
     status.set_code(Code::OK);
     for (const auto &entity : request.entities()) {
@@ -1312,49 +1309,49 @@ class DeviceMgrImp {
   }
 
   // internal version of read_one, which does not acquire an exclusive lock
-  Status read_one_(const p4rt::Entity &entity,
-                   p4rt::ReadResponse *response) const {
+  Status read_one_(const p4v1::Entity &entity,
+                   p4v1::ReadResponse *response) const {
     Status status;
     SessionTemp session(false  /* = batch */);
     switch (entity.entity_case()) {
-      case p4rt::Entity::kTableEntry:
+      case p4v1::Entity::kTableEntry:
         status = table_read(entity.table_entry(), session, response);
         break;
-      case p4rt::Entity::kActionProfileMember:
+      case p4v1::Entity::kActionProfileMember:
         status = action_profile_member_read(
             entity.action_profile_member(), session, response);
         break;
-      case p4rt::Entity::kActionProfileGroup:
+      case p4v1::Entity::kActionProfileGroup:
         status = action_profile_group_read(
             entity.action_profile_group(), session, response);
         break;
-      case p4rt::Entity::kMeterEntry:
+      case p4v1::Entity::kMeterEntry:
         status = meter_read(entity.meter_entry(), session, response);
         break;
-      case p4rt::Entity::kDirectMeterEntry:
+      case p4v1::Entity::kDirectMeterEntry:
         status = direct_meter_read(
             entity.direct_meter_entry(), session, response);
         break;
-      case p4rt::Entity::kCounterEntry:
+      case p4v1::Entity::kCounterEntry:
         status = counter_read(entity.counter_entry(), session, response);
         break;
-      case p4rt::Entity::kDirectCounterEntry:
+      case p4v1::Entity::kDirectCounterEntry:
         status = direct_counter_read(
             entity.direct_counter_entry(), session, response);
         break;
-      case p4rt::Entity::kPacketReplicationEngineEntry:
+      case p4v1::Entity::kPacketReplicationEngineEntry:
         status = ERROR_STATUS(Code::UNIMPLEMENTED,
                               "Reading from PRE is not supported yet");
         break;
-      case p4rt::Entity::kValueSetEntry:  // TODO(antonin)
+      case p4v1::Entity::kValueSetEntry:  // TODO(antonin)
         status = ERROR_STATUS(Code::UNIMPLEMENTED,
                               "ValueSet reads are not supported yet");
         break;
-      case p4rt::Entity::kRegisterEntry:
+      case p4v1::Entity::kRegisterEntry:
         status = ERROR_STATUS(Code::UNIMPLEMENTED,
                               "Register reads are not supported yet");
         break;
-      case p4rt::Entity::kDigestEntry:
+      case p4v1::Entity::kDigestEntry:
         status = ERROR_STATUS(Code::UNIMPLEMENTED,
                               "Digest config reads are not supported yet");
         break;
@@ -1366,7 +1363,7 @@ class DeviceMgrImp {
   }
 
   // internal version of write, which does not acquire a shared lock
-  Status write_(const p4rt::WriteRequest &request) {
+  Status write_(const p4v1::WriteRequest &request) {
     Status status;
     status.set_code(Code::OK);
     SessionTemp session(true  /* = batch */);
@@ -1374,49 +1371,49 @@ class DeviceMgrImp {
     for (const auto &update : request.updates()) {
       const auto &entity = update.entity();
       switch (entity.entity_case()) {
-        case p4rt::Entity::kExternEntry:
+        case p4v1::Entity::kExternEntry:
           Logger::get()->error("No extern support yet");
           status.set_code(Code::UNIMPLEMENTED);
           break;
-        case p4rt::Entity::kTableEntry:
+        case p4v1::Entity::kTableEntry:
           status = table_write(update.type(), entity.table_entry(), session);
           break;
-        case p4rt::Entity::kActionProfileMember:
+        case p4v1::Entity::kActionProfileMember:
           status = action_profile_member_write(
               update.type(), entity.action_profile_member(), session);
           break;
-        case p4rt::Entity::kActionProfileGroup:
+        case p4v1::Entity::kActionProfileGroup:
           status = action_profile_group_write(
               update.type(), entity.action_profile_group(), session);
           break;
-        case p4rt::Entity::kMeterEntry:
+        case p4v1::Entity::kMeterEntry:
           status = meter_write(update.type(), entity.meter_entry(), session);
           break;
-        case p4rt::Entity::kDirectMeterEntry:
+        case p4v1::Entity::kDirectMeterEntry:
           status = direct_meter_write(
               update.type(), entity.direct_meter_entry(), session);
           break;
-        case p4rt::Entity::kCounterEntry:
+        case p4v1::Entity::kCounterEntry:
           status = counter_write(
               update.type(), entity.counter_entry(), session);
           break;
-        case p4rt::Entity::kDirectCounterEntry:
+        case p4v1::Entity::kDirectCounterEntry:
           status = direct_counter_write(
               update.type(), entity.direct_counter_entry(), session);
           break;
-        case p4rt::Entity::kPacketReplicationEngineEntry:
+        case p4v1::Entity::kPacketReplicationEngineEntry:
           status = ERROR_STATUS(Code::UNIMPLEMENTED,
                                 "Writing to PRE is not supported yet");
           break;
-        case p4rt::Entity::kValueSetEntry:  // TODO(antonin)
+        case p4v1::Entity::kValueSetEntry:  // TODO(antonin)
           status = ERROR_STATUS(Code::UNIMPLEMENTED,
                                 "ValueSet writes are not supported yet");
           break;
-        case p4rt::Entity::kRegisterEntry:
+        case p4v1::Entity::kRegisterEntry:
           status = ERROR_STATUS(Code::UNIMPLEMENTED,
                                 "Register writes are not supported yet");
           break;
-        case p4rt::Entity::kDigestEntry:
+        case p4v1::Entity::kDigestEntry:
           status = ERROR_STATUS(Code::UNIMPLEMENTED,
                                 "Digest config writes are not supported yet");
           break;
@@ -1430,7 +1427,7 @@ class DeviceMgrImp {
   }
 
   p4_id_t pi_get_table_direct_resource_p4_id(
-      pi_p4_id_t table_id, p4config::P4Ids::Prefix resource_type) const {
+      pi_p4_id_t table_id, P4Ids::Prefix resource_type) const {
     size_t num_direct_resources = 0;
     p4_id_t table_direct_resource_id = PI_INVALID_ID;
     const pi_p4_id_t* direct_resource = pi_p4info_table_get_direct_resources(
@@ -1444,27 +1441,26 @@ class DeviceMgrImp {
     return table_direct_resource_id;
   }
 
-  bool check_p4_id(p4_id_t p4_id,
-                   p4config::P4Ids::Prefix expected_type) const {
+  bool check_p4_id(p4_id_t p4_id, P4Ids::Prefix expected_type) const {
     return (pi::proto::util::resource_type_from_id(p4_id) == expected_type)
         && pi_p4info_is_valid_id(p4info.get(), p4_id);
   }
 
-  const p4rt::FieldMatch *find_mf(const p4rt::TableEntry &entry,
+  const p4v1::FieldMatch *find_mf(const p4v1::TableEntry &entry,
                                 pi_p4_id_t mf_id) const {
     for (const auto &mf : entry.match())
       if (mf.field_id() == mf_id) return &mf;
     return nullptr;
   }
 
-  Status validate_exact_match(const p4rt::FieldMatch::Exact &mf,
+  Status validate_exact_match(const p4v1::FieldMatch::Exact &mf,
                               size_t bitwidth) const {
     if (check_proto_bytestring(mf.value(), bitwidth) != Code::OK)
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT, "Invalid bytestring format");
     RETURN_OK_STATUS();
   }
 
-  Status validate_lpm_match(const p4rt::FieldMatch::LPM &mf,
+  Status validate_lpm_match(const p4v1::FieldMatch::LPM &mf,
                             size_t bitwidth) const {
     const auto &value = mf.value();
     const auto pLen = mf.prefix_len();
@@ -1493,7 +1489,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status validate_ternary_match(const p4rt::FieldMatch::Ternary &mf,
+  Status validate_ternary_match(const p4v1::FieldMatch::Ternary &mf,
                                 size_t bitwidth) const {
     const auto &value = mf.value();
     const auto &mask = mf.mask();
@@ -1521,7 +1517,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status validate_range_match(const p4rt::FieldMatch::Range &mf,
+  Status validate_range_match(const p4v1::FieldMatch::Range &mf,
                               size_t bitwidth) const {
     const auto &low = mf.low();
     const auto &high = mf.high();
@@ -1544,7 +1540,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status validate_match_key(const p4rt::TableEntry &entry) const {
+  Status validate_match_key(const p4v1::TableEntry &entry) const {
     auto t_id = entry.table_id();
     size_t num_match_fields;
     auto expected_mf_ids = pi_p4info_table_get_match_fields(
@@ -1611,7 +1607,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status construct_match_key(const p4rt::TableEntry &entry,
+  Status construct_match_key(const p4v1::TableEntry &entry,
                              pi::MatchKey *match_key) const {
     if (entry.is_default_action()) {
       if (!entry.match().empty()) {
@@ -1697,10 +1693,10 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status construct_action_data(uint32_t table_id, const p4rt::Action &action,
+  Status construct_action_data(uint32_t table_id, const p4v1::Action &action,
                                pi::ActionEntry *action_entry) const {
     auto action_id = action.action_id();
-    if (!check_p4_id(action_id, p4config::P4Ids::ACTION))
+    if (!check_p4_id(action_id, P4Ids::ACTION))
       return make_invalid_p4_id_status();
     if (!pi_p4info_table_is_action_of(p4info.get(), table_id, action_id))
       RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT, "Invalid action for table");
@@ -1715,7 +1711,7 @@ class DeviceMgrImp {
   }
 
   Status construct_action_entry_indirect(uint32_t table_id,
-                                         const p4rt::TableAction &table_action,
+                                         const p4v1::TableAction &table_action,
                                          pi::ActionEntry *action_entry) {
     auto action_prof_id = pi_p4info_table_get_implementation(p4info.get(),
                                                              table_id);
@@ -1730,11 +1726,11 @@ class DeviceMgrImp {
     assert(action_prof_mgr);
     const pi_indirect_handle_t *indirect_h = nullptr;
     switch (table_action.type_case()) {
-      case p4rt::TableAction::kActionProfileMemberId:
+      case p4v1::TableAction::kActionProfileMemberId:
         indirect_h = action_prof_mgr->retrieve_member_handle(
             table_action.action_profile_member_id());
         break;
-      case p4rt::TableAction::kActionProfileGroupId:
+      case p4v1::TableAction::kActionProfileGroupId:
         indirect_h = action_prof_mgr->retrieve_group_handle(
             table_action.action_profile_group_id());
         break;
@@ -1750,14 +1746,14 @@ class DeviceMgrImp {
 
   // the table_id is needed for indirect entries
   Status construct_action_entry(uint32_t table_id,
-                                const p4rt::TableAction &table_action,
+                                const p4v1::TableAction &table_action,
                                 pi::ActionEntry *action_entry) {
     switch (table_action.type_case()) {
-      case p4rt::TableAction::kAction:
+      case p4v1::TableAction::kAction:
         return construct_action_data(table_id, table_action.action(),
                                      action_entry);
-      case p4rt::TableAction::kActionProfileMemberId:
-      case p4rt::TableAction::kActionProfileGroupId:
+      case p4v1::TableAction::kActionProfileMemberId:
+      case p4v1::TableAction::kActionProfileGroupId:
         return construct_action_entry_indirect(table_id, table_action,
                                                action_entry);
       default:
@@ -1766,13 +1762,13 @@ class DeviceMgrImp {
   }
 
   // takes storage for meter_spec and counter_data to enable using stack storage
-  Status construct_direct_resources(const p4rt::TableEntry &table_entry,
+  Status construct_direct_resources(const p4v1::TableEntry &table_entry,
                                     pi::ActionEntry *action_entry,
                                     pi_meter_spec_t *meter_spec,
                                     pi_counter_data_t *counter_data) {
     if (table_entry.has_meter_config()) {
       p4_id_t meter_id = pi_get_table_direct_resource_p4_id(
-          table_entry.table_id(), p4config::P4Ids::DIRECT_METER);
+          table_entry.table_id(), P4Ids::DIRECT_METER);
       if (meter_id == PI_INVALID_ID) {
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "Table has no direct meters");
@@ -1786,7 +1782,7 @@ class DeviceMgrImp {
 
     if (table_entry.has_counter_data()) {
       p4_id_t counter_id = pi_get_table_direct_resource_p4_id(
-          table_entry.table_id(), p4config::P4Ids::DIRECT_COUNTER);
+          table_entry.table_id(), P4Ids::DIRECT_COUNTER);
       if (counter_id == PI_INVALID_ID) {
         RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
                             "Table has no direct counters");
@@ -1799,7 +1795,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status table_insert(const p4rt::TableEntry &table_entry,
+  Status table_insert(const p4v1::TableEntry &table_entry,
                       const SessionTemp &session) {
     const auto table_id = table_entry.table_id();
     pi::MatchKey match_key(p4info.get(), table_id);
@@ -1856,7 +1852,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status table_modify(const p4rt::TableEntry &table_entry,
+  Status table_modify(const p4v1::TableEntry &table_entry,
                       const SessionTemp &session) {
     const auto table_id = table_entry.table_id();
     pi::MatchKey match_key(p4info.get(), table_id);
@@ -1905,7 +1901,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  Status table_delete(const p4rt::TableEntry &table_entry,
+  Status table_delete(const p4v1::TableEntry &table_entry,
                       const SessionTemp &session) {
     const auto table_id = table_entry.table_id();
     pi::MatchKey match_key(p4info.get(), table_id);
@@ -1942,14 +1938,14 @@ class DeviceMgrImp {
   }
 
   void counter_data_pi_to_proto(const pi_counter_data_t &pi_data,
-                                p4rt::CounterData *data) const {
+                                p4v1::CounterData *data) const {
     if (pi_data.valid & PI_COUNTER_UNIT_PACKETS)
       data->set_packet_count(pi_data.packets);
     if (pi_data.valid & PI_COUNTER_UNIT_BYTES)
       data->set_byte_count(pi_data.bytes);
   }
 
-  pi_counter_data_t counter_data_proto_to_pi(const p4rt::CounterData &data,
+  pi_counter_data_t counter_data_proto_to_pi(const p4v1::CounterData &data,
                                              pi_p4_id_t counter_id) const {
     pi_counter_data_t pi_data;
     switch (pi_p4info_counter_get_unit(p4info.get(), counter_id)) {
@@ -1970,7 +1966,7 @@ class DeviceMgrImp {
     return pi_data;
   }
 
-  static Status validate_meter_spec(const p4rt::MeterConfig &config) {
+  static Status validate_meter_spec(const p4v1::MeterConfig &config) {
     // as per P4Runtime spec, -1 is a valid value and means that the packet is
     // always marked "green"
     if (config.cir() < 0 && config.cir() != -1)
@@ -1989,7 +1985,7 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  pi_meter_spec_t meter_spec_proto_to_pi(const p4rt::MeterConfig &config,
+  pi_meter_spec_t meter_spec_proto_to_pi(const p4v1::MeterConfig &config,
                                          pi_p4_id_t meter_id) const {
     pi_meter_spec_t pi_meter_spec;
     pi_meter_spec.cir = static_cast<uint64_t>(config.cir());
@@ -2006,7 +2002,7 @@ class DeviceMgrImp {
   }
 
   void meter_spec_pi_to_proto(const pi_meter_spec_t &pi_meter_spec,
-                              p4rt::MeterConfig *config) const {
+                              p4v1::MeterConfig *config) const {
     config->set_cir(pi_meter_spec.cir);
     if (pi_meter_spec.cburst == static_cast<decltype(pi_meter_spec.cburst)>(-1))
       config->set_cburst(-1);
@@ -2020,7 +2016,7 @@ class DeviceMgrImp {
   }
 
   Status counter_read_one_index(const SessionTemp &session, uint32_t counter_id,
-                                p4rt::CounterEntry *entry,
+                                p4v1::CounterEntry *entry,
                                 bool hw_sync = false) const {
     // checked by caller
     assert(entry->has_index() && entry->index().index() >= 0);
@@ -2039,7 +2035,7 @@ class DeviceMgrImp {
   }
 
   Status meter_read_one_index(const SessionTemp &session, uint32_t meter_id,
-                              p4rt::MeterEntry *entry) const {
+                              p4v1::MeterEntry *entry) const {
     // checked by caller
     assert(entry->has_index() && entry->index().index() >= 0);
     auto index = static_cast<size_t>(entry->index().index());
@@ -2063,8 +2059,8 @@ class DeviceMgrImp {
   // before match-action tables. This relies on our knowledge of the rest of the
   // implementation, since we know that the read operations will be done in
   // order.
-  Status save_forwarding_state(p4rt::ReadResponse *response) {
-    p4rt::ReadRequest request;
+  Status save_forwarding_state(p4v1::ReadResponse *response) {
+    p4v1::ReadRequest request;
     // setting the device id is not really necessary since DeviceMgr::Read does
     // not check it (check is done by the server)
     request.set_device_id(device_id);
@@ -2102,7 +2098,7 @@ class DeviceMgrImp {
   // for now, we assume all possible pipes of device are programmed in the same
   // way
   pi_dev_tgt_t device_tgt;
-  p4config::P4Info p4info_proto{};
+  p4configv1::P4Info p4info_proto{};
   P4InfoWrapper p4info{nullptr, p4info_deleter};
 
   PacketIOMgr packet_io;
@@ -2126,35 +2122,35 @@ DeviceMgr::~DeviceMgr() { }
 
 Status
 DeviceMgr::pipeline_config_set(
-    p4rt::SetForwardingPipelineConfigRequest_Action action,
-    const p4rt::ForwardingPipelineConfig &config) {
+    p4v1::SetForwardingPipelineConfigRequest_Action action,
+    const p4v1::ForwardingPipelineConfig &config) {
   return pimp->pipeline_config_set(action, config);
 }
 
 Status
-DeviceMgr::pipeline_config_get(p4rt::ForwardingPipelineConfig *config) {
+DeviceMgr::pipeline_config_get(p4v1::ForwardingPipelineConfig *config) {
   return pimp->pipeline_config_get(config);
 }
 
 Status
-DeviceMgr::write(const p4rt::WriteRequest &request) {
+DeviceMgr::write(const p4v1::WriteRequest &request) {
   return pimp->write(request);
 }
 
 Status
-DeviceMgr::read(const p4rt::ReadRequest &request,
-                p4rt::ReadResponse *response) const {
+DeviceMgr::read(const p4v1::ReadRequest &request,
+                p4v1::ReadResponse *response) const {
   return pimp->read(request, response);
 }
 
 Status
-DeviceMgr::read_one(const p4rt::Entity &entity,
-                    p4rt::ReadResponse *response) const {
+DeviceMgr::read_one(const p4v1::Entity &entity,
+                    p4v1::ReadResponse *response) const {
   return pimp->read_one(entity, response);
 }
 
 Status
-DeviceMgr::packet_out_send(const p4rt::PacketOut &packet) const {
+DeviceMgr::packet_out_send(const p4v1::PacketOut &packet) const {
   return pimp->packet_out_send(packet);
 }
 

--- a/proto/frontend/src/packet_io_mgr.cpp
+++ b/proto/frontend/src/packet_io_mgr.cpp
@@ -27,8 +27,8 @@
 
 #include "google/rpc/code.pb.h"
 
-namespace p4rt = ::p4::v1;
-namespace p4config = ::p4::config::v1;
+namespace p4v1 = ::p4::v1;
+namespace p4configv1 = ::p4::config::v1;
 
 namespace pi {
 
@@ -40,7 +40,7 @@ using Code = ::google::rpc::Code;
 
 namespace {
 
-using p4config::ControllerPacketMetadata;
+using p4configv1::ControllerPacketMetadata;
 
 size_t compute_nbytes(const ControllerPacketMetadata &metadata_hdr) {
   size_t nbits = 0;
@@ -155,7 +155,7 @@ class PacketInMutate {
   }
 
   bool operator ()(const char *pkt, size_t size,
-                   p4rt::PacketIn *packet_in) const {
+                   p4v1::PacketIn *packet_in) const {
     if (size < nbytes) return false;
     packet_in->set_payload(pkt + nbytes, size - nbytes);
     int bit_offset = 0;
@@ -218,7 +218,7 @@ class PacketOutMutate {
     nbytes = compute_nbytes(metadata_hdr);
   }
 
-  bool operator ()(const p4rt::PacketOut &packet_out, std::string *pkt) const {
+  bool operator ()(const p4v1::PacketOut &packet_out, std::string *pkt) const {
     pkt->clear();
     const auto &payload = packet_out.payload();
     pkt->reserve(nbytes + payload.size());
@@ -249,7 +249,7 @@ PacketIOMgr::PacketIOMgr(device_id_t device_id)
 PacketIOMgr::~PacketIOMgr() = default;
 
 void
-PacketIOMgr::p4_change(const p4config::P4Info &p4info) {
+PacketIOMgr::p4_change(const p4configv1::P4Info &p4info) {
   PacketInMutate *packet_in_mutate_new = nullptr;
   PacketOutMutate *packet_out_mutate_new = nullptr;
   for (const auto &metadata_hdr : p4info.controller_packet_metadata()) {
@@ -265,7 +265,7 @@ PacketIOMgr::p4_change(const p4config::P4Info &p4info) {
 }
 
 Status
-PacketIOMgr::packet_out_send(const p4rt::PacketOut &packet) const {
+PacketIOMgr::packet_out_send(const p4v1::PacketOut &packet) const {
     Status status;
     pi_status_t pi_status = PI_STATUS_SUCCESS;
     if (packet_out_mutate) {
@@ -302,7 +302,7 @@ PacketIOMgr::packet_in_cb(pi_dev_id_t dev_id, const char *pkt, size_t size,
                           void *cookie) {
   auto mgr = static_cast<PacketIOMgr *>(cookie);
   assert(dev_id == mgr->device_id);
-  p4rt::PacketIn packet_in;
+  p4v1::PacketIn packet_in;
   if (mgr->packet_in_mutate) {
     Lock lock(mgr->mutex);
     auto success = (*mgr->packet_in_mutate)(pkt, size, &packet_in);

--- a/proto/frontend/src/packet_io_mgr.h
+++ b/proto/frontend/src/packet_io_mgr.h
@@ -28,8 +28,8 @@
 #include <mutex>
 
 #include "google/rpc/status.pb.h"
-#include "p4/config/p4info.pb.h"
-#include "p4/p4runtime.pb.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
 
 namespace pi {
 
@@ -49,9 +49,9 @@ class PacketIOMgr {
   explicit PacketIOMgr(device_id_t device_id);
   ~PacketIOMgr();
 
-  void p4_change(const p4::config::P4Info &p4info);
+  void p4_change(const p4::config::v1::P4Info &p4info);
 
-  Status packet_out_send(const p4::PacketOut &packet) const;
+  Status packet_out_send(const p4::v1::PacketOut &packet) const;
 
   void packet_in_register_cb(PacketInCb cb, void *cookie);
 

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -15,11 +15,11 @@
 syntax = "proto3";
 
 import "google/protobuf/any.proto";
-import "p4/p4types.proto";
+import "p4/config/v1/p4types.proto";
 
 // This package and its contents are a work-in-progress.
 
-package p4.config;
+package p4.config.v1;
 
 message P4Info {
   PkgInfo pkg_info = 1;

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package p4;
+package p4.config.v1;
 
 // P4 type specs ---------------------------------------------------------------
 
@@ -169,43 +169,3 @@ message P4ErrorTypeSpec {
 }
 
 // End of P4 type specs --------------------------------------------------------
-
-message P4Data {
-  oneof data {
-    bytes bitstring = 1;  // for bit<W>, int<W>, varbit<W>
-    bool bool = 2;
-    P4StructLike tuple = 3;
-    P4StructLike struct = 4;
-    P4Header header = 5;
-    P4HeaderUnion header_union = 6;
-    P4HeaderStack header_stack = 7;
-    P4HeaderUnionStack header_union_stack = 8;
-    // Could be replaced with integer values in future versions.
-    string enum = 9;
-    string error = 10;
-  }
-}
-
-message P4StructLike {
-  repeated P4Data members = 1;
-}
-
-message P4Header {
-  bool is_valid = 1;
-  repeated bytes bitstrings = 2;
-}
-
-message P4HeaderUnion {
-  // An empty string indicates that none of the union members are valid and
-  // valid_header must therefore be unset.
-  string valid_header_name = 1;
-  P4Header valid_header = 2;
-}
-
-message P4HeaderStack {
-  repeated P4Header entries = 1;
-}
-
-message P4HeaderUnionStack {
-  repeated P4HeaderUnion entries = 1;
-}

--- a/proto/p4/v1/p4data.proto
+++ b/proto/p4/v1/p4data.proto
@@ -1,0 +1,57 @@
+// Copyright 2013-present Barefoot Networks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package p4.v1;
+
+message P4Data {
+  oneof data {
+    bytes bitstring = 1;  // for bit<W>, int<W>, varbit<W>
+    bool bool = 2;
+    P4StructLike tuple = 3;
+    P4StructLike struct = 4;
+    P4Header header = 5;
+    P4HeaderUnion header_union = 6;
+    P4HeaderStack header_stack = 7;
+    P4HeaderUnionStack header_union_stack = 8;
+    // Could be replaced with integer values in future versions.
+    string enum = 9;
+    string error = 10;
+  }
+}
+
+message P4StructLike {
+  repeated P4Data members = 1;
+}
+
+message P4Header {
+  bool is_valid = 1;
+  repeated bytes bitstrings = 2;
+}
+
+message P4HeaderUnion {
+  // An empty string indicates that none of the union members are valid and
+  // valid_header must therefore be unset.
+  string valid_header_name = 1;
+  P4Header valid_header = 2;
+}
+
+message P4HeaderStack {
+  repeated P4Header entries = 1;
+}
+
+message P4HeaderUnionStack {
+  repeated P4HeaderUnion entries = 1;
+}

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -16,14 +16,14 @@ syntax = "proto3";
 
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
-import "p4/config/p4info.proto";
-import "p4/p4types.proto";
+import "p4/config/v1/p4info.proto";
+import "p4/v1/p4data.proto";
 
 // P4_14 spec: http://p4.org/wp-content/uploads/2015/04/p4-latest.pdf
 
 // This package and its contents are a work-in-progress.
 
-package p4;
+package p4.v1;
 
 service P4Runtime {
   // Update one or more P4 entities on the target.
@@ -591,7 +591,7 @@ message SetForwardingPipelineConfigResponse {
 }
 
 message ForwardingPipelineConfig {
-  config.P4Info p4info = 1;
+  config.v1.P4Info p4info = 1;
   // Target-specific P4 configuration.
   bytes p4_device_config = 2;
 }

--- a/proto/p4info/convert_p4info.cpp
+++ b/proto/p4info/convert_p4info.cpp
@@ -28,7 +28,7 @@
 
 #include "p4info_to_and_from_proto.h"
 
-#include "p4/config/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
 
 namespace {
 
@@ -125,7 +125,7 @@ int main(int argc, char *argv[]) {
       return 1;
     }
   } else if (from_str == "proto") {
-    p4::config::P4Info p4info_proto;
+    p4::config::v1::P4Info p4info_proto;
     std::ifstream is(input_path_str, std::ifstream::binary);
     if (!is) {
       std::cerr << "Error while opening protobuf input file.\n";

--- a/proto/p4info/p4info_to_and_from_proto.cpp
+++ b/proto/p4info/p4info_to_and_from_proto.cpp
@@ -31,7 +31,7 @@
 
 #include "p4/config/v1/p4info.pb.h"
 
-namespace p4config = ::p4::config::v1;
+namespace p4configv1 = ::p4::config::v1;
 
 namespace pi {
 
@@ -55,21 +55,21 @@ class read_proto_exception : public std::exception {
   std::string msg;
 };
 
-void import_annotations(const p4config::Preamble &pre, pi_p4info_t *p4info) {
+void import_annotations(const p4configv1::Preamble &pre, pi_p4info_t *p4info) {
   for (const auto &annotation : pre.annotations())
     pi_p4info_add_annotation(p4info, pre.id(), annotation.c_str());
 }
 
-void import_alias(const p4config::Preamble &pre, pi_p4info_t *p4info) {
+void import_alias(const p4configv1::Preamble &pre, pi_p4info_t *p4info) {
   pi_p4info_add_alias(p4info, pre.id(), pre.alias().c_str());
 }
 
-void import_common(const p4config::Preamble &pre, pi_p4info_t *p4info) {
+void import_common(const p4configv1::Preamble &pre, pi_p4info_t *p4info) {
   import_annotations(pre, p4info);
   import_alias(pre, p4info);
 }
 
-void read_actions(const p4config::P4Info &p4info_proto, pi_p4info_t *p4info) {
+void read_actions(const p4configv1::P4Info &p4info_proto, pi_p4info_t *p4info) {
   const auto &actions = p4info_proto.actions();
   pi_p4info_action_init(p4info, actions.size());
   for (const auto &action : actions) {
@@ -84,7 +84,7 @@ void read_actions(const p4config::P4Info &p4info_proto, pi_p4info_t *p4info) {
   }
 }
 
-void read_tables(const p4config::P4Info &p4info_proto, pi_p4info_t *p4info) {
+void read_tables(const p4configv1::P4Info &p4info_proto, pi_p4info_t *p4info) {
   const auto &tables = p4info_proto.tables();
   pi_p4info_table_init(p4info, tables.size());
   for (const auto &table : tables) {
@@ -96,15 +96,15 @@ void read_tables(const p4config::P4Info &p4info_proto, pi_p4info_t *p4info) {
     for (const auto &mf : table.match_fields()) {
       auto match_type_convert = [&mf]() {
         switch (mf.match_type()) {
-          case p4config::MatchField_MatchType_VALID:
+          case p4configv1::MatchField_MatchType_VALID:
             return PI_P4INFO_MATCH_TYPE_VALID;
-          case p4config::MatchField_MatchType_EXACT:
+          case p4configv1::MatchField_MatchType_EXACT:
             return PI_P4INFO_MATCH_TYPE_EXACT;
-          case p4config::MatchField_MatchType_LPM:
+          case p4configv1::MatchField_MatchType_LPM:
             return PI_P4INFO_MATCH_TYPE_LPM;
-          case p4config::MatchField_MatchType_TERNARY:
+          case p4configv1::MatchField_MatchType_TERNARY:
             return PI_P4INFO_MATCH_TYPE_TERNARY;
-          case p4config::MatchField_MatchType_RANGE:
+          case p4configv1::MatchField_MatchType_RANGE:
             return PI_P4INFO_MATCH_TYPE_RANGE;
           default:  // invalid
             throw read_proto_exception("Invalid match type");
@@ -139,7 +139,7 @@ void read_tables(const p4config::P4Info &p4info_proto, pi_p4info_t *p4info) {
   }
 }
 
-void read_act_profs(const p4config::P4Info &p4info_proto,
+void read_act_profs(const p4configv1::P4Info &p4info_proto,
                     pi_p4info_t *p4info) {
   const auto &action_profiles = p4info_proto.action_profiles();
   pi_p4info_act_prof_init(p4info, action_profiles.size());
@@ -154,18 +154,18 @@ void read_act_profs(const p4config::P4Info &p4info_proto,
   }
 }
 
-void read_counters(const p4config::P4Info &p4info_proto,
+void read_counters(const p4configv1::P4Info &p4info_proto,
                    pi_p4info_t *p4info) {
   const auto &counters = p4info_proto.counters();
   const auto &direct_counters = p4info_proto.direct_counters();
 
-  auto unit_convert = [](const p4config::CounterSpec &spec) {
+  auto unit_convert = [](const p4configv1::CounterSpec &spec) {
     switch (spec.unit()) {
-      case p4config::CounterSpec_Unit_BYTES:
+      case p4configv1::CounterSpec_Unit_BYTES:
         return PI_P4INFO_COUNTER_UNIT_BYTES;
-      case p4config::CounterSpec_Unit_PACKETS:
+      case p4configv1::CounterSpec_Unit_PACKETS:
         return PI_P4INFO_COUNTER_UNIT_PACKETS;
-      case p4config::CounterSpec_Unit_BOTH:
+      case p4configv1::CounterSpec_Unit_BOTH:
         return PI_P4INFO_COUNTER_UNIT_BOTH;
       default:  // invalid
         throw read_proto_exception("Invalid counter unit");
@@ -190,26 +190,26 @@ void read_counters(const p4config::P4Info &p4info_proto,
   }
 }
 
-void read_meters(const p4config::P4Info &p4info_proto, pi_p4info_t *p4info) {
+void read_meters(const p4configv1::P4Info &p4info_proto, pi_p4info_t *p4info) {
   const auto &meters = p4info_proto.meters();
   const auto &direct_meters = p4info_proto.direct_meters();
 
-  auto unit_convert = [](const p4config::MeterSpec &spec) {
+  auto unit_convert = [](const p4configv1::MeterSpec &spec) {
     switch (spec.unit()) {
-      case p4config::MeterSpec_Unit_BYTES:
+      case p4configv1::MeterSpec_Unit_BYTES:
         return PI_P4INFO_METER_UNIT_BYTES;
-      case p4config::MeterSpec_Unit_PACKETS:
+      case p4configv1::MeterSpec_Unit_PACKETS:
         return PI_P4INFO_METER_UNIT_PACKETS;
       default:  // invalid
         throw read_proto_exception("Invalid meter unit");
     }
   };
 
-  auto type_convert = [](const p4config::MeterSpec &spec) {
+  auto type_convert = [](const p4configv1::MeterSpec &spec) {
     switch (spec.type()) {
-      case p4config::MeterSpec_Type_COLOR_AWARE:
+      case p4configv1::MeterSpec_Type_COLOR_AWARE:
         return PI_P4INFO_METER_TYPE_COLOR_AWARE;
-      case p4config::MeterSpec_Type_COLOR_UNAWARE:
+      case p4configv1::MeterSpec_Type_COLOR_UNAWARE:
         return PI_P4INFO_METER_TYPE_COLOR_UNAWARE;
       default:  // invalid
         throw read_proto_exception("Invalid meter type");
@@ -238,7 +238,7 @@ void read_meters(const p4config::P4Info &p4info_proto, pi_p4info_t *p4info) {
 
 }  // namespace
 
-bool p4info_proto_reader(const p4config::P4Info &p4info_proto,
+bool p4info_proto_reader(const p4configv1::P4Info &p4info_proto,
                          pi_p4info_t **p4info) {
   pi_empty_config(p4info);
   try {
@@ -275,7 +275,7 @@ void set_preamble(T *obj, pi_p4_id_t id, const char *name,
 }
 
 void p4info_serialize_actions(const pi_p4info_t *p4info,
-                              p4config::P4Info *p4info_proto) {
+                              p4configv1::P4Info *p4info_proto) {
   for (auto id = pi_p4info_action_begin(p4info);
        id != pi_p4info_action_end(p4info);
        id = pi_p4info_action_next(p4info, id)) {
@@ -297,7 +297,7 @@ void p4info_serialize_actions(const pi_p4info_t *p4info,
 }
 
 void p4info_serialize_tables(const pi_p4info_t *p4info,
-                             p4config::P4Info *p4info_proto) {
+                             p4configv1::P4Info *p4info_proto) {
   for (auto id = pi_p4info_table_begin(p4info);
        id != pi_p4info_table_end(p4info);
        id = pi_p4info_table_next(p4info, id)) {
@@ -317,17 +317,17 @@ void p4info_serialize_tables(const pi_p4info_t *p4info,
       auto match_type_convert = [info]() {
         switch (info->match_type) {
           case PI_P4INFO_MATCH_TYPE_VALID:
-            return p4config::MatchField_MatchType_VALID;
+            return p4configv1::MatchField_MatchType_VALID;
           case PI_P4INFO_MATCH_TYPE_EXACT:
-            return p4config::MatchField_MatchType_EXACT;
+            return p4configv1::MatchField_MatchType_EXACT;
           case PI_P4INFO_MATCH_TYPE_LPM:
-            return p4config::MatchField_MatchType_LPM;
+            return p4configv1::MatchField_MatchType_LPM;
           case PI_P4INFO_MATCH_TYPE_TERNARY:
-            return p4config::MatchField_MatchType_TERNARY;
+            return p4configv1::MatchField_MatchType_TERNARY;
           case PI_P4INFO_MATCH_TYPE_RANGE:
-            return p4config::MatchField_MatchType_RANGE;
+            return p4configv1::MatchField_MatchType_RANGE;
           default:
-            return p4config::MatchField_MatchType_UNSPECIFIED;
+            return p4configv1::MatchField_MatchType_UNSPECIFIED;
         }
       };
       mf->set_match_type(match_type_convert());
@@ -366,7 +366,7 @@ void p4info_serialize_tables(const pi_p4info_t *p4info,
 }
 
 void p4info_serialize_act_profs(const pi_p4info_t *p4info,
-                                p4config::P4Info *p4info_proto) {
+                                p4configv1::P4Info *p4info_proto) {
   for (auto id = pi_p4info_act_prof_begin(p4info);
        id != pi_p4info_act_prof_end(p4info);
        id = pi_p4info_act_prof_next(p4info, id)) {
@@ -388,17 +388,17 @@ void serialize_one_counter(const pi_p4info_t *p4info, pi_p4_id_t id,
   auto unit_convert = [](pi_p4info_counter_unit_t unit) {
     switch (unit) {
       case PI_P4INFO_COUNTER_UNIT_BYTES:
-        return p4config::CounterSpec_Unit_BYTES;
+        return p4configv1::CounterSpec_Unit_BYTES;
       case PI_P4INFO_COUNTER_UNIT_PACKETS:
-        return p4config::CounterSpec_Unit_PACKETS;
+        return p4configv1::CounterSpec_Unit_PACKETS;
       case PI_P4INFO_COUNTER_UNIT_BOTH:
-        return p4config::CounterSpec_Unit_BOTH;
+        return p4configv1::CounterSpec_Unit_BOTH;
       default:  // invalid
-        return p4config::CounterSpec_Unit_UNSPECIFIED;
+        return p4configv1::CounterSpec_Unit_UNSPECIFIED;
     }
   };
 
-  auto set_spec = [p4info, id, &unit_convert](p4config::CounterSpec *spec) {
+  auto set_spec = [p4info, id, &unit_convert](p4configv1::CounterSpec *spec) {
     auto unit = pi_p4info_counter_get_unit(p4info, id);
     spec->set_unit(unit_convert(unit));
   };
@@ -409,7 +409,7 @@ void serialize_one_counter(const pi_p4info_t *p4info, pi_p4_id_t id,
 }
 
 void p4info_serialize_counters(const pi_p4info_t *p4info,
-                               p4config::P4Info *p4info_proto) {
+                               p4configv1::P4Info *p4info_proto) {
   for (auto id = pi_p4info_counter_begin(p4info);
        id != pi_p4info_counter_end(p4info);
        id = pi_p4info_counter_next(p4info, id)) {
@@ -432,26 +432,26 @@ void serialize_one_meter(const pi_p4info_t *p4info, pi_p4_id_t id, T *meter) {
   auto unit_convert = [](pi_p4info_meter_unit_t unit) {
     switch (unit) {
       case PI_P4INFO_METER_UNIT_BYTES:
-        return p4config::MeterSpec_Unit_BYTES;
+        return p4configv1::MeterSpec_Unit_BYTES;
       case PI_P4INFO_METER_UNIT_PACKETS:
-        return p4config::MeterSpec_Unit_PACKETS;
+        return p4configv1::MeterSpec_Unit_PACKETS;
       default:  // invalid
-        return p4config::MeterSpec_Unit_UNSPECIFIED;
+        return p4configv1::MeterSpec_Unit_UNSPECIFIED;
     }
   };
   auto type_convert = [](pi_p4info_meter_type_t type) {
     switch (type) {
       case PI_P4INFO_METER_TYPE_COLOR_AWARE:
-        return p4config::MeterSpec_Type_COLOR_AWARE;
+        return p4configv1::MeterSpec_Type_COLOR_AWARE;
       case PI_P4INFO_METER_TYPE_COLOR_UNAWARE:
-        return p4config::MeterSpec_Type_COLOR_UNAWARE;
+        return p4configv1::MeterSpec_Type_COLOR_UNAWARE;
       default:  // invalid
-        return p4config::MeterSpec_Type_COLOR_AWARE;
+        return p4configv1::MeterSpec_Type_COLOR_AWARE;
     }
   };
 
   auto set_spec = [p4info, id, &unit_convert, &type_convert](
-      p4config::MeterSpec *spec) {
+      p4configv1::MeterSpec *spec) {
     auto unit = pi_p4info_meter_get_unit(p4info, id);
     spec->set_unit(unit_convert(unit));
     auto type = pi_p4info_meter_get_type(p4info, id);
@@ -464,7 +464,7 @@ void serialize_one_meter(const pi_p4info_t *p4info, pi_p4_id_t id, T *meter) {
 }
 
 void p4info_serialize_meters(const pi_p4info_t *p4info,
-                             p4config::P4Info *p4info_proto) {
+                             p4configv1::P4Info *p4info_proto) {
   for (auto id = pi_p4info_meter_begin(p4info);
        id != pi_p4info_meter_end(p4info);
        id = pi_p4info_meter_next(p4info, id)) {
@@ -484,8 +484,8 @@ void p4info_serialize_meters(const pi_p4info_t *p4info,
 
 }  // namespace
 
-p4config::P4Info p4info_serialize_to_proto(const pi_p4info_t *p4info) {
-  p4config::P4Info p4info_proto;
+p4configv1::P4Info p4info_serialize_to_proto(const pi_p4info_t *p4info) {
+  p4configv1::P4Info p4info_proto;
   p4info_serialize_actions(p4info, &p4info_proto);
   p4info_serialize_tables(p4info, &p4info_proto);
   p4info_serialize_act_profs(p4info, &p4info_proto);

--- a/proto/p4info/p4info_to_and_from_proto.h
+++ b/proto/p4info/p4info_to_and_from_proto.h
@@ -21,7 +21,7 @@
 #ifndef PROTO_P4INFO_P4INFO_TO_AND_FROM_PROTO_H_
 #define PROTO_P4INFO_P4INFO_TO_AND_FROM_PROTO_H_
 
-#include "p4/config/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
 
 #include <PI/p4info.h>
 
@@ -29,10 +29,10 @@ namespace pi {
 
 namespace p4info {
 
-p4::config::P4Info p4info_serialize_to_proto(const pi_p4info_t *p4info);
+p4::config::v1::P4Info p4info_serialize_to_proto(const pi_p4info_t *p4info);
 
 // returns true if success, false otherwise
-bool p4info_proto_reader(const p4::config::P4Info &p4info_proto,
+bool p4info_proto_reader(const p4::config::v1::P4Info &p4info_proto,
                          pi_p4info_t **p4info);
 
 }  // namespace p4info

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -49,7 +49,7 @@ using grpc::StatusCode;
 
 using pi::fe::proto::DeviceMgr;
 
-namespace p4rt = ::p4::v1;
+namespace p4v1 = ::p4::v1;
 namespace p4config = ::p4::config::v1;
 
 namespace pi {
@@ -98,7 +98,7 @@ grpc::Status not_master_status() {
 }
 
 using StreamChannelReaderWriter = grpc::ServerReaderWriter<
-  p4rt::StreamMessageResponse, p4rt::StreamMessageRequest>;
+  p4v1::StreamMessageResponse, p4v1::StreamMessageRequest>;
 
 class ConnectionId {
  public:
@@ -175,12 +175,12 @@ class DeviceState {
     return device_mgr.get();
   }
 
-  void send_packet_in(p4rt::PacketIn *packet) {
+  void send_packet_in(p4v1::PacketIn *packet) {
     std::lock_guard<std::mutex> lock(m);
     auto master = get_master();
     if (master == nullptr) return;
     auto stream = master->stream();
-    p4rt::StreamMessageResponse response;
+    p4v1::StreamMessageResponse response;
     response.set_allocated_packet(packet);
     stream->Write(response);
     response.release_packet();
@@ -244,7 +244,7 @@ class DeviceState {
   }
 
   void process_packet_out(Connection *connection,
-                          const p4rt::PacketOut &packet_out) {
+                          const p4v1::PacketOut &packet_out) {
     std::lock_guard<std::mutex> lock(m);
     SIMPLELOG << "PACKET OUT\n";
     if (!is_master(connection)) return;
@@ -281,10 +281,10 @@ class DeviceState {
   void notify_one(const Connection *connection) const {
     auto is_master = (connection == *connections.begin());
     auto stream = connection->stream();
-    p4rt::StreamMessageResponse response;
+    p4v1::StreamMessageResponse response;
     auto arbitration = response.mutable_arbitration();
     arbitration->set_device_id(device_id);
-    auto convert_u128 = [](const Uint128 &from, p4rt::Uint128 *to) {
+    auto convert_u128 = [](const Uint128 &from, p4v1::Uint128 *to) {
       to->set_high(from.high());
       to->set_low(from.low());
     };
@@ -343,14 +343,14 @@ class Devices {
                      std::unique_ptr<DeviceState> > device_map{};
 };
 
-void packet_in_cb(DeviceMgr::device_id_t device_id, p4rt::PacketIn *packet,
+void packet_in_cb(DeviceMgr::device_id_t device_id, p4v1::PacketIn *packet,
                   void *cookie);
 
-class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
+class P4RuntimeServiceImpl : public p4v1::P4Runtime::Service {
  private:
   Status Write(ServerContext *context,
-               const p4rt::WriteRequest *request,
-               p4rt::WriteResponse *rep) override {
+               const p4v1::WriteRequest *request,
+               p4v1::WriteResponse *rep) override {
     SIMPLELOG << "P4Runtime Write\n";
     SIMPLELOG << request->DebugString();
     (void) rep;
@@ -371,11 +371,11 @@ class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
   }
 
   Status Read(ServerContext *context,
-              const p4rt::ReadRequest *request,
-              ServerWriter<p4rt::ReadResponse> *writer) override {
+              const p4v1::ReadRequest *request,
+              ServerWriter<p4v1::ReadResponse> *writer) override {
     SIMPLELOG << "P4Runtime Read\n";
     SIMPLELOG << request->DebugString();
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     auto device_mgr = Devices::get(request->device_id())->get_p4_mgr();
     if (device_mgr == nullptr) return no_pipeline_config_status();
     auto status = device_mgr->read(*request, &response);
@@ -385,8 +385,8 @@ class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
 
   Status SetForwardingPipelineConfig(
       ServerContext *context,
-      const p4rt::SetForwardingPipelineConfigRequest *request,
-      p4rt::SetForwardingPipelineConfigResponse *rep) override {
+      const p4v1::SetForwardingPipelineConfigRequest *request,
+      p4v1::SetForwardingPipelineConfigResponse *rep) override {
     SIMPLELOG << "P4Runtime SetForwardingPipelineConfig\n";
     (void) rep;
     auto device = Devices::get(request->device_id());
@@ -409,8 +409,8 @@ class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
 
   Status GetForwardingPipelineConfig(
       ServerContext *context,
-      const p4rt::GetForwardingPipelineConfigRequest *request,
-      p4rt::GetForwardingPipelineConfigResponse *rep) override {
+      const p4v1::GetForwardingPipelineConfigRequest *request,
+      p4v1::GetForwardingPipelineConfigResponse *rep) override {
     SIMPLELOG << "P4Runtime GetForwardingPipelineConfig\n";
     auto device_mgr = Devices::get(request->device_id())->get_p4_mgr();
     if (device_mgr == nullptr) return no_pipeline_config_status();
@@ -434,10 +434,10 @@ class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
     };
     ConnectionStatus connection_status(context);
 
-    p4rt::StreamMessageRequest request;
+    p4v1::StreamMessageRequest request;
     while (stream->Read(&request)) {
       switch (request.update_case()) {
-        case p4rt::StreamMessageRequest::kArbitration:
+        case p4v1::StreamMessageRequest::kArbitration:
           {
             auto device_id = request.arbitration().device_id();
             auto election_id = convert_u128(
@@ -471,7 +471,7 @@ class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
             }
           }
           break;
-        case p4rt::StreamMessageRequest::kPacket:
+        case p4v1::StreamMessageRequest::kPacket:
           {
             if (connection_status.connection == nullptr) break;
             auto device_id = connection_status.device_id;
@@ -479,7 +479,7 @@ class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
                 connection_status.connection.get(), request.packet());
           }
           break;
-        case p4rt::StreamMessageRequest::kDigestAck:
+        case p4v1::StreamMessageRequest::kDigestAck:
           // DigestAck not supported, and not expected either since we do not
           // support generating DigestList notifications yet.
           SIMPLELOG << "DigestAck not supported yet\n";
@@ -491,12 +491,12 @@ class P4RuntimeServiceImpl : public p4rt::P4Runtime::Service {
     return Status::OK;
   }
 
-  static Uint128 convert_u128(const p4rt::Uint128 &from) {
+  static Uint128 convert_u128(const p4v1::Uint128 &from) {
     return Uint128(from.high(), from.low());
   }
 };
 
-void packet_in_cb(DeviceMgr::device_id_t device_id, p4rt::PacketIn *packet,
+void packet_in_cb(DeviceMgr::device_id_t device_id, p4v1::PacketIn *packet,
                   void *cookie) {
   (void) cookie;
   SIMPLELOG << "PACKET IN\n";
@@ -516,7 +516,7 @@ struct ServerData {
 
 namespace testing {
 
-void send_packet_in(DeviceMgr::device_id_t device_id, p4rt::PacketIn *packet) {
+void send_packet_in(DeviceMgr::device_id_t device_id, p4v1::PacketIn *packet) {
   packet_in_cb(device_id, packet, nullptr);
 }
 

--- a/proto/server/pi_server_testing.h
+++ b/proto/server/pi_server_testing.h
@@ -25,7 +25,11 @@
 
 namespace p4 {
 
+namespace v1 {
+
 class PacketIn;
+
+}  // namespace v1
 
 }  // namespace p4
 
@@ -36,7 +40,7 @@ namespace server {
 namespace testing {
 
 void send_packet_in(::pi::fe::proto::DeviceMgr::device_id_t device_id,
-                    p4::PacketIn *packet);
+                    p4::v1::PacketIn *packet);
 
 size_t max_connections();
 

--- a/proto/src/util.cpp
+++ b/proto/src/util.cpp
@@ -26,29 +26,30 @@ namespace proto {
 
 namespace util {
 
-p4::config::P4Ids::Prefix
+p4::config::v1::P4Ids::Prefix
 resource_type_from_id(p4_id_t p4_id) {
+  using p4::config::v1::P4Ids;
   switch (p4_id >> 24) {
-    case static_cast<p4_id_t>(p4::config::P4Ids::UNSPECIFIED):
-      return p4::config::P4Ids::UNSPECIFIED;
-    case static_cast<p4_id_t>(p4::config::P4Ids::ACTION):
-      return p4::config::P4Ids::ACTION;
-    case static_cast<p4_id_t>(p4::config::P4Ids::TABLE):
-      return p4::config::P4Ids::TABLE;
-    case static_cast<p4_id_t>(p4::config::P4Ids::VALUE_SET):
-      return p4::config::P4Ids::VALUE_SET;
-    case static_cast<p4_id_t>(p4::config::P4Ids::ACTION_PROFILE):
-      return p4::config::P4Ids::ACTION_PROFILE;
-    case static_cast<p4_id_t>(p4::config::P4Ids::COUNTER):
-      return p4::config::P4Ids::COUNTER;
-    case static_cast<p4_id_t>(p4::config::P4Ids::DIRECT_COUNTER):
-      return p4::config::P4Ids::DIRECT_COUNTER;
-    case static_cast<p4_id_t>(p4::config::P4Ids::METER):
-      return p4::config::P4Ids::METER;
-    case static_cast<p4_id_t>(p4::config::P4Ids::DIRECT_METER):
-      return p4::config::P4Ids::DIRECT_METER;
+    case static_cast<p4_id_t>(P4Ids::UNSPECIFIED):
+      return P4Ids::UNSPECIFIED;
+    case static_cast<p4_id_t>(P4Ids::ACTION):
+      return P4Ids::ACTION;
+    case static_cast<p4_id_t>(P4Ids::TABLE):
+      return P4Ids::TABLE;
+    case static_cast<p4_id_t>(P4Ids::VALUE_SET):
+      return P4Ids::VALUE_SET;
+    case static_cast<p4_id_t>(P4Ids::ACTION_PROFILE):
+      return P4Ids::ACTION_PROFILE;
+    case static_cast<p4_id_t>(P4Ids::COUNTER):
+      return P4Ids::COUNTER;
+    case static_cast<p4_id_t>(P4Ids::DIRECT_COUNTER):
+      return P4Ids::DIRECT_COUNTER;
+    case static_cast<p4_id_t>(P4Ids::METER):
+      return P4Ids::METER;
+    case static_cast<p4_id_t>(P4Ids::DIRECT_METER):
+      return P4Ids::DIRECT_METER;
     default:
-      return p4::config::P4Ids::UNSPECIFIED;
+      return P4Ids::UNSPECIFIED;
   }
 }
 

--- a/proto/tests/matchers.cpp
+++ b/proto/tests/matchers.cpp
@@ -24,12 +24,15 @@
 #include <ostream>
 #include <string>
 
-#include "p4/p4runtime.pb.h"
+#include "p4/v1/p4runtime.pb.h"
 
 #include "PI/int/pi_int.h"
 #include "PI/pi.h"
 
 #include "matchers.h"
+
+using p4::v1::CounterData;
+using p4::v1::MeterConfig;
 
 namespace pi {
 namespace proto {
@@ -101,7 +104,7 @@ ActionDataMatcher::DescribeNegationTo(std::ostream *os) const {
   *os << "is not correct action data";
 }
 
-MeterSpecMatcher::MeterSpecMatcher(const p4::MeterConfig &config,
+MeterSpecMatcher::MeterSpecMatcher(const MeterConfig &config,
                                    pi_meter_unit_t meter_unit,
                                    pi_meter_type_t meter_type)
     : config(config), meter_unit(meter_unit), meter_type(meter_type) { }
@@ -154,7 +157,7 @@ MeterSpecMatcher::DescribeNegationTo(std::ostream *os) const {
   *os << "is not correct meter spec";
 }
 
-CounterDataMatcher::CounterDataMatcher(const p4::CounterData &data,
+CounterDataMatcher::CounterDataMatcher(const CounterData &data,
                                        bool check_bytes, bool check_packets)
     : data(data), check_bytes(check_bytes), check_packets(check_packets) { }
 
@@ -198,7 +201,7 @@ TableEntryMatcher_Base::TableEntryMatcher_Base() = default;
 
 void
 TableEntryMatcher_Base::add_direct_meter(pi_p4_id_t meter_id,
-                                         const p4::MeterConfig &config,
+                                         const MeterConfig &config,
                                          pi_meter_unit_t meter_unit,
                                          pi_meter_type_t meter_type) {
   meters.emplace(meter_id, MeterSpecMatcher(config, meter_unit, meter_type));
@@ -206,7 +209,7 @@ TableEntryMatcher_Base::add_direct_meter(pi_p4_id_t meter_id,
 
 void
 TableEntryMatcher_Base::add_direct_counter(pi_p4_id_t counter_id,
-                                           const p4::CounterData &data,
+                                           const CounterData &data,
                                            bool check_bytes,
                                            bool check_packets) {
   counters.emplace(counter_id,

--- a/proto/tests/matchers.h
+++ b/proto/tests/matchers.h
@@ -27,7 +27,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "p4/p4runtime.pb.h"
+#include "p4/v1/p4runtime.pb.h"
 
 #include "PI/pi.h"
 
@@ -87,7 +87,7 @@ inline Matcher<const pi_action_data_t *> CorrectActionData(
 
 class MeterSpecMatcher : public MatcherInterface<const pi_meter_spec_t *> {
  public:
-  MeterSpecMatcher(const p4::MeterConfig &config,
+  MeterSpecMatcher(const p4::v1::MeterConfig &config,
                    pi_meter_unit_t meter_unit,
                    pi_meter_type_t meter_type);
 
@@ -99,20 +99,20 @@ class MeterSpecMatcher : public MatcherInterface<const pi_meter_spec_t *> {
   void DescribeNegationTo(std::ostream *os) const override;
 
  private:
-  p4::MeterConfig config;
+  p4::v1::MeterConfig config;
   pi_meter_unit_t meter_unit;
   pi_meter_type_t meter_type;
 };
 
 inline Matcher<const pi_meter_spec_t *> CorrectMeterSpec(
-    const p4::MeterConfig &config,
+    const p4::v1::MeterConfig &config,
     pi_meter_unit_t meter_unit, pi_meter_type_t meter_type) {
   return MakeMatcher(new MeterSpecMatcher(config, meter_unit, meter_type));
 }
 
 class CounterDataMatcher : public MatcherInterface<const pi_counter_data_t *> {
  public:
-  CounterDataMatcher(const p4::CounterData &data,
+  CounterDataMatcher(const p4::v1::CounterData &data,
                      bool check_bytes, bool check_packets);
 
   bool MatchAndExplain(const pi_counter_data_t *pi_data,
@@ -123,23 +123,25 @@ class CounterDataMatcher : public MatcherInterface<const pi_counter_data_t *> {
   void DescribeNegationTo(std::ostream *os) const override;
 
  private:
-  p4::CounterData data;
+  p4::v1::CounterData data;
   bool check_bytes;
   bool check_packets;
 };
 
 inline Matcher<const pi_counter_data_t *> CorrectCounterData(
-    const p4::CounterData &data, bool check_bytes, bool check_packets) {
+    const p4::v1::CounterData &data, bool check_bytes, bool check_packets) {
   return MakeMatcher(new CounterDataMatcher(data, check_bytes, check_packets));
 }
 
 class TableEntryMatcher_Base {
  public:
-  void add_direct_meter(pi_p4_id_t meter_id, const p4::MeterConfig &config,
+  void add_direct_meter(pi_p4_id_t meter_id,
+                        const p4::v1::MeterConfig &config,
                         pi_meter_unit_t meter_unit,
                         pi_meter_type_t meter_type);
 
-  void add_direct_counter(pi_p4_id_t counter_id, const p4::CounterData &data,
+  void add_direct_counter(pi_p4_id_t counter_id,
+                          const p4::v1::CounterData &data,
                           bool check_bytes, bool check_packets);
 
  protected:

--- a/proto/tests/server/test_no_pipeline_config.cpp
+++ b/proto/tests/server/test_no_pipeline_config.cpp
@@ -26,7 +26,7 @@
 
 #include "utils.h"
 
-namespace p4rt = ::p4::v1;
+namespace p4v1 = ::p4::v1;
 
 namespace pi {
 namespace proto {
@@ -42,7 +42,7 @@ class TestNoForwardingPipeline : public ::testing::Test {
   TestNoForwardingPipeline()
       : p4runtime_channel(grpc::CreateChannel(
             server->bind_addr(), grpc::InsecureChannelCredentials())),
-        p4runtime_stub(p4rt::P4Runtime::NewStub(p4runtime_channel)) { }
+        p4runtime_stub(p4v1::P4Runtime::NewStub(p4runtime_channel)) { }
 
   static void SetUpTestCase() {
     server = new TestServer();
@@ -54,7 +54,7 @@ class TestNoForwardingPipeline : public ::testing::Test {
 
   void SetUp() override {
     stream = p4runtime_stub->StreamChannel(&stream_context);
-    p4rt::StreamMessageRequest request;
+    p4v1::StreamMessageRequest request;
     auto arbitration = request.mutable_arbitration();
     arbitration->set_device_id(device_id);
     stream->Write(request);
@@ -62,7 +62,7 @@ class TestNoForwardingPipeline : public ::testing::Test {
 
   void TearDown() override {
     stream->WritesDone();
-    p4rt::StreamMessageResponse response;
+    p4v1::StreamMessageResponse response;
     while (stream->Read(&response)) { }
     auto status = stream->Finish();
     EXPECT_TRUE(status.ok());
@@ -70,9 +70,9 @@ class TestNoForwardingPipeline : public ::testing::Test {
 
   int device_id{0};
   std::shared_ptr<grpc::Channel> p4runtime_channel;
-  std::unique_ptr<p4rt::P4Runtime::Stub> p4runtime_stub;
-  using ReaderWriter = ::grpc::ClientReaderWriter<p4rt::StreamMessageRequest,
-                                                  p4rt::StreamMessageResponse>;
+  std::unique_ptr<p4v1::P4Runtime::Stub> p4runtime_stub;
+  using ReaderWriter = ::grpc::ClientReaderWriter<p4v1::StreamMessageRequest,
+                                                  p4v1::StreamMessageResponse>;
   ClientContext stream_context;
   std::unique_ptr<ReaderWriter> stream{nullptr};
 
@@ -82,21 +82,21 @@ class TestNoForwardingPipeline : public ::testing::Test {
 TestServer *TestNoForwardingPipeline::server = nullptr;
 
 TEST_F(TestNoForwardingPipeline, Write) {
-  p4rt::WriteRequest request;
+  p4v1::WriteRequest request;
   request.set_device_id(device_id);
   ClientContext context;
-  p4rt::WriteResponse rep;
+  p4v1::WriteResponse rep;
   auto status = p4runtime_stub->Write(&context, request, &rep);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(StatusCode::FAILED_PRECONDITION, status.error_code());
 }
 
 TEST_F(TestNoForwardingPipeline, Read) {
-  p4rt::ReadRequest request;
+  p4v1::ReadRequest request;
   request.set_device_id(device_id);
   ClientContext context;
-  p4rt::ReadResponse rep;
-  std::unique_ptr<grpc::ClientReader<p4rt::ReadResponse> > reader(
+  p4v1::ReadResponse rep;
+  std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse> > reader(
       p4runtime_stub->Read(&context, request));
   reader->Read(&rep);
   auto status = reader->Finish();
@@ -105,10 +105,10 @@ TEST_F(TestNoForwardingPipeline, Read) {
 }
 
 TEST_F(TestNoForwardingPipeline, GetForwardingPipelineConfig) {
-  p4rt::GetForwardingPipelineConfigRequest request;
+  p4v1::GetForwardingPipelineConfigRequest request;
   request.set_device_id(device_id);
   ClientContext context;
-  p4rt::GetForwardingPipelineConfigResponse rep;
+  p4v1::GetForwardingPipelineConfigResponse rep;
   auto status = p4runtime_stub->GetForwardingPipelineConfig(
       &context, request, &rep);
   EXPECT_FALSE(status.ok());

--- a/proto/tests/test_p4info_convert.cpp
+++ b/proto/tests/test_p4info_convert.cpp
@@ -26,7 +26,7 @@
 
 #include "PI/p4info.h"
 
-#include "p4/config/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
 
 #include "p4info_to_and_from_proto.h"
 

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -51,8 +51,8 @@
 #include "matchers.h"
 #include "mock_switch.h"
 
-namespace p4rt = ::p4::v1;
-namespace p4config = ::p4::config::v1;
+namespace p4v1 = ::p4::v1;
+namespace p4configv1 = ::p4::config::v1;
 
 // Needs to be in same namespace as google::rpc::Status for ADL
 namespace google {
@@ -61,7 +61,7 @@ std::ostream &operator<<(std::ostream &out, const Status &status) {
   out << "Status(code=" << status.code() << ", message='" << status.message()
       << "', details=";
   for (const auto &error_any : status.details()) {
-    p4rt::Error error;
+    p4v1::Error error;
     if (!error_any.UnpackTo(&error)) {
       out << "INVALID + ";
     } else {
@@ -90,7 +90,7 @@ using ::testing::AnyNumber;
 using ::testing::AtLeast;
 
 // Used to make sure that a google::rpc::Status object has the correct format
-// and contains a single p4rt::Error message with a matching canonical error
+// and contains a single p4v1::Error message with a matching canonical error
 // code and message. The test writer can simply write the following:
 // EXPECT_EQ(returned_status, OneExpectedError(expected_code [, expected_msg]));
 struct OneExpectedError {
@@ -111,7 +111,7 @@ bool operator==(const DeviceMgr::Status &status,
   if (status.code() != Code::UNKNOWN) return false;
   if (status.details().size() != 1) return false;
   const auto &error_any = status.details().Get(0);
-  p4rt::Error error;
+  p4v1::Error error;
   if (!error_any.UnpackTo(&error)) return false;
   if (error.canonical_code() != expected.code) return false;
   if (!expected.msg.empty() && (expected.msg != error.message())) return false;
@@ -133,7 +133,7 @@ std::ostream &operator<<(std::ostream &out, const OneExpectedError &error) {
 
 // Used to make sure that a google::rpc::Status object has the correct format
 // and contains the correct error codes in the details field, which is a
-// repeated field of p4rt::Error messages (as Any messages).
+// repeated field of p4v1::Error messages (as Any messages).
 struct ExpectedErrors {
   void push_back(Code code) {
     expected_codes.push_back(code);
@@ -156,7 +156,7 @@ bool operator==(const DeviceMgr::Status &status,
     return false;
   for (size_t i = 0; i < expected_errors.size(); i++) {
     const auto &error_any = status.details().Get(i);
-    p4rt::Error error;
+    p4v1::Error error;
     if (!error_any.UnpackTo(&error)) return false;
     if (error.canonical_code() != expected_errors.at(i)) return false;
   }
@@ -193,10 +193,10 @@ class DeviceMgrTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    p4rt::ForwardingPipelineConfig config;
+    p4v1::ForwardingPipelineConfig config;
     config.set_allocated_p4info(&p4info_proto);
     auto status = mgr.pipeline_config_set(
-        p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
+        p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
         config);
     // releasing resource before the assert to avoid double free in case the
     // assert is false
@@ -206,10 +206,10 @@ class DeviceMgrTest : public ::testing::Test {
 
   void TearDown() override { }
 
-  DeviceMgr::Status add_entry(p4rt::TableEntry *entry) {
-    p4rt::WriteRequest request;
+  DeviceMgr::Status add_entry(p4v1::TableEntry *entry) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_table_entry(entry);
     auto status = mgr.write(request);
@@ -218,16 +218,16 @@ class DeviceMgrTest : public ::testing::Test {
   }
 
   DeviceMgr::Status read_table_entries(pi_p4_id_t t_id,
-                                       p4rt::ReadResponse *response) {
-    p4rt::Entity entity;
+                                       p4v1::ReadResponse *response) {
+    p4v1::Entity entity;
     auto table_entry = entity.mutable_table_entry();
     table_entry->set_table_id(t_id);
     return mgr.read_one(entity, response);
   }
 
-  DeviceMgr::Status read_table_entry(p4rt::TableEntry *table_entry,
-                                     p4rt::ReadResponse *response) {
-    p4rt::Entity entity;
+  DeviceMgr::Status read_table_entry(p4v1::TableEntry *table_entry,
+                                     p4v1::ReadResponse *response) {
+    p4v1::Entity entity;
     entity.set_allocated_table_entry(table_entry);
     auto status = mgr.read_one(entity, response);
     entity.release_table_entry();
@@ -237,7 +237,7 @@ class DeviceMgrTest : public ::testing::Test {
   static constexpr const char *input_path =
            TESTDATADIR "/" "unittest.p4info.txt";
   static pi_p4info_t *p4info;
-  static p4config::P4Info p4info_proto;
+  static p4configv1::P4Info p4info_proto;
   static constexpr const char *invalid_p4_id_error_str = "Invalid P4 id";
 
   DummySwitchWrapper wrapper{};
@@ -247,11 +247,11 @@ class DeviceMgrTest : public ::testing::Test {
 };
 
 pi_p4info_t *DeviceMgrTest::p4info = nullptr;
-p4config::P4Info DeviceMgrTest::p4info_proto;
+p4configv1::P4Info DeviceMgrTest::p4info_proto;
 constexpr const char *DeviceMgrTest::invalid_p4_id_error_str;
 
 TEST_F(DeviceMgrTest, ResourceTypeFromId) {
-  using Type = p4config::P4Ids;
+  using Type = p4configv1::P4Ids;
   using pi::proto::util::resource_type_from_id;
   auto a_id = pi_p4info_action_id_from_name(p4info, "actionA");
   ASSERT_EQ(Type::ACTION, resource_type_from_id(a_id));
@@ -272,7 +272,7 @@ TEST_F(DeviceMgrTest, ResourceTypeFromId) {
 }
 
 TEST_F(DeviceMgrTest, PipelineConfigGet) {
-  p4rt::ForwardingPipelineConfig config;
+  p4v1::ForwardingPipelineConfig config;
   auto status = mgr.pipeline_config_get(&config);
   ASSERT_EQ(status.code(), Code::OK);
   EXPECT_TRUE(MessageDifferencer::Equals(p4info_proto, config.p4info()));
@@ -323,8 +323,8 @@ class MatchKeyInput {
     return mk;
   }
 
-  p4rt::FieldMatch get_proto(pi_p4_id_t f_id) const {
-    p4rt::FieldMatch fm;
+  p4v1::FieldMatch get_proto(pi_p4_id_t f_id) const {
+    p4v1::FieldMatch fm;
     fm.set_field_id(f_id);
     switch (type) {
       case Type::EXACT:
@@ -393,17 +393,17 @@ class MatchTableTest
     a_id = pi_p4info_action_id_from_name(p4info, "actionA");
   }
 
-  p4rt::TableEntry generic_make(pi_p4_id_t t_id,
-                                boost::optional<p4rt::FieldMatch> mf,
+  p4v1::TableEntry generic_make(pi_p4_id_t t_id,
+                                boost::optional<p4v1::FieldMatch> mf,
                                 const std::string &param_v,
                                 int priority = 0,
                                 uint64_t controller_metadata = 0);
 
-  DeviceMgr::Status generic_write(p4rt::Update_Type type,
-                                  p4rt::TableEntry *entry);
-  DeviceMgr::Status add_one(p4rt::TableEntry *entry);
-  DeviceMgr::Status remove(p4rt::TableEntry *entry);
-  DeviceMgr::Status modify(p4rt::TableEntry *entry);
+  DeviceMgr::Status generic_write(p4v1::Update_Type type,
+                                  p4v1::TableEntry *entry);
+  DeviceMgr::Status add_one(p4v1::TableEntry *entry);
+  DeviceMgr::Status remove(p4v1::TableEntry *entry);
+  DeviceMgr::Status modify(p4v1::TableEntry *entry);
 
   boost::optional<MatchKeyInput> default_mf() const;
 
@@ -413,8 +413,8 @@ class MatchTableTest
 };
 
 DeviceMgr::Status
-MatchTableTest::generic_write(p4rt::Update_Type type, p4rt::TableEntry *entry) {
-  p4rt::WriteRequest request;
+MatchTableTest::generic_write(p4v1::Update_Type type, p4v1::TableEntry *entry) {
+  p4v1::WriteRequest request;
   auto update = request.add_updates();
   update->set_type(type);
   auto entity = update->mutable_entity();
@@ -425,27 +425,27 @@ MatchTableTest::generic_write(p4rt::Update_Type type, p4rt::TableEntry *entry) {
 }
 
 DeviceMgr::Status
-MatchTableTest::add_one(p4rt::TableEntry *entry) {
-  return generic_write(p4rt::Update_Type_INSERT, entry);
+MatchTableTest::add_one(p4v1::TableEntry *entry) {
+  return generic_write(p4v1::Update_Type_INSERT, entry);
 }
 
 DeviceMgr::Status
-MatchTableTest::remove(p4rt::TableEntry *entry) {
-  return generic_write(p4rt::Update_Type_DELETE, entry);
+MatchTableTest::remove(p4v1::TableEntry *entry) {
+  return generic_write(p4v1::Update_Type_DELETE, entry);
 }
 
 DeviceMgr::Status
-MatchTableTest::modify(p4rt::TableEntry *entry) {
-  return generic_write(p4rt::Update_Type_MODIFY, entry);
+MatchTableTest::modify(p4v1::TableEntry *entry) {
+  return generic_write(p4v1::Update_Type_MODIFY, entry);
 }
 
-p4rt::TableEntry
+p4v1::TableEntry
 MatchTableTest::generic_make(pi_p4_id_t t_id,
-                             boost::optional<p4rt::FieldMatch> mf,
+                             boost::optional<p4v1::FieldMatch> mf,
                              const std::string &param_v,
                              int priority,
                              uint64_t controller_metadata) {
-  p4rt::TableEntry table_entry;
+  p4v1::TableEntry table_entry;
   table_entry.set_table_id(t_id);
   table_entry.set_controller_metadata(controller_metadata);
   table_entry.set_priority(priority);
@@ -508,7 +508,7 @@ TEST_P(MatchTableTest, AddAndRead) {
   // 2 different reads: first one is wildcard read on the table, other filters
   // on the match key.
   {
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     auto status = read_table_entries(t_id, &response);
     ASSERT_EQ(status.code(), Code::OK);
     const auto &entities = response.entities();
@@ -517,7 +517,7 @@ TEST_P(MatchTableTest, AddAndRead) {
         MessageDifferencer::Equals(entry, entities.Get(0).table_entry()));
   }
   {
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     auto status = read_table_entry(&entry, &response);
     ASSERT_EQ(status.code(), Code::OK);
     const auto &entities = response.entities();
@@ -622,8 +622,8 @@ TEST_P(MatchTableTest, InvalidTableId) {
         OneExpectedError(Code::INVALID_ARGUMENT, invalid_p4_id_error_str));
   };
   auto check_bad_status_read = [this](pi_p4_id_t bad_id) {
-    p4rt::ReadResponse response;
-    p4rt::Entity entity;
+    p4v1::ReadResponse response;
+    p4v1::Entity entity;
     auto table_entry = entity.mutable_table_entry();
     table_entry->set_table_id(bad_id);
     auto status = mgr.read_one(entity, &response);
@@ -708,22 +708,22 @@ TEST_P(MatchTableTest, WriteBatchWithError) {
       t_id, mk_input.get_proto(mf_id), adata, mk_input.get_priority());
 
   ExpectedErrors expected_errors;
-  p4rt::WriteRequest request;
+  p4v1::WriteRequest request;
   {
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_DELETE);
+    update->set_type(p4v1::Update_Type_DELETE);
     update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
     expected_errors.push_back(Code::NOT_FOUND);
   }
   {
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
     expected_errors.push_back(Code::OK);
   }
   {
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
     expected_errors.push_back(Code::ALREADY_EXISTS);
   }
@@ -760,7 +760,7 @@ INSTANTIATE_TEST_CASE_P(
 
 class ActionProfTest : public DeviceMgrTest {
  protected:
-  void set_action(p4rt::Action *action, const std::string &param_v) {
+  void set_action(p4v1::Action *action, const std::string &param_v) {
     auto a_id = pi_p4info_action_id_from_name(p4info, "actionA");
     action->set_action_id(a_id);
     auto param = action->add_params();
@@ -769,9 +769,9 @@ class ActionProfTest : public DeviceMgrTest {
     param->set_value(param_v);
   }
 
-  p4rt::ActionProfileMember make_member(uint32_t member_id,
+  p4v1::ActionProfileMember make_member(uint32_t member_id,
                                         const std::string &param_v = "") {
-    p4rt::ActionProfileMember member;
+    p4v1::ActionProfileMember member;
     auto act_prof_id = pi_p4info_act_prof_id_from_name(p4info, "ActProfWS");
     member.set_action_profile_id(act_prof_id);
     member.set_member_id(member_id);
@@ -779,9 +779,9 @@ class ActionProfTest : public DeviceMgrTest {
     return member;
   }
 
-  DeviceMgr::Status write_member(p4rt::Update_Type type,
-                                 p4rt::ActionProfileMember *member) {
-    p4rt::WriteRequest request;
+  DeviceMgr::Status write_member(p4v1::Update_Type type,
+                                 p4v1::ActionProfileMember *member) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
     update->set_type(type);
     auto entity = update->mutable_entity();
@@ -791,28 +791,28 @@ class ActionProfTest : public DeviceMgrTest {
     return status;
   }
 
-  DeviceMgr::Status create_member(p4rt::ActionProfileMember *member) {
-    return write_member(p4rt::Update_Type_INSERT, member);
+  DeviceMgr::Status create_member(p4v1::ActionProfileMember *member) {
+    return write_member(p4v1::Update_Type_INSERT, member);
   }
 
-  DeviceMgr::Status modify_member(p4rt::ActionProfileMember *member) {
-    return write_member(p4rt::Update_Type_MODIFY, member);
+  DeviceMgr::Status modify_member(p4v1::ActionProfileMember *member) {
+    return write_member(p4v1::Update_Type_MODIFY, member);
   }
 
-  DeviceMgr::Status delete_member(p4rt::ActionProfileMember *member) {
-    return write_member(p4rt::Update_Type_DELETE, member);
+  DeviceMgr::Status delete_member(p4v1::ActionProfileMember *member) {
+    return write_member(p4v1::Update_Type_DELETE, member);
   }
 
-  void add_member_to_group(p4rt::ActionProfileGroup *group,
+  void add_member_to_group(p4v1::ActionProfileGroup *group,
                            uint32_t member_id) {
     auto member = group->add_members();
     member->set_member_id(member_id);
   }
 
   template <typename It>
-  p4rt::ActionProfileGroup make_group(uint32_t group_id,
+  p4v1::ActionProfileGroup make_group(uint32_t group_id,
                                       It members_begin, It members_end) {
-    p4rt::ActionProfileGroup group;
+    p4v1::ActionProfileGroup group;
     auto act_prof_id = pi_p4info_act_prof_id_from_name(p4info, "ActProfWS");
     group.set_action_profile_id(act_prof_id);
     group.set_group_id(group_id);
@@ -823,14 +823,14 @@ class ActionProfTest : public DeviceMgrTest {
     return group;
   }
 
-  p4rt::ActionProfileGroup make_group(uint32_t group_id) {
+  p4v1::ActionProfileGroup make_group(uint32_t group_id) {
     std::vector<uint32_t> members;
     return make_group(group_id, members.begin(), members.end());
   }
 
-  DeviceMgr::Status write_group(p4rt::Update_Type type,
-                                p4rt::ActionProfileGroup *group) {
-    p4rt::WriteRequest request;
+  DeviceMgr::Status write_group(p4v1::Update_Type type,
+                                p4v1::ActionProfileGroup *group) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
     update->set_type(type);
     auto entity = update->mutable_entity();
@@ -840,16 +840,16 @@ class ActionProfTest : public DeviceMgrTest {
     return status;
   }
 
-  DeviceMgr::Status create_group(p4rt::ActionProfileGroup *group) {
-    return write_group(p4rt::Update_Type_INSERT, group);
+  DeviceMgr::Status create_group(p4v1::ActionProfileGroup *group) {
+    return write_group(p4v1::Update_Type_INSERT, group);
   }
 
-  DeviceMgr::Status modify_group(p4rt::ActionProfileGroup *group) {
-    return write_group(p4rt::Update_Type_MODIFY, group);
+  DeviceMgr::Status modify_group(p4v1::ActionProfileGroup *group) {
+    return write_group(p4v1::Update_Type_MODIFY, group);
   }
 
-  DeviceMgr::Status delete_group(p4rt::ActionProfileGroup *group) {
-    return write_group(p4rt::Update_Type_DELETE, group);
+  DeviceMgr::Status delete_group(p4v1::ActionProfileGroup *group) {
+    return write_group(p4v1::Update_Type_DELETE, group);
   }
 };
 
@@ -983,8 +983,8 @@ TEST_F(ActionProfTest, Read) {
   ASSERT_EQ(create_group(&group).code(), Code::OK);
 
   EXPECT_CALL(*mock, action_prof_entries_fetch(act_prof_id, _)).Times(2);
-  p4rt::ReadResponse response;
-  p4rt::ReadRequest request;
+  p4v1::ReadResponse response;
+  p4v1::ReadRequest request;
   {
     auto entity = request.add_entities();
     auto member = entity->mutable_action_profile_member();
@@ -1048,8 +1048,8 @@ TEST_F(ActionProfTest, InvalidActionProfId) {
         OneExpectedError(Code::INVALID_ARGUMENT, invalid_p4_id_error_str));
   };
   auto check_bad_status_read = [this](pi_p4_id_t bad_id) {
-    p4rt::ReadResponse response;
-    p4rt::Entity entity;
+    p4v1::ReadResponse response;
+    p4v1::Entity entity;
     auto member = entity.mutable_action_profile_member();
     member->set_action_profile_id(bad_id);
     auto status = mgr.read_one(entity, &response);
@@ -1106,7 +1106,7 @@ TEST_F(ActionProfTest, InvalidActionId) {
 
 class MatchTableIndirectTest : public DeviceMgrTest {
  protected:
-  void set_action(p4rt::Action *action, const std::string &param_v) {
+  void set_action(p4v1::Action *action, const std::string &param_v) {
     auto a_id = pi_p4info_action_id_from_name(p4info, "actionA");
     action->set_action_id(a_id);
     auto param = action->add_params();
@@ -1115,9 +1115,9 @@ class MatchTableIndirectTest : public DeviceMgrTest {
     param->set_value(param_v);
   }
 
-  p4rt::ActionProfileMember make_member(uint32_t member_id,
+  p4v1::ActionProfileMember make_member(uint32_t member_id,
                                         const std::string &param_v = "") {
-    p4rt::ActionProfileMember member;
+    p4v1::ActionProfileMember member;
     auto act_prof_id = pi_p4info_act_prof_id_from_name(p4info, "ActProfWS");
     member.set_action_profile_id(act_prof_id);
     member.set_member_id(member_id);
@@ -1129,9 +1129,9 @@ class MatchTableIndirectTest : public DeviceMgrTest {
     auto act_prof_id = pi_p4info_act_prof_id_from_name(p4info, "ActProfWS");
     EXPECT_CALL(*mock, action_prof_member_create(act_prof_id, _, _));
     auto member = make_member(member_id, param_v);
-    p4rt::WriteRequest request;
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_action_profile_member(&member);
     auto status = mgr.write(request);
@@ -1140,9 +1140,9 @@ class MatchTableIndirectTest : public DeviceMgrTest {
   }
 
   template <typename It>
-  p4rt::ActionProfileGroup make_group(uint32_t group_id,
+  p4v1::ActionProfileGroup make_group(uint32_t group_id,
                                       It members_begin, It members_end) {
-    p4rt::ActionProfileGroup group;
+    p4v1::ActionProfileGroup group;
     auto act_prof_id = pi_p4info_act_prof_id_from_name(p4info, "ActProfWS");
     group.set_action_profile_id(act_prof_id);
     group.set_group_id(group_id);
@@ -1161,9 +1161,9 @@ class MatchTableIndirectTest : public DeviceMgrTest {
     EXPECT_CALL(*mock, action_prof_group_add_member(act_prof_id, _, _))
         .Times(std::distance(members_begin, members_end));
     auto group = make_group(group_id, members_begin, members_end);
-    p4rt::WriteRequest request;
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_action_profile_group(&group);
     auto status = mgr.write(request);
@@ -1175,20 +1175,20 @@ class MatchTableIndirectTest : public DeviceMgrTest {
     create_group(group_id, &member_id, (&member_id) + 1);
   }
 
-  p4rt::TableEntry make_indirect_entry_to_member(const std::string &mf_v,
+  p4v1::TableEntry make_indirect_entry_to_member(const std::string &mf_v,
                                                  uint32_t member_id) {
     return make_indirect_entry_common(mf_v, member_id, false);
   }
 
-  p4rt::TableEntry make_indirect_entry_to_group(const std::string &mf_v,
+  p4v1::TableEntry make_indirect_entry_to_group(const std::string &mf_v,
                                                 uint32_t group_id) {
     return make_indirect_entry_common(mf_v, group_id, true);
   }
 
-  DeviceMgr::Status add_indirect_entry(p4rt::TableEntry *entry) {
-    p4rt::WriteRequest request;
+  DeviceMgr::Status add_indirect_entry(p4v1::TableEntry *entry) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_table_entry(entry);
     auto status = mgr.write(request);
@@ -1197,10 +1197,10 @@ class MatchTableIndirectTest : public DeviceMgrTest {
   }
 
  private:
-  p4rt::TableEntry make_indirect_entry_common(const std::string &mf_v,
+  p4v1::TableEntry make_indirect_entry_common(const std::string &mf_v,
                                               uint32_t indirect_id,
                                               bool is_group) {
-    p4rt::TableEntry table_entry;
+    p4v1::TableEntry table_entry;
     auto t_id = pi_p4info_table_id_from_name(p4info, "IndirectWS");
     table_entry.set_table_id(t_id);
     auto mf = table_entry.add_match();
@@ -1232,8 +1232,8 @@ TEST_F(MatchTableIndirectTest, Member) {
   ASSERT_EQ(status.code(), Code::OK);
 
   EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
-  p4rt::ReadResponse response;
-  p4rt::Entity entity;
+  p4v1::ReadResponse response;
+  p4v1::Entity entity;
   auto table_entry = entity.mutable_table_entry();
   table_entry->set_table_id(t_id);
   status = mgr.read_one(entity, &response);
@@ -1260,8 +1260,8 @@ TEST_F(MatchTableIndirectTest, Group) {
   ASSERT_EQ(status.code(), Code::OK);
 
   EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
-  p4rt::ReadResponse response;
-  p4rt::Entity entity;
+  p4v1::ReadResponse response;
+  p4v1::Entity entity;
   auto table_entry = entity.mutable_table_entry();
   table_entry->set_table_id(t_id);
   status = mgr.read_one(entity, &response);
@@ -1283,9 +1283,9 @@ class ExactOneTest : public DeviceMgrTest {
   ExactOneTest()
       : ExactOneTest("ExactOne", "header_test.field32") { }
 
-  p4rt::TableEntry make_entry(const std::string &mf_v,
+  p4v1::TableEntry make_entry(const std::string &mf_v,
                               const std::string &param_v) {
-    p4rt::TableEntry table_entry;
+    p4v1::TableEntry table_entry;
     table_entry.set_table_id(t_id);
     auto mf = table_entry.add_match();
     mf->set_field_id(pi_p4info_table_match_field_id_from_name(
@@ -1326,10 +1326,10 @@ class DirectMeterTest : public ExactOneTest {
     m_id = pi_p4info_meter_id_from_name(p4info, "ExactOne_meter");
   }
 
-  DeviceMgr::Status set_meter(p4rt::DirectMeterEntry *direct_meter_entry) {
-    p4rt::WriteRequest request;
+  DeviceMgr::Status set_meter(p4v1::DirectMeterEntry *direct_meter_entry) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_MODIFY);
+    update->set_type(p4v1::Update_Type_MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_direct_meter_entry(direct_meter_entry);
     auto status = mgr.write(request);
@@ -1337,16 +1337,16 @@ class DirectMeterTest : public ExactOneTest {
     return status;
   }
 
-  p4rt::DirectMeterEntry make_meter_entry(const p4rt::TableEntry &entry,
-                                          const p4rt::MeterConfig &config) {
-    p4rt::DirectMeterEntry direct_meter_entry;
+  p4v1::DirectMeterEntry make_meter_entry(const p4v1::TableEntry &entry,
+                                          const p4v1::MeterConfig &config) {
+    p4v1::DirectMeterEntry direct_meter_entry;
     direct_meter_entry.mutable_table_entry()->CopyFrom(entry);
     direct_meter_entry.mutable_config()->CopyFrom(config);
     return direct_meter_entry;
   }
 
-  p4rt::MeterConfig make_meter_config() const {
-    p4rt::MeterConfig config;
+  p4v1::MeterConfig make_meter_config() const {
+    p4v1::MeterConfig config;
     config.set_cir(10);
     config.set_cburst(5);
     config.set_pir(100);
@@ -1354,9 +1354,9 @@ class DirectMeterTest : public ExactOneTest {
     return config;
   }
 
-  DeviceMgr::Status read_meter(p4rt::DirectMeterEntry *direct_meter_entry,
-                               p4rt::ReadResponse *response) {
-    p4rt::ReadRequest request;
+  DeviceMgr::Status read_meter(p4v1::DirectMeterEntry *direct_meter_entry,
+                               p4v1::ReadResponse *response) {
+    p4v1::ReadRequest request;
     auto entity = request.add_entities();
     entity->set_allocated_direct_meter_entry(direct_meter_entry);
     auto status = mgr.read(request, response);
@@ -1394,7 +1394,7 @@ TEST_F(DirectMeterTest, WriteAndRead) {
   // read with DirectMeterEntry
   EXPECT_CALL(*mock, meter_read_direct(m_id, entry_h, _));
   {
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     auto status = read_meter(&meter_entry, &response);
     ASSERT_EQ(status.code(), Code::OK);
     const auto &entities = response.entities();
@@ -1406,8 +1406,8 @@ TEST_F(DirectMeterTest, WriteAndRead) {
   // read with TableEntry
   EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
   {
-    p4rt::ReadResponse response;
-    p4rt::Entity entity;
+    p4v1::ReadResponse response;
+    p4v1::Entity entity;
     auto table_entry = entity.mutable_table_entry();
     table_entry->set_table_id(t_id);
     table_entry->mutable_meter_config();
@@ -1461,7 +1461,7 @@ TEST_F(DirectMeterTest, InvalidTableEntry) {
 }
 
 TEST_F(DirectMeterTest, MissingTableEntry) {
-  p4rt::DirectMeterEntry meter_entry;
+  p4v1::DirectMeterEntry meter_entry;
   auto status = set_meter(&meter_entry);
   EXPECT_EQ(status, OneExpectedError(Code::INVALID_ARGUMENT));
 }
@@ -1473,9 +1473,9 @@ class IndirectMeterTest : public DeviceMgrTest  {
     m_size = pi_p4info_meter_get_size(p4info, m_id);
   }
 
-  DeviceMgr::Status read_meter(p4rt::MeterEntry *meter_entry,
-                               p4rt::ReadResponse *response) {
-    p4rt::ReadRequest request;
+  DeviceMgr::Status read_meter(p4v1::MeterEntry *meter_entry,
+                               p4v1::ReadResponse *response) {
+    p4v1::ReadRequest request;
     auto entity = request.add_entities();
     entity->set_allocated_meter_entry(meter_entry);
     auto status = mgr.read(request, response);
@@ -1483,10 +1483,10 @@ class IndirectMeterTest : public DeviceMgrTest  {
     return status;
   }
 
-  DeviceMgr::Status write_meter(p4rt::MeterEntry *meter_entry) {
-    p4rt::WriteRequest request;
+  DeviceMgr::Status write_meter(p4v1::MeterEntry *meter_entry) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_MODIFY);
+    update->set_type(p4v1::Update_Type_MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_meter_entry(meter_entry);
     auto status = mgr.write(request);
@@ -1494,8 +1494,8 @@ class IndirectMeterTest : public DeviceMgrTest  {
     return status;
   }
 
-  p4rt::MeterConfig make_meter_config() const {
-    p4rt::MeterConfig config;
+  p4v1::MeterConfig make_meter_config() const {
+    p4v1::MeterConfig config;
     config.set_cir(10);
     config.set_cburst(5);
     config.set_pir(100);
@@ -1503,7 +1503,7 @@ class IndirectMeterTest : public DeviceMgrTest  {
     return config;
   }
 
-  void set_index(p4rt::MeterEntry *meter_entry, int index) const {
+  void set_index(p4v1::MeterEntry *meter_entry, int index) const {
     auto *index_msg = meter_entry->mutable_index();
     index_msg->set_index(index);
   }
@@ -1514,8 +1514,8 @@ class IndirectMeterTest : public DeviceMgrTest  {
 
 TEST_F(IndirectMeterTest, WriteAndRead) {
   int index = 66;
-  p4rt::ReadResponse response;
-  p4rt::MeterEntry meter_entry;
+  p4v1::ReadResponse response;
+  p4v1::MeterEntry meter_entry;
   meter_entry.set_meter_id(m_id);
   set_index(&meter_entry, index);
   auto meter_config = make_meter_config();
@@ -1548,9 +1548,9 @@ class DirectCounterTest : public ExactOneTest {
   }
 
   // sends a read request for a DirectCounterEntry; returns the RPC status
-  DeviceMgr::Status read_counter(p4rt::DirectCounterEntry *direct_counter_entry,
-                                 p4rt::ReadResponse *response) {
-    p4rt::ReadRequest request;
+  DeviceMgr::Status read_counter(p4v1::DirectCounterEntry *direct_counter_entry,
+                                 p4v1::ReadResponse *response) {
+    p4v1::ReadRequest request;
     auto entity = request.add_entities();
     entity->set_allocated_direct_counter_entry(direct_counter_entry);
     auto status = mgr.read(request, response);
@@ -1559,10 +1559,10 @@ class DirectCounterTest : public ExactOneTest {
   }
 
   DeviceMgr::Status write_counter(
-      p4rt::DirectCounterEntry *direct_counter_entry) {
-    p4rt::WriteRequest request;
+      p4v1::DirectCounterEntry *direct_counter_entry) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_MODIFY);
+    update->set_type(p4v1::Update_Type_MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_direct_counter_entry(direct_counter_entry);
     auto status = mgr.write(request);
@@ -1570,8 +1570,8 @@ class DirectCounterTest : public ExactOneTest {
     return status;
   }
 
-  p4rt::DirectCounterEntry make_counter_entry(const p4rt::TableEntry *entry) {
-    p4rt::DirectCounterEntry direct_counter_entry;
+  p4v1::DirectCounterEntry make_counter_entry(const p4v1::TableEntry *entry) {
+    p4v1::DirectCounterEntry direct_counter_entry;
     if (entry) direct_counter_entry.mutable_table_entry()->CopyFrom(*entry);
     return direct_counter_entry;
   }
@@ -1606,7 +1606,7 @@ TEST_F(DirectCounterTest, WriteAndRead) {
   // read with DirectCounterEntry
   EXPECT_CALL(*mock, counter_read_direct(c_id, entry_h, _, _));
   {
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     auto status = read_counter(&counter_entry, &response);
     ASSERT_EQ(status.code(), Code::OK);
     const auto &entities = response.entities();
@@ -1620,8 +1620,8 @@ TEST_F(DirectCounterTest, WriteAndRead) {
   // read with TableEntry
   EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
   {
-    p4rt::ReadResponse response;
-    p4rt::Entity entity;
+    p4v1::ReadResponse response;
+    p4v1::Entity entity;
     auto table_entry = entity.mutable_table_entry();
     table_entry->set_table_id(t_id);
     table_entry->mutable_counter_data();
@@ -1652,7 +1652,7 @@ TEST_F(DirectCounterTest, InvalidTableEntry) {
   auto entry_1 = make_entry(mf_1, adata);
   auto counter_entry = make_counter_entry(&entry_1);
   {
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     auto status = read_counter(&counter_entry, &response);
     ASSERT_EQ(status.code(), Code::INVALID_ARGUMENT);
   }
@@ -1671,24 +1671,24 @@ TEST_F(DirectCounterTest, ReadAllFromTable) {
     ASSERT_EQ(status.code(), Code::OK);
   }
 
-  p4rt::ReadResponse response;
-  p4rt::DirectCounterEntry counter_entry;
+  p4v1::ReadResponse response;
+  p4v1::DirectCounterEntry counter_entry;
   counter_entry.mutable_table_entry()->set_table_id(entry.table_id());
   auto status = read_counter(&counter_entry, &response);
   ASSERT_EQ(status.code(), Code::UNIMPLEMENTED);
 }
 
 TEST_F(DirectCounterTest, MissingTableEntry) {
-  p4rt::ReadResponse response;
-  p4rt::DirectCounterEntry counter_entry;
+  p4v1::ReadResponse response;
+  p4v1::DirectCounterEntry counter_entry;
   auto status = read_counter(&counter_entry, &response);
   EXPECT_EQ(status.code(), Code::INVALID_ARGUMENT);
 }
 
 // TODO(antonin)
 TEST_F(DirectCounterTest, ReadAll) {
-  p4rt::ReadResponse response;
-  p4rt::DirectCounterEntry counter_entry;
+  p4v1::ReadResponse response;
+  p4v1::DirectCounterEntry counter_entry;
   counter_entry.mutable_table_entry();
   auto status = read_counter(&counter_entry, &response);
   ASSERT_EQ(status.code(), Code::UNIMPLEMENTED);
@@ -1720,9 +1720,9 @@ class IndirectCounterTest : public DeviceMgrTest  {
   }
 
   // sends a read request for a CounterEntry; returns the RPC status
-  DeviceMgr::Status read_counter(p4rt::CounterEntry *counter_entry,
-                                 p4rt::ReadResponse *response) {
-    p4rt::ReadRequest request;
+  DeviceMgr::Status read_counter(p4v1::CounterEntry *counter_entry,
+                                 p4v1::ReadResponse *response) {
+    p4v1::ReadRequest request;
     auto entity = request.add_entities();
     entity->set_allocated_counter_entry(counter_entry);
     auto status = mgr.read(request, response);
@@ -1730,10 +1730,10 @@ class IndirectCounterTest : public DeviceMgrTest  {
     return status;
   }
 
-  DeviceMgr::Status write_counter(p4rt::CounterEntry *counter_entry) {
-    p4rt::WriteRequest request;
+  DeviceMgr::Status write_counter(p4v1::CounterEntry *counter_entry) {
+    p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4rt::Update_Type_MODIFY);
+    update->set_type(p4v1::Update_Type_MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_counter_entry(counter_entry);
     auto status = mgr.write(request);
@@ -1741,7 +1741,7 @@ class IndirectCounterTest : public DeviceMgrTest  {
     return status;
   }
 
-  void set_index(p4rt::CounterEntry *counter_entry, int index) const {
+  void set_index(p4v1::CounterEntry *counter_entry, int index) const {
     auto *index_msg = counter_entry->mutable_index();
     index_msg->set_index(index);
   }
@@ -1752,8 +1752,8 @@ class IndirectCounterTest : public DeviceMgrTest  {
 
 TEST_F(IndirectCounterTest, WriteAndRead) {
   int index = 66;
-  p4rt::ReadResponse response;
-  p4rt::CounterEntry counter_entry;
+  p4v1::ReadResponse response;
+  p4v1::CounterEntry counter_entry;
   counter_entry.set_counter_id(c_id);
   set_index(&counter_entry, index);
   auto *counter_data = counter_entry.mutable_data();
@@ -1780,8 +1780,8 @@ TEST_F(IndirectCounterTest, WriteAndRead) {
 }
 
 TEST_F(IndirectCounterTest, ReadAll) {
-  p4rt::ReadResponse response;
-  p4rt::CounterEntry counter_entry;
+  p4v1::ReadResponse response;
+  p4v1::CounterEntry counter_entry;
   counter_entry.set_counter_id(c_id);
 
   // TODO(antonin): match index?
@@ -1810,8 +1810,8 @@ class MatchKeyFormatTest : public ExactOneTest {
   MatchKeyFormatTest()
       : ExactOneTest("ExactOneNonAligned", "header_test.field12") { }
 
-  p4rt::TableEntry make_entry_no_mk() {
-    p4rt::TableEntry table_entry;
+  p4v1::TableEntry make_entry_no_mk() {
+    p4v1::TableEntry table_entry;
     table_entry.set_table_id(t_id);
     auto entry = table_entry.mutable_action();
     auto action = entry->mutable_action();
@@ -1825,7 +1825,7 @@ class MatchKeyFormatTest : public ExactOneTest {
     return table_entry;
   }
 
-  void add_one_mf(p4rt::TableEntry *entry, const std::string &mf_v) {
+  void add_one_mf(p4v1::TableEntry *entry, const std::string &mf_v) {
     auto mf = entry->add_match();
     mf->set_field_id(pi_p4info_table_match_field_id_from_name(
         p4info, t_id, "header_test.field12"));
@@ -1911,10 +1911,10 @@ class TernaryOneTest : public DeviceMgrTest {
   TernaryOneTest()
       : TernaryOneTest("TernaryOne", "header_test.field32") { }
 
-  p4rt::TableEntry make_entry(const boost::optional<std::string> &mf_v,
+  p4v1::TableEntry make_entry(const boost::optional<std::string> &mf_v,
                               const boost::optional<std::string> &mask_v,
                               const std::string &param_v) {
-    p4rt::TableEntry table_entry;
+    p4v1::TableEntry table_entry;
     table_entry.set_table_id(t_id);
     // not supported by older versions of boost
     // if (mf_v != boost::none) {
@@ -1970,7 +1970,7 @@ TEST_F(TernaryOneTest, DontCare) {
     auto status = add_entry(&entry);
     ASSERT_EQ(status.code(), Code::OK);
 
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     {
       EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
       auto status = read_table_entries(t_id, &response);
@@ -1999,10 +1999,10 @@ class RangeOneTest : public DeviceMgrTest {
   RangeOneTest()
       : RangeOneTest("RangeOne", "header_test.field32") { }
 
-  p4rt::TableEntry make_entry(const boost::optional<std::string> &low_v,
+  p4v1::TableEntry make_entry(const boost::optional<std::string> &low_v,
                             const boost::optional<std::string> &high_v,
                             const std::string &param_v) {
-    p4rt::TableEntry table_entry;
+    p4v1::TableEntry table_entry;
     table_entry.set_table_id(t_id);
     // not supported by older versions of boost
     // if (low_v != boost::none) {
@@ -2066,7 +2066,7 @@ TEST_F(RangeOneTest, DontCare) {
     auto status = add_entry(&entry);
     ASSERT_EQ(status.code(), Code::OK);
 
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     {
       EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
       auto status = read_table_entries(t_id, &response);
@@ -2095,10 +2095,10 @@ class LpmOneTest : public DeviceMgrTest {
   LpmOneTest()
       : LpmOneTest("LpmOne", "header_test.field32") { }
 
-  p4rt::TableEntry make_entry(const boost::optional<std::string> &mf_v,
+  p4v1::TableEntry make_entry(const boost::optional<std::string> &mf_v,
                               int pLen,
                               const std::string &param_v) {
-    p4rt::TableEntry table_entry;
+    p4v1::TableEntry table_entry;
     table_entry.set_table_id(t_id);
     // not supported by older versions of boost
     // if (mf_v != boost::none) {
@@ -2168,7 +2168,7 @@ TEST_F(LpmOneTest, DontCare) {
     auto status = add_entry(&entry);
     ASSERT_EQ(status.code(), Code::OK);
 
-    p4rt::ReadResponse response;
+    p4v1::ReadResponse response;
     {
       EXPECT_CALL(*mock, table_entries_fetch(t_id, _));
       auto status = read_table_entries(t_id, &response);
@@ -2194,12 +2194,12 @@ class TernaryTwoTest : public DeviceMgrTest {
     a_id = pi_p4info_action_id_from_name(p4info, "actionA");
   }
 
-  p4rt::TableEntry make_entry(const std::string &mf1_v,
+  p4v1::TableEntry make_entry(const std::string &mf1_v,
                               const std::string &mask1_v,
                               const std::string &mf2_v,
                               const std::string &mask2_v,
                               const std::string &param_v) {
-    p4rt::TableEntry table_entry;
+    p4v1::TableEntry table_entry;
     table_entry.set_table_id(t_id);
     if (!mf1_v.empty()) {
       auto mf = table_entry.add_match();
@@ -2265,9 +2265,9 @@ TEST_F(TernaryTwoTest, MissingMatchField) {
 class PRETest : public DeviceMgrTest { };
 
 TEST_F(PRETest, Write) {
-  p4rt::WriteRequest request;
+  p4v1::WriteRequest request;
   auto *update = request.add_updates();
-  update->set_type(p4rt::Update_Type_MODIFY);
+  update->set_type(p4v1::Update_Type_MODIFY);
   auto *entity = update->mutable_entity();
   auto *pre_entry = entity->mutable_packet_replication_engine_entry();
   auto *mg_entry = pre_entry->mutable_multicast_group_entry();
@@ -2281,8 +2281,8 @@ TEST_F(PRETest, Write) {
 }
 
 TEST_F(PRETest, Read) {
-  p4rt::ReadRequest request;
-  p4rt::ReadResponse response;
+  p4v1::ReadRequest request;
+  p4v1::ReadResponse response;
   auto *entity = request.add_entities();
   // set oneof to PRE
   auto *pre_entry = entity->mutable_packet_replication_engine_entry();
@@ -2311,7 +2311,7 @@ class ReadConstTableTest : public DeviceMgrTest {
 
   pi_p4_id_t t_id;
   pi_p4_id_t a_id;
-  p4rt::WriteRequest const_entries_request;
+  p4v1::WriteRequest const_entries_request;
 };
 
 // This test is not representative of what bmv2 does. In bmv2 const entries are
@@ -2327,7 +2327,7 @@ TEST_F(ReadConstTableTest, P4RuntimeEntries) {
   }
 
   EXPECT_CALL(*mock, table_entries_fetch(t_id, _)).Times(AnyNumber());
-  p4rt::ReadResponse response;
+  p4v1::ReadResponse response;
   auto status = read_table_entries(t_id, &response);
   EXPECT_EQ(status.code(), Code::OK);
 }
@@ -2365,7 +2365,7 @@ TEST_F(ReadConstTableTest, OutOfBandEntries) {
   }
 
   EXPECT_CALL(*mock, table_entries_fetch(t_id, _)).Times(AnyNumber());
-  p4rt::ReadResponse response;
+  p4v1::ReadResponse response;
   auto status = read_table_entries(t_id, &response);
   EXPECT_EQ(status.code(), Code::OK);
 }
@@ -2376,9 +2376,9 @@ TEST_F(ReadConstTableTest, OutOfBandEntries) {
 class PVSTest : public DeviceMgrTest { };
 
 TEST_F(PVSTest, Write) {
-  p4rt::WriteRequest request;
+  p4v1::WriteRequest request;
   auto *update = request.add_updates();
-  update->set_type(p4rt::Update_Type_MODIFY);
+  update->set_type(p4v1::Update_Type_MODIFY);
   auto *entity = update->mutable_entity();
   auto *pvs_entry = entity->mutable_value_set_entry();
   (void) pvs_entry;
@@ -2387,8 +2387,8 @@ TEST_F(PVSTest, Write) {
 }
 
 TEST_F(PVSTest, Read) {
-  p4rt::ReadRequest request;
-  p4rt::ReadResponse response;
+  p4v1::ReadRequest request;
+  p4v1::ReadResponse response;
   auto *entity = request.add_entities();
   // set oneof to PVS
   auto *pvs_entry = entity->mutable_value_set_entry();
@@ -2401,9 +2401,9 @@ TEST_F(PVSTest, Read) {
 class RegisterTest : public DeviceMgrTest { };
 
 TEST_F(RegisterTest, Write) {
-  p4rt::WriteRequest request;
+  p4v1::WriteRequest request;
   auto *update = request.add_updates();
-  update->set_type(p4rt::Update_Type_MODIFY);
+  update->set_type(p4v1::Update_Type_MODIFY);
   auto *entity = update->mutable_entity();
   auto *register_entry = entity->mutable_register_entry();
   (void) register_entry;
@@ -2412,8 +2412,8 @@ TEST_F(RegisterTest, Write) {
 }
 
 TEST_F(RegisterTest, Read) {
-  p4rt::ReadRequest request;
-  p4rt::ReadResponse response;
+  p4v1::ReadRequest request;
+  p4v1::ReadResponse response;
   auto *entity = request.add_entities();
   auto *register_entry = entity->mutable_register_entry();
   (void) register_entry;
@@ -2425,9 +2425,9 @@ TEST_F(RegisterTest, Read) {
 class DigestTest : public DeviceMgrTest { };
 
 TEST_F(DigestTest, Write) {
-  p4rt::WriteRequest request;
+  p4v1::WriteRequest request;
   auto *update = request.add_updates();
-  update->set_type(p4rt::Update_Type_MODIFY);
+  update->set_type(p4v1::Update_Type_MODIFY);
   auto *entity = update->mutable_entity();
   auto *register_entry = entity->mutable_register_entry();
   (void) register_entry;
@@ -2436,8 +2436,8 @@ TEST_F(DigestTest, Write) {
 }
 
 TEST_F(DigestTest, Read) {
-  p4rt::ReadRequest request;
-  p4rt::ReadResponse response;
+  p4v1::ReadRequest request;
+  p4v1::ReadResponse response;
   auto *entity = request.add_entities();
   auto *register_entry = entity->mutable_register_entry();
   (void) register_entry;
@@ -2483,32 +2483,32 @@ TEST_F(ReadExclusiveAccess, ConcurrentReadAndWrites) {
     auto member = make_member(member_id, adata);
     auto entry = make_indirect_entry_to_member(mf, member_id);
 
-    std::vector<p4rt::WriteRequest> requests(4);
+    std::vector<p4v1::WriteRequest> requests(4);
     {
       auto &request = requests.at(0);
       auto *update = request.add_updates();
-      update->set_type(p4rt::Update_Type_INSERT);
+      update->set_type(p4v1::Update_Type_INSERT);
       auto *entity = update->mutable_entity();
       entity->mutable_action_profile_member()->CopyFrom(member);
     }
     {
       auto &request = requests.at(1);
       auto *update = request.add_updates();
-      update->set_type(p4rt::Update_Type_INSERT);
+      update->set_type(p4v1::Update_Type_INSERT);
       auto *entity = update->mutable_entity();
       entity->mutable_table_entry()->CopyFrom(entry);
     }
     {
       auto &request = requests.at(2);
       auto *update = request.add_updates();
-      update->set_type(p4rt::Update_Type_DELETE);
+      update->set_type(p4v1::Update_Type_DELETE);
       auto *entity = update->mutable_entity();
       entity->mutable_table_entry()->CopyFrom(entry);
     }
     {
       auto &request = requests.at(3);
       auto *update = request.add_updates();
-      update->set_type(p4rt::Update_Type_DELETE);
+      update->set_type(p4v1::Update_Type_DELETE);
       auto *entity = update->mutable_entity();
       entity->mutable_action_profile_member()->CopyFrom(member);
     }
@@ -2527,7 +2527,7 @@ TEST_F(ReadExclusiveAccess, ConcurrentReadAndWrites) {
     EXPECT_CALL(*mock, table_entries_fetch(t_id, _)).Times(AtLeast(1));
     EXPECT_CALL(*mock, action_prof_entries_fetch(act_prof_id, _))
         .Times(AtLeast(1));
-    p4rt::ReadRequest request;
+    p4v1::ReadRequest request;
     {
       auto *entity = request.add_entities();
       auto *entry = entity->mutable_table_entry();
@@ -2539,7 +2539,7 @@ TEST_F(ReadExclusiveAccess, ConcurrentReadAndWrites) {
       member->set_action_profile_id(act_prof_id);
     }
     while (!stop) {
-      p4rt::ReadResponse response;
+      p4v1::ReadResponse response;
       auto status = mgr.read(request, &response);
       ASSERT_EQ(status.code(), Code::OK);
       const auto num_objects = response.entities_size();

--- a/proto/tests/test_proto_fe_packet_io.cpp
+++ b/proto/tests/test_proto_fe_packet_io.cpp
@@ -31,6 +31,9 @@
 
 #include "mock_switch.h"
 
+namespace p4rt = ::p4::v1;
+namespace p4config = ::p4::config::v1;
+
 namespace pi {
 namespace proto {
 namespace testing {
@@ -58,10 +61,10 @@ class DeviceMgrPacketIOTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    p4::ForwardingPipelineConfig config;
+    p4rt::ForwardingPipelineConfig config;
     config.set_allocated_p4info(&p4info_proto);
     auto status = mgr.pipeline_config_set(
-        p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
+        p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
         config);
     // releasing resource before the assert to avoid double free in case the
     // assert is false
@@ -71,7 +74,7 @@ class DeviceMgrPacketIOTest : public ::testing::Test {
 
   void TearDown() override { }
 
-  p4::config::P4Info p4info_proto;
+  p4config::P4Info p4info_proto;
 
   DummySwitchWrapper wrapper{};
   DummySwitchMock *mock;
@@ -83,9 +86,9 @@ class DeviceMgrPacketIOTest : public ::testing::Test {
 class DeviceMgrPacketIORegTest : public DeviceMgrPacketIOTest { };
 
 TEST_F(DeviceMgrPacketIORegTest, PacketIn) {
-  p4::PacketIn packet_in;
+  p4rt::PacketIn packet_in;
   bool received = false;
-  auto cb_fn = [&packet_in, &received](device_id_t, p4::PacketIn *p, void *) {
+  auto cb_fn = [&packet_in, &received](device_id_t, p4rt::PacketIn *p, void *) {
     packet_in.CopyFrom(*p);
     received = true;
   };
@@ -99,7 +102,7 @@ TEST_F(DeviceMgrPacketIORegTest, PacketIn) {
 }
 
 TEST_F(DeviceMgrPacketIORegTest, PacketOut) {
-  p4::PacketOut packet_out;
+  p4rt::PacketOut packet_out;
   std::string payload(10, '\xab');
   packet_out.set_payload(payload);
   EXPECT_CALL(*mock, packetout_send(StrEq(payload.c_str()), payload.size()));
@@ -215,7 +218,7 @@ class DeviceMgrPacketIOMetadataTest : public DeviceMgrPacketIOTest {
 
  protected:
   DeviceMgrPacketIOMetadataTest() {
-    p4::config::ControllerPacketMetadata header;
+    p4config::ControllerPacketMetadata header;
     uint32_t id = 1;
     for (auto bw : bitwidths) {
       auto metadata = header.add_metadata();
@@ -281,9 +284,9 @@ TEST_F(DeviceMgrPacketIOMetadataTest, PacketIn) {
   std::string payload(10, '\xab');
   ValueIterator<VType> values(bitwidths, steps);
   std::vector<std::string> binary_strs(num);
-  p4::PacketIn packet_in;
+  p4rt::PacketIn packet_in;
   bool received;
-  auto cb_fn = [&packet_in, &received](device_id_t, p4::PacketIn *p, void *) {
+  auto cb_fn = [&packet_in, &received](device_id_t, p4rt::PacketIn *p, void *) {
     packet_in.CopyFrom(*p);
     received = true;
   };
@@ -311,7 +314,7 @@ TEST_F(DeviceMgrPacketIOMetadataTest, PacketOut) {
   ValueIterator<VType> values(bitwidths, steps);
   std::vector<std::string> binary_strs(num);
   for (const auto &v : values) {
-    p4::PacketOut packet_out;
+    p4rt::PacketOut packet_out;
     packet_out.set_payload(payload);
     BitPattern pattern;
     for (uint32_t id = 0; id < num; id++) {

--- a/proto/tests/test_proto_fe_packet_io.cpp
+++ b/proto/tests/test_proto_fe_packet_io.cpp
@@ -31,8 +31,8 @@
 
 #include "mock_switch.h"
 
-namespace p4rt = ::p4::v1;
-namespace p4config = ::p4::config::v1;
+namespace p4v1 = ::p4::v1;
+namespace p4configv1 = ::p4::config::v1;
 
 namespace pi {
 namespace proto {
@@ -61,10 +61,10 @@ class DeviceMgrPacketIOTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    p4rt::ForwardingPipelineConfig config;
+    p4v1::ForwardingPipelineConfig config;
     config.set_allocated_p4info(&p4info_proto);
     auto status = mgr.pipeline_config_set(
-        p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
+        p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
         config);
     // releasing resource before the assert to avoid double free in case the
     // assert is false
@@ -74,7 +74,7 @@ class DeviceMgrPacketIOTest : public ::testing::Test {
 
   void TearDown() override { }
 
-  p4config::P4Info p4info_proto;
+  p4configv1::P4Info p4info_proto;
 
   DummySwitchWrapper wrapper{};
   DummySwitchMock *mock;
@@ -86,9 +86,9 @@ class DeviceMgrPacketIOTest : public ::testing::Test {
 class DeviceMgrPacketIORegTest : public DeviceMgrPacketIOTest { };
 
 TEST_F(DeviceMgrPacketIORegTest, PacketIn) {
-  p4rt::PacketIn packet_in;
+  p4v1::PacketIn packet_in;
   bool received = false;
-  auto cb_fn = [&packet_in, &received](device_id_t, p4rt::PacketIn *p, void *) {
+  auto cb_fn = [&packet_in, &received](device_id_t, p4v1::PacketIn *p, void *) {
     packet_in.CopyFrom(*p);
     received = true;
   };
@@ -102,7 +102,7 @@ TEST_F(DeviceMgrPacketIORegTest, PacketIn) {
 }
 
 TEST_F(DeviceMgrPacketIORegTest, PacketOut) {
-  p4rt::PacketOut packet_out;
+  p4v1::PacketOut packet_out;
   std::string payload(10, '\xab');
   packet_out.set_payload(payload);
   EXPECT_CALL(*mock, packetout_send(StrEq(payload.c_str()), payload.size()));
@@ -218,7 +218,7 @@ class DeviceMgrPacketIOMetadataTest : public DeviceMgrPacketIOTest {
 
  protected:
   DeviceMgrPacketIOMetadataTest() {
-    p4config::ControllerPacketMetadata header;
+    p4configv1::ControllerPacketMetadata header;
     uint32_t id = 1;
     for (auto bw : bitwidths) {
       auto metadata = header.add_metadata();
@@ -284,9 +284,9 @@ TEST_F(DeviceMgrPacketIOMetadataTest, PacketIn) {
   std::string payload(10, '\xab');
   ValueIterator<VType> values(bitwidths, steps);
   std::vector<std::string> binary_strs(num);
-  p4rt::PacketIn packet_in;
+  p4v1::PacketIn packet_in;
   bool received;
-  auto cb_fn = [&packet_in, &received](device_id_t, p4rt::PacketIn *p, void *) {
+  auto cb_fn = [&packet_in, &received](device_id_t, p4v1::PacketIn *p, void *) {
     packet_in.CopyFrom(*p);
     received = true;
   };
@@ -314,7 +314,7 @@ TEST_F(DeviceMgrPacketIOMetadataTest, PacketOut) {
   ValueIterator<VType> values(bitwidths, steps);
   std::vector<std::string> binary_strs(num);
   for (const auto &v : values) {
-    p4rt::PacketOut packet_out;
+    p4v1::PacketOut packet_out;
     packet_out.set_payload(payload);
     BitPattern pattern;
     for (uint32_t id = 0; id < num; id++) {

--- a/proto/tests/test_proto_fe_set_pipeline_config.cpp
+++ b/proto/tests/test_proto_fe_set_pipeline_config.cpp
@@ -38,6 +38,9 @@
 #include "matchers.h"
 #include "mock_switch.h"
 
+namespace p4rt = ::p4::v1;
+namespace p4config = ::p4::config::v1;
+
 namespace pi {
 namespace proto {
 namespace testing {
@@ -62,8 +65,8 @@ class DeviceMgrSetPipelineConfigTest : public ::testing::Test {
     DeviceMgr::destroy();
   }
 
-  p4::config::P4Info read_p4info(const std::string &p4info_path) {
-    p4::config::P4Info p4info_proto;
+  p4config::P4Info read_p4info(const std::string &p4info_path) {
+    p4config::P4Info p4info_proto;
     std::ifstream istream(p4info_path);
     google::protobuf::io::IstreamInputStream istream_(&istream);
     google::protobuf::TextFormat::Parse(&istream_, &p4info_proto);
@@ -71,19 +74,19 @@ class DeviceMgrSetPipelineConfigTest : public ::testing::Test {
   }
 
   DeviceMgr::Status set_pipeline_config(
-      p4::config::P4Info *p4info_proto,
-      p4::SetForwardingPipelineConfigRequest_Action action) {
-    p4::ForwardingPipelineConfig config;
+      p4config::P4Info *p4info_proto,
+      p4rt::SetForwardingPipelineConfigRequest_Action action) {
+    p4rt::ForwardingPipelineConfig config;
     config.set_allocated_p4info(p4info_proto);
     auto status = mgr.pipeline_config_set(action, config);
     config.release_p4info();
     return status;
   }
 
-  DeviceMgr::Status add_entry(p4::TableEntry *entry) {
-    p4::WriteRequest request;
+  DeviceMgr::Status add_entry(p4rt::TableEntry *entry) {
+    p4rt::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4::Update_Type_INSERT);
+    update->set_type(p4rt::Update_Type_INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_table_entry(entry);
     auto status = mgr.write(request);
@@ -118,13 +121,13 @@ TEST_F(DeviceMgrSetPipelineConfigTest, Reconcile) {
   {
     auto status = set_pipeline_config(
         &p4info_proto_1,
-        p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
+        p4rt::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
     ASSERT_EQ(status.code(), Code::OK);
   }
 
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
   {
-    p4::TableEntry t_entry;
+    p4rt::TableEntry t_entry;
     t_entry.set_table_id(t_id);
     auto *mf = t_entry.add_match();
     mf->set_field_id(1);
@@ -145,14 +148,14 @@ TEST_F(DeviceMgrSetPipelineConfigTest, Reconcile) {
     EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
     auto status = set_pipeline_config(
         &p4info_proto_2,
-        p4::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT);
+        p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT);
     ASSERT_EQ(status.code(), Code::OK);
   }
 
   // check that table entry is still present
   {
-    p4::ReadResponse response;
-    p4::Entity entity;
+    p4rt::ReadResponse response;
+    p4rt::Entity entity;
     auto t_entry = entity.mutable_table_entry();
     t_entry->set_table_id(t_id);
     auto status = mgr.read_one(entity, &response);
@@ -164,7 +167,7 @@ TEST_F(DeviceMgrSetPipelineConfigTest, Reconcile) {
   {
     auto status = set_pipeline_config(
         &p4info_proto_3,
-        p4::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT);
+        p4rt::SetForwardingPipelineConfigRequest_Action_RECONCILE_AND_COMMIT);
     ASSERT_NE(status.code(), Code::OK);
   }
 }


### PR DESCRIPTION
We follow best practices for protobuf cloud services and add the major
version number to the package path. This change affects many C++ source
files in this project and I didn't find a good way to make the diff
smaller by using namespace "tricks".

Fixes #294

This commit also split p4/p4types.proto into p4/v1/p4data.proto and
p4/config/v1/p4types.proto, thus breaking the circular import in golang
between the p4 and p4.config packages.

Fixes #350