### PR TITLE
Fix installation of generated Python code for P4Runtime

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -113,14 +113,22 @@ AM_CPPFLAGS = -Icpp_out -Igrpc_out \
 BUILT_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
 
 if HAVE_GRPC_PY_PLUGIN
-p4pydir = $(pythondir)/p4/v1
+p4pydir = $(pythondir)/p4
 nodist_p4py_PYTHON = \
+py_out/p4/__init__.py
+
+p4v1pydir = $(pythondir)/p4/v1
+nodist_p4v1py_PYTHON = \
 py_out/p4/v1/p4data_pb2.py \
 py_out/p4/v1/p4runtime_pb2.py \
 py_out/p4/v1/__init__.py
 
-p4configpydir = $(pythondir)/p4/config/v1
+p4configpydir = $(pythondir)/p4/config
 nodist_p4configpy_PYTHON = \
+py_out/p4/config/__init__.py
+
+p4configv1pydir = $(pythondir)/p4/config/v1
+nodist_p4configv1py_PYTHON = \
 py_out/p4/config/v1/p4info_pb2.py \
 py_out/p4/config/v1/p4types_pb2.py \
 py_out/p4/config/v1/__init__.py
@@ -172,7 +180,9 @@ if HAVE_GRPC_PY_PLUGIN
 # plugin inserts code into the proto-generated files). But maybe I am just using
 # an old version of the Python plugin.
 	$(PROTOC) $^ --python_out $(builddir)/py_out $(PROTOFLAGS) --grpc_out $(builddir)/py_out --plugin=protoc-gen-grpc=$(GRPC_PY_PLUGIN)
-	@touch $(builddir)/py_out/p4/v1/__init__.py $(builddir)/py_out/p4/config/v1/__init__.py $(builddir)/py_out/p4/tmp/__init__.py
+	@touch $(builddir)/py_out/p4/__init__.py $(builddir)/py_out/p4/v1/__init__.py
+	@touch $(builddir)/py_out/p4/config/__init__.py $(builddir)/py_out/p4/config/v1/__init__.py
+	@touch $(builddir)/py_out/p4/tmp/__init__.py
 	@touch $(builddir)/py_out/google/__init__.py $(builddir)/py_out/google/rpc/__init__.py $(builddir)/py_out/gnmi/__init__.py
 endif
 	@mv -f proto_files.tmp $@

--- a/proto/ptf/base_test.py
+++ b/proto/ptf/base_test.py
@@ -34,9 +34,9 @@ import ptf.testutils as testutils
 import grpc
 
 from google.rpc import status_pb2, code_pb2
-from p4 import p4runtime_pb2
+from p4.v1 import p4runtime_pb2
+from p4.config.v1 import p4info_pb2
 from p4.tmp import p4config_pb2
-from p4.config import p4info_pb2
 import google.protobuf.text_format
 
 # See https://gist.github.com/carymrobbins/8940382

--- a/proto/ptf/ptf_runner.py
+++ b/proto/ptf/ptf_runner.py
@@ -30,8 +30,8 @@ import subprocess
 import sys
 
 import grpc
-from p4 import p4runtime_pb2
-from p4.config import p4info_pb2
+from p4.v1 import p4runtime_pb2
+from p4.config.v1 import p4info_pb2
 import google.protobuf.text_format
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Add missing __init__.py files in directory hierarchy.