### PR TITLE
Added reserved ports and fixed metadata types to uint32

### DIFF
--- a/proto/p4/p4runtime.proto
+++ b/proto/p4/p4runtime.proto
@@ -344,6 +344,20 @@ message CounterData {
 }
 
 //------------------------------------------------------------------------------
+// Reserved controller-specified port numbers for reference.
+// Wrapping the enum in a message to avoid name collisions in C++, where "enum
+// values are siblings of their type, not children of it"
+message Ports {
+  enum ReservedPorts {
+    // Port number 0 in invalid. Egress port is initialized to this
+    // controller port number at the beginning of ingress and should
+    // be assigned a valid number in the ingress for all unicast packets.
+    P4RUNTIME_PORT_UNKNOWN = 0;
+    P4RUNTIME_PORT_CPU = 0xFFFFFFFD;
+    P4RUNTIME_PORT_RECIRCULATE = 0xFFFFFFFE;
+  }
+}
+
 // Only one instance of a Packet Replication Engine (PRE) is expected in the
 // P4 pipeline. Hence, no instance id is needed to access the PRE.
 message PacketReplicationEngineEntry {
@@ -355,8 +369,8 @@ message PacketReplicationEngineEntry {
 
 // Used for replicas created for cloning and multicasting actions.
 message Replica {
-  uint64 egress_port = 1;
-  uint64 instance = 2;
+  uint32 egress_port = 1;
+  uint32 instance = 2;
 }
 
 // The (egress_port, instance) pair must be unique for each replica in a given
@@ -366,7 +380,7 @@ message Replica {
 // each replica's egress input metadata will be set to the respective values
 // programmed in the multicast group entry.
 message MulticastGroupEntry {
-  uint64 multicast_group_id = 1;
+  uint32 multicast_group_id = 1;
   repeated Replica replicas = 2;
 }
 
@@ -384,10 +398,10 @@ message MulticastGroupEntry {
 // packet_length_bytes field is 0, no truncation on the clone(s) will be
 // performed.
 message CloneSessionEntry {
-  uint64 session_id = 1;
+  uint32 session_id = 1;
   repeated Replica replicas = 2;
-  uint64 class_of_service = 3;
-  uint64 packet_length_bytes = 4;
+  uint32 class_of_service = 3;
+  uint32 packet_length_bytes = 4;
 }
 
 //------------------------------------------------------------------------------

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -378,18 +378,16 @@ message CounterData {
 }
 
 //------------------------------------------------------------------------------
-// Reserved controller-specified port numbers for reference.
-// Wrapping the enum in a message to avoid name collisions in C++, where "enum
-// values are siblings of their type, not children of it"
-message Ports {
-  enum ReservedPorts {
-    // Port number 0 in invalid. Egress port is initialized to this
-    // controller port number at the beginning of ingress and should
-    // be assigned a valid number in the ingress for all unicast packets.
-    P4RUNTIME_PORT_UNKNOWN = 0;
-    P4RUNTIME_PORT_CPU = 0xFFFFFFFD;
-    P4RUNTIME_PORT_RECIRCULATE = 0xFFFFFFFE;
-  }
+// Reserved controller-specified SDN port numbers for reference.
+enum SdnPort {
+  SDN_PORT_UNSPECIFIED = 0;
+  // SDN ports are numbered starting form 1.
+  SDN_PORT_MIN = 1;
+  // The maximum value of an SDN port (physical or logical).
+  SDN_PORT_MAX = 0xFFFFFEFF;
+  // Reserved SDN port numbers (0xFFFFFFF0 - 0xFFFFFFFF)
+  SDN_PORT_RECIRCULATE = 0xFFFFFFFA;
+  SDN_PORT_CPU = 0xFFFFFFFD;
 }
 
 // Only one instance of a Packet Replication Engine (PRE) is expected in the
@@ -435,7 +433,7 @@ message CloneSessionEntry {
   uint32 session_id = 1;
   repeated Replica replicas = 2;
   uint32 class_of_service = 3;
-  uint32 packet_length_bytes = 4;
+  int32 packet_length_bytes = 4;
 }
 
 //------------------------------------------------------------------------------

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -380,14 +380,16 @@ message CounterData {
 //------------------------------------------------------------------------------
 // Reserved controller-specified SDN port numbers for reference.
 enum SdnPort {
-  SDN_PORT_UNSPECIFIED = 0;
+  SDN_PORT_UNKNOWN = 0;
   // SDN ports are numbered starting form 1.
   SDN_PORT_MIN = 1;
-  // The maximum value of an SDN port (physical or logical).
-  SDN_PORT_MAX = 0xFFFFFEFF;
-  // Reserved SDN port numbers (0xFFFFFFF0 - 0xFFFFFFFF)
-  SDN_PORT_RECIRCULATE = 0xFFFFFFFA;
-  SDN_PORT_CPU = 0xFFFFFFFD;
+  // 0xFFFFFEFF: The maximum value of an SDN port (physical or logical).
+  SDN_PORT_MAX = -257;
+  // Reserved SDN port numbers (0xFFFFFF00 - 0xFFFFFFFF)
+  // 0xFFFFFFFA: Recirculate the packet back to ingress
+  SDN_PORT_RECIRCULATE = -6;
+  // 0xFFFFFFFD: Send to CPU
+  SDN_PORT_CPU = -3;
 }
 
 // Only one instance of a Packet Replication Engine (PRE) is expected in the


### PR DESCRIPTION
uint32 types for PSA metadata are compatible with the max suggested bitwidths for clone session, multicast group, CoS and replica ID.