### PR TITLE
Replaced boost::shared_ptr with std::shared_ptr to work with thrift > 0.9.2

### DIFF
--- a/targets/bmv2/conn_mgr.cpp
+++ b/targets/bmv2/conn_mgr.cpp
@@ -36,7 +36,7 @@ using namespace ::apache::thrift::protocol;  // NOLINT(build/namespaces)
 using namespace ::apache::thrift::transport;  // NOLINT(build/namespaces)
 
 struct ClientImp {
-  boost::shared_ptr<TTransport> transport{nullptr};
+  std::shared_ptr<TTransport> transport{nullptr};
   std::unique_ptr<StandardClient> client{nullptr};
   std::unique_ptr<SimplePreLAGClient> mc_client{nullptr};
   std::mutex mutex{};
@@ -61,14 +61,14 @@ int conn_mgr_client_init(conn_mgr_t *conn_mgr_state, dev_id_t dev_id,
   assert(conn_mgr_state->clients.find(dev_id) == conn_mgr_state->clients.end());
   auto &client = conn_mgr_state->clients[dev_id];  // construct
 
-  boost::shared_ptr<TTransport> socket(
+  std::shared_ptr<TTransport> socket(
       new TSocket("localhost", thrift_port_num));
-  boost::shared_ptr<TTransport> transport(new TBufferedTransport(socket));
-  boost::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
+  std::shared_ptr<TTransport> transport(new TBufferedTransport(socket));
+  std::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
 
-  boost::shared_ptr<TMultiplexedProtocol> standard_protocol(
+  std::shared_ptr<TMultiplexedProtocol> standard_protocol(
       new TMultiplexedProtocol(protocol, "standard"));
-  boost::shared_ptr<TMultiplexedProtocol> mc_protocol(
+  std::shared_ptr<TMultiplexedProtocol> mc_protocol(
       new TMultiplexedProtocol(protocol, "simple_pre_lag"));
 
   try {


### PR DESCRIPTION
* since thrift 0.9.3 TBufferedTransports constructor takes an `std::shared_ptr` instead of an `boost::shared_ptr` (https://github.com/apache/thrift/commit/82ae9575cdc112088771fc7b876f75e1e4d85ebb)
* This commit replaces `boost::shared_ptr` with `std::shared_ptr` in conn_mgr to compile PI with thrift >= 0.9.3
* Thus, the checks, linking against thrift 0.9.2, fail to compile PI 

Signed-off-by: Simon Buttgereit <simon.buttgereit@tu-ilmenau.de>