### PR TITLE
Support for arch-specific extensions for tables in P4Runtime

### DIFF
--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -161,7 +161,12 @@ message MatchField {
     TERNARY = 4;
     RANGE = 5;
   }
-  MatchType match_type = 5;
+  oneof match {
+    MatchType match_type = 5;
+    // used for achitecture-specific match types which are not part of the core
+    // P4 language or of the PSA architecture.
+    string other_match_type = 7;
+  }
   // Documentation of the match field
   Documentation doc = 6;
 }
@@ -202,6 +207,9 @@ message Table {
   IdleTimeoutBehavior idle_timeout_behavior = 9;
   // table with static P4 entries, cannot be modified at runtime
   bool is_const_table = 10;
+  // architecture-specific table properties which are not part of the core P4
+  // language or of the PSA architecture.
+  google.protobuf.Any other_properties = 100;
 }
 
 // used to list all possible actions in a Table

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -240,6 +240,9 @@ message FieldMatch {
     Ternary ternary = 3;
     LPM lpm = 4;
     Range range = 6;
+    // Architecture-specific match value; it corresponds to the other_match_type
+    // in the P4Info MatchField message.
+    google.protobuf.Any other = 7;
   }
 }
 

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -242,7 +242,7 @@ message FieldMatch {
     Range range = 6;
     // Architecture-specific match value; it corresponds to the other_match_type
     // in the P4Info MatchField message.
-    google.protobuf.Any other = 7;
+    google.protobuf.Any other = 100;
   }
 }
 


### PR DESCRIPTION
This introduces support for:
 - additional architecture-specific match types. This is achieved on the
 P4Info side by wrapping the match_type field in a oneof, where the
 alternative is a string specifying the arch-specific match-type
 name. On the P4Runtime side, we simply add Any as a possible value for
 the FieldMatch oneof.
 - ability to extend TableEntry message with Any message field.

Fixes #301