### PR TITLE
Add static max group size for action profile to P4Info

### DIFF
--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -230,7 +230,12 @@ message ActionProfile {
   repeated uint32 table_ids = 2;
   // true iff the action profile used dynamic selection
   bool with_selector = 3;
-  int64 size = 4;  // max number of member entries in action profile
+  // max number of weighted member entries in action profile (across all
+  // selector groups, if the action profile has a selector)
+  int64 size = 4;
+  // max number of weighted member entries in any given selector group, or 0 if
+  // the action profile does not have a selector
+  int32 max_group_size = 5;
 }
 
 message CounterSpec {

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -253,7 +253,13 @@ message ActionProfileGroup {
     uint32 watch = 3;
   }
   repeated Member members = 3;
-  int32 max_size = 4;  // cannot be modified after a group has been created
+  // Max number of weighted member entries in this group. It cannot be modified
+  // after a group has been created. It must not exceed the static
+  // max_group_size included in P4Info. If the max size is not known at group
+  // creation-time, the client may leave this field unset (default value 0), in
+  // which case the static max_group_size value will be used and the group will
+  // be able to include up to max_group_size weighted member entries.
+  int32 max_size = 4;
 }
 
 // An index as a protobuf message. In proto3, fields cannot be optional and


### PR DESCRIPTION
This information must be known at compile-time. The dynamic group max
size provided at hroup creation time is now optional and must never
exceed the static max group size when provided.

Fixes #366