### PR TITLE
Add implementation for P4Runtime MulticastGroupEntry message

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -9,7 +9,8 @@ PI/pi_value.h \
 PI/pi_act_prof.h \
 PI/pi_counter.h \
 PI/pi_meter.h \
-PI/pi_learn.h
+PI/pi_learn.h \
+PI/pi_mc.h
 
 nobase_include_HEADERS += \
 PI/frontends/generic/pi.h
@@ -32,4 +33,5 @@ PI/target/pi_tables_imp.h \
 PI/target/pi_act_prof_imp.h \
 PI/target/pi_counter_imp.h \
 PI/target/pi_meter_imp.h \
-PI/target/pi_learn_imp.h
+PI/target/pi_learn_imp.h \
+PI/target/pi_mc_imp.h

--- a/include/PI/pi_mc.h
+++ b/include/PI/pi_mc.h
@@ -1,0 +1,82 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+//! @file
+
+#ifndef PI_INC_PI_PI_MC_H_
+#define PI_INC_PI_PI_MC_H_
+
+#include <PI/pi_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint32_t pi_mc_session_handle_t;
+typedef uint32_t pi_mc_grp_id_t;
+typedef uint32_t pi_mc_grp_handle_t;
+typedef uint32_t pi_mc_node_handle_t;
+typedef int32_t pi_mc_port_t;
+typedef int32_t pi_mc_rid_t;
+
+//! Init a client session for multicast.
+pi_status_t pi_mc_session_init(pi_mc_session_handle_t *session_handle);
+
+//! Terminate a client session for multicast.
+pi_status_t pi_mc_session_cleanup(pi_mc_session_handle_t session_handle);
+
+pi_status_t pi_mc_grp_create(pi_mc_session_handle_t session_handle,
+                             pi_dev_id_t dev_id, pi_mc_grp_id_t grp_id,
+                             pi_mc_grp_handle_t *grp_handle);
+
+pi_status_t pi_mc_grp_delete(pi_mc_session_handle_t session_handle,
+                             pi_dev_id_t dev_id, pi_mc_grp_handle_t grp_handle);
+
+pi_status_t pi_mc_node_create(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id, pi_mc_rid_t rid,
+                              size_t eg_ports_count,
+                              const pi_mc_port_t *eg_ports,
+                              pi_mc_node_handle_t *node_handle);
+
+pi_status_t pi_mc_node_modify(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_node_handle_t node_handle,
+                              size_t eg_ports_count,
+                              const pi_mc_port_t *eg_ports);
+
+pi_status_t pi_mc_node_delete(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_node_handle_t node_handle);
+
+pi_status_t pi_mc_grp_attach_node(pi_mc_session_handle_t session_handle,
+                                  pi_dev_id_t dev_id,
+                                  pi_mc_grp_handle_t grp_handle,
+                                  pi_mc_node_handle_t node_handle);
+
+pi_status_t pi_mc_grp_detach_node(pi_mc_session_handle_t session_handle,
+                                  pi_dev_id_t dev_id,
+                                  pi_mc_grp_handle_t grp_handle,
+                                  pi_mc_node_handle_t node_handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PI_INC_PI_PI_MC_H_

--- a/include/PI/target/pi_mc_imp.h
+++ b/include/PI/target/pi_mc_imp.h
@@ -1,0 +1,74 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+//! @file
+
+#ifndef PI_INC_PI_TARGET_PI_MC_IMP_H_
+#define PI_INC_PI_TARGET_PI_MC_IMP_H_
+
+#include <PI/pi_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+pi_status_t _pi_mc_session_init(pi_mc_session_handle_t *session_handle);
+
+pi_status_t _pi_mc_session_cleanup(pi_mc_session_handle_t session_handle);
+
+pi_status_t _pi_mc_grp_create(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id, pi_mc_grp_id_t grp_id,
+                              pi_mc_grp_handle_t *grp_handle);
+
+pi_status_t _pi_mc_grp_delete(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_grp_handle_t grp_handle);
+
+pi_status_t _pi_mc_node_create(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id, pi_mc_rid_t rid,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports,
+                               pi_mc_node_handle_t *node_handle);
+
+pi_status_t _pi_mc_node_modify(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports);
+
+pi_status_t _pi_mc_node_delete(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle);
+
+pi_status_t _pi_mc_grp_attach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle);
+
+pi_status_t _pi_mc_grp_detach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PI_INC_PI_TARGET_PI_MC_IMP_H_

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -26,7 +26,9 @@ src/common.h \
 src/common.cpp \
 src/logger.h \
 src/logging.cpp \
-src/report_error.h
+src/report_error.h \
+src/pre_mc_mgr.h \
+src/pre_mc_mgr.cpp
 
 libpifeproto_la_LIBADD = \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \

--- a/proto/frontend/src/pre_mc_mgr.cpp
+++ b/proto/frontend/src/pre_mc_mgr.cpp
@@ -1,0 +1,223 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_mc.h>
+
+#include <vector>
+
+#include "google/rpc/code.pb.h"
+
+#include "pre_mc_mgr.h"
+#include "report_error.h"
+
+namespace p4v1 = ::p4::v1;
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+using Code = ::google::rpc::Code;
+using Status = PreMcMgr::Status;
+using GroupEntry = PreMcMgr::GroupEntry;
+
+struct McSessionTemp {
+  McSessionTemp() {
+    pi_mc_session_init(&sess);
+  }
+
+  ~McSessionTemp() {
+    pi_mc_session_cleanup(sess);
+  }
+
+  pi_mc_session_handle_t get() const { return sess; }
+
+  pi_mc_session_handle_t sess;
+  bool batch;
+};
+
+/* static */ Status
+PreMcMgr::make_new_group(const GroupEntry &group_entry, Group *group) {
+  for (const auto &replica : group_entry.replicas()) {
+    auto rid = static_cast<RId>(replica.instance());
+    auto eg_port = static_cast<pi_mc_port_t>(replica.egress_port());
+    auto &node = group->nodes[rid];
+    auto p = node.eg_ports.insert(eg_port);
+    if (!p.second) {
+      RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT,
+                          "Duplicate replica in multicast group");
+    }
+  }
+  RETURN_OK_STATUS();
+}
+
+Status
+PreMcMgr::create_and_attach_node(const McSessionTemp &session,
+                                 pi_mc_grp_handle_t group_h,
+                                 RId rid,
+                                 Node *node) {
+  pi_status_t pi_status;
+  std::vector<pi_mc_port_t> eg_ports_seq(
+      node->eg_ports.begin(), node->eg_ports.end());
+  pi_status = pi_mc_node_create(
+      session.get(), device_id, rid,
+      eg_ports_seq.size(), eg_ports_seq.data(), &node->node_h);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(
+        Code::UNKNOWN, "Error when modifying multicast group in target");
+  }
+  pi_status = pi_mc_grp_attach_node(
+      session.get(), device_id, group_h, node->node_h);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(
+        Code::UNKNOWN, "Error when modifying multicast group in target");
+  }
+  RETURN_OK_STATUS();
+}
+
+Status
+PreMcMgr::modify_node(const McSessionTemp &session, const Node &node) {
+  pi_status_t pi_status;
+  std::vector<pi_mc_port_t> eg_ports_seq(
+      node.eg_ports.begin(), node.eg_ports.end());
+  pi_status = pi_mc_node_modify(session.get(), device_id, node.node_h,
+                                eg_ports_seq.size(), eg_ports_seq.data());
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(
+        Code::UNKNOWN, "Error when modifying multicast group in target");
+  }
+  RETURN_OK_STATUS();
+}
+
+Status
+PreMcMgr::detach_and_delete_node(const McSessionTemp &session,
+                                 pi_mc_grp_handle_t group_h,
+                                 const Node &node) {
+  pi_status_t pi_status;
+  pi_status = pi_mc_grp_detach_node(
+      session.get(), device_id, group_h, node.node_h);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(
+        Code::UNKNOWN, "Error when modifying multicast group in target");
+  }
+  pi_status = pi_mc_node_delete(session.get(), device_id, node.node_h);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(
+        Code::UNKNOWN, "Error when modifying multicast group in target");
+  }
+  RETURN_OK_STATUS();
+}
+
+Status
+PreMcMgr::group_create(const GroupEntry &group_entry) {
+  auto group_id = static_cast<GroupId>(group_entry.multicast_group_id());
+  Lock lock(mutex);
+  if (groups.find(group_id) != groups.end())
+    RETURN_ERROR_STATUS(Code::ALREADY_EXISTS, "Multicast group already exists");
+
+  Group group;
+  RETURN_IF_ERROR(make_new_group(group_entry, &group));
+
+  McSessionTemp session;
+
+  auto pi_status = pi_mc_grp_create(
+      session.get(), device_id, group_id, &group.group_h);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(Code::UNKNOWN,
+                        "Error when creating multicast group in target");
+  }
+  for (auto &node_p : group.nodes) {
+    RETURN_IF_ERROR(create_and_attach_node(
+        session, group.group_h, node_p.first, &node_p.second));
+  }
+
+  groups.emplace(group_id, std::move(group));
+  RETURN_OK_STATUS();
+}
+
+Status
+PreMcMgr::group_modify(const GroupEntry &group_entry) {
+  auto group_id = static_cast<GroupId>(group_entry.multicast_group_id());
+  Lock lock(mutex);
+  auto group_it = groups.find(group_id);
+  if (group_it == groups.end())
+    RETURN_ERROR_STATUS(Code::NOT_FOUND, "Multicast group does not exist");
+  auto &old_group = group_it->second;
+
+  Group new_group;
+  new_group.group_h = old_group.group_h;
+  RETURN_IF_ERROR(make_new_group(group_entry, &new_group));
+
+  McSessionTemp session;
+
+  for (auto &node_p : new_group.nodes) {
+    auto rid = node_p.first;
+    auto old_node_it = old_group.nodes.find(rid);
+    if (old_node_it == old_group.nodes.end()) {
+      RETURN_IF_ERROR(create_and_attach_node(
+          session, new_group.group_h, node_p.first, &node_p.second));
+    } else {
+      node_p.second.node_h = old_node_it->second.node_h;
+      if (node_p.second.eg_ports != old_node_it->second.eg_ports)
+        RETURN_IF_ERROR(modify_node(session, node_p.second));
+      old_group.nodes.erase(old_node_it);
+    }
+  }
+  for (auto &node_p : old_group.nodes) {
+    RETURN_IF_ERROR(detach_and_delete_node(
+        session, new_group.group_h, node_p.second));
+  }
+
+  group_it->second = std::move(new_group);
+  RETURN_OK_STATUS();
+}
+
+Status
+PreMcMgr::group_delete(const GroupEntry &group_entry) {
+  auto group_id = static_cast<GroupId>(group_entry.multicast_group_id());
+  Lock lock(mutex);
+  auto group_it = groups.find(group_id);
+  if (group_it == groups.end())
+    RETURN_ERROR_STATUS(Code::NOT_FOUND, "Multicast group does not exist");
+  auto& group = group_it->second;
+
+  McSessionTemp session;
+
+  for (auto& node_p : group.nodes) {
+    RETURN_IF_ERROR(detach_and_delete_node(
+        session, group.group_h, node_p.second));
+  }
+
+  auto pi_status = pi_mc_grp_delete(session.get(), device_id, group.group_h);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(
+        Code::UNKNOWN, "Error when deleting multicast group in target");
+  }
+
+  groups.erase(group_id);
+  RETURN_OK_STATUS();
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi

--- a/proto/frontend/src/pre_mc_mgr.h
+++ b/proto/frontend/src/pre_mc_mgr.h
@@ -1,0 +1,96 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SRC_PRE_MC_MGR_H_
+#define SRC_PRE_MC_MGR_H_
+
+#include <PI/pi_base.h>
+#include <PI/pi_mc.h>
+
+#include <mutex>
+#include <set>
+#include <unordered_map>
+
+#include "google/rpc/status.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+struct McSessionTemp;
+
+// This class is used to map P4Runtime MulticastGroupEntry messages to
+// lower-level PI operations. It currently does not do any rollback in case of
+// error, which means a single P4Runtime multicast group modification can be
+// only partially committed to the target in case of error.
+class PreMcMgr {
+ public:
+  using Status = ::google::rpc::Status;
+  using GroupEntry = ::p4::v1::MulticastGroupEntry;
+  using GroupId = uint32_t;
+  using RId = uint32_t;
+
+  explicit PreMcMgr(pi_dev_id_t device_id)
+      : device_id(device_id) { }
+
+  Status group_create(const GroupEntry &group_entry);
+  Status group_modify(const GroupEntry &group_entry);
+  Status group_delete(const GroupEntry &group_entry);
+
+ private:
+  using Mutex = std::mutex;
+  using Lock = std::lock_guard<Mutex>;
+
+  struct Node {
+    pi_mc_node_handle_t node_h;
+    std::set<pi_mc_port_t> eg_ports{};
+  };
+
+  struct Group {
+    pi_mc_grp_handle_t group_h;
+    std::unordered_map<RId, Node> nodes{};
+  };
+
+  static Status make_new_group(const GroupEntry &group_entry, Group *group);
+
+  Status create_and_attach_node(const McSessionTemp &session,
+                                pi_mc_grp_handle_t group_h,
+                                RId rid,
+                                Node *node);
+  Status modify_node(const McSessionTemp &session, const Node &node);
+  Status detach_and_delete_node(const McSessionTemp &session,
+                                pi_mc_grp_handle_t group_h,
+                                const Node &node);
+
+  pi_dev_id_t device_id;
+  std::unordered_map<GroupId, Group> groups{};
+  mutable Mutex mutex{};
+};
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi
+
+#endif  // SRC_PRE_MC_MGR_H_

--- a/proto/frontend/src/report_error.h
+++ b/proto/frontend/src/report_error.h
@@ -90,4 +90,11 @@ static inline ::google::rpc::Status GENERIC_STATUS(::google::rpc::Code code) {
 #define IS_OK(status) (status.code() == ::google::rpc::Code::OK)
 #define IS_ERROR(status) (status.code() != ::google::rpc::Code::OK)
 
+#define RETURN_IF_ERROR(status)                 \
+  do {                                          \
+    auto status_ = status;                      \
+    if (IS_ERROR(status_)) return status_;      \
+  }                                             \
+  while (false)
+
 #endif  // SRC_REPORT_ERROR_H_

--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -31,6 +31,7 @@
 #include <cstdint>
 
 #include "PI/pi.h"
+#include "PI/pi_mc.h"
 
 namespace pi {
 namespace proto {
@@ -64,6 +65,20 @@ class DummySwitchMock {
                                         pi_indirect_handle_t *h);
 
   pi_indirect_handle_t get_action_prof_handle() const;
+
+  // used to capture handle for MC groups
+  pi_status_t _mc_grp_create(pi_mc_grp_id_t grp_id,
+                             pi_mc_grp_handle_t *grp_handle);
+
+  pi_mc_grp_handle_t get_mc_grp_handle() const;
+
+  // used to capture handle for MC nodes
+  pi_status_t _mc_node_create(pi_mc_rid_t rid,
+                              size_t eg_ports_count,
+                              const pi_mc_port_t *eg_ports,
+                              pi_mc_node_handle_t *node_handle);
+
+  pi_mc_node_handle_t get_mc_node_handle() const;
 
   pi_status_t packetin_inject(const std::string &packet) const;
 
@@ -131,10 +146,26 @@ class DummySwitchMock {
 
   MOCK_METHOD2(packetout_send, pi_status_t(const char *, size_t));
 
+  MOCK_METHOD2(mc_grp_create,
+               pi_status_t(pi_mc_grp_id_t, pi_mc_grp_handle_t *));
+  MOCK_METHOD1(mc_grp_delete, pi_status_t(pi_mc_grp_handle_t));
+  MOCK_METHOD4(mc_node_create,
+               pi_status_t(pi_mc_rid_t, size_t, const pi_mc_port_t *,
+                           pi_mc_node_handle_t *));
+  MOCK_METHOD3(mc_node_modify,
+               pi_status_t(pi_mc_node_handle_t, size_t, const pi_mc_port_t *));
+  MOCK_METHOD1(mc_node_delete, pi_status_t(pi_mc_node_handle_t));
+  MOCK_METHOD2(mc_grp_attach_node,
+               pi_status_t(pi_mc_grp_handle_t, pi_mc_node_handle_t));
+  MOCK_METHOD2(mc_grp_detach_node,
+               pi_status_t(pi_mc_grp_handle_t, pi_mc_node_handle_t));
+
  private:
   std::unique_ptr<DummySwitch> sw;
   pi_indirect_handle_t action_prof_h;
   pi_entry_handle_t table_h;
+  pi_mc_grp_handle_t mc_grp_h;
+  pi_mc_node_handle_t mc_node_h;
 };
 
 // used to map device ids to DummySwitchMock instances; thread safe in case we

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,7 @@ pi_counter.c \
 pi_meter.c \
 pi_learn.c \
 pi_value.c \
+pi_mc.c \
 device_map.c \
 device_map.h
 

--- a/src/pi_mc.c
+++ b/src/pi_mc.c
@@ -1,0 +1,85 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_base.h>
+#include <PI/pi_mc.h>
+#include <PI/target/pi_mc_imp.h>
+
+#include <stdlib.h>
+
+pi_status_t pi_mc_session_init(pi_mc_session_handle_t *session_handle) {
+  return _pi_mc_session_init(session_handle);
+}
+
+pi_status_t pi_mc_session_cleanup(pi_mc_session_handle_t session_handle) {
+  return _pi_mc_session_cleanup(session_handle);
+}
+
+pi_status_t pi_mc_grp_create(pi_mc_session_handle_t session_handle,
+                             pi_dev_id_t dev_id, pi_mc_grp_id_t grp_id,
+                             pi_mc_grp_handle_t *grp_handle) {
+  return _pi_mc_grp_create(session_handle, dev_id, grp_id, grp_handle);
+}
+
+pi_status_t pi_mc_grp_delete(pi_mc_session_handle_t session_handle,
+                             pi_dev_id_t dev_id,
+                             pi_mc_grp_handle_t grp_handle) {
+  return _pi_mc_grp_delete(session_handle, dev_id, grp_handle);
+}
+
+pi_status_t pi_mc_node_create(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id, pi_mc_rid_t rid,
+                              size_t eg_ports_count,
+                              const pi_mc_port_t *eg_ports,
+                              pi_mc_node_handle_t *node_handle) {
+  return _pi_mc_node_create(session_handle, dev_id, rid, eg_ports_count,
+                            eg_ports, node_handle);
+}
+
+pi_status_t pi_mc_node_modify(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_node_handle_t node_handle,
+                              size_t eg_ports_count,
+                              const pi_mc_port_t *eg_ports) {
+  return _pi_mc_node_modify(session_handle, dev_id, node_handle, eg_ports_count,
+                            eg_ports);
+}
+
+pi_status_t pi_mc_node_delete(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_node_handle_t node_handle) {
+  return _pi_mc_node_delete(session_handle, dev_id, node_handle);
+}
+
+pi_status_t pi_mc_grp_attach_node(pi_mc_session_handle_t session_handle,
+                                  pi_dev_id_t dev_id,
+                                  pi_mc_grp_handle_t grp_handle,
+                                  pi_mc_node_handle_t node_handle) {
+  return _pi_mc_grp_attach_node(session_handle, dev_id, grp_handle,
+                                node_handle);
+}
+
+pi_status_t pi_mc_grp_detach_node(pi_mc_session_handle_t session_handle,
+                                  pi_dev_id_t dev_id,
+                                  pi_mc_grp_handle_t grp_handle,
+                                  pi_mc_node_handle_t node_handle) {
+  return _pi_mc_grp_detach_node(session_handle, dev_id, grp_handle,
+                                node_handle);
+}

--- a/targets/bmv2/Makefile.am
+++ b/targets/bmv2/Makefile.am
@@ -13,6 +13,7 @@ pi_act_prof_imp.cpp \
 pi_counter_imp.cpp \
 pi_meter_imp.cpp \
 pi_learn_imp.cpp \
+pi_mc_imp.cpp \
 conn_mgr.h \
 conn_mgr.cpp \
 common.h \

--- a/targets/bmv2/pi_mc_imp.cpp
+++ b/targets/bmv2/pi_mc_imp.cpp
@@ -1,0 +1,206 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_mc.h>
+#include <PI/target/pi_mc_imp.h>
+
+#include <algorithm>  // for std::reverse
+#include <iostream>
+#include <string>
+
+#include "common.h"
+#include "conn_mgr.h"
+
+namespace pibmv2 {
+
+extern conn_mgr_t *conn_mgr_state;
+
+}  // namespace pibmv2
+
+namespace {
+
+std::string convert_map(const pi_mc_port_t *eg_ports, size_t eg_ports_count) {
+  std::string output;
+  for (size_t i = 0; i < eg_ports_count; i++) {
+    output.resize(eg_ports[i] + 1, '0');
+    output[eg_ports[i]] = '1';
+  }
+  std::reverse(output.begin(), output.end());
+  return output;
+}
+
+}  // namespace
+
+extern "C" {
+
+pi_status_t _pi_mc_session_init(pi_mc_session_handle_t *session_handle) {
+  *session_handle = 0;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_session_cleanup(pi_mc_session_handle_t session_handle) {
+  (void)session_handle;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_create(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_grp_id_t grp_id,
+                              pi_mc_grp_handle_t *grp_handle) {
+  (void) session_handle;
+
+  auto mc_client = conn_mgr_mc_client(pibmv2::conn_mgr_state, dev_id);
+  try {
+    *grp_handle = mc_client.c->bm_mc_mgrp_create(0, grp_id);
+  } catch (InvalidMcOperation &imo) {
+    const char *what =
+        _McOperationErrorCode_VALUES_TO_NAMES.find(imo.code)->second;
+    std::cout << "Invalid multicast operation (" << imo.code << "): "
+              << what << std::endl;
+    return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + imo.code);
+  }
+
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_delete(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_grp_handle_t grp_handle) {
+  (void) session_handle;
+
+  auto mc_client = conn_mgr_mc_client(pibmv2::conn_mgr_state, dev_id);
+  try {
+    mc_client.c->bm_mc_mgrp_destroy(0, grp_handle);
+  } catch (InvalidMcOperation &imo) {
+    const char *what =
+        _McOperationErrorCode_VALUES_TO_NAMES.find(imo.code)->second;
+    std::cout << "Invalid multicast operation (" << imo.code << "): "
+              << what << std::endl;
+    return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + imo.code);
+  }
+
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_create(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_rid_t rid,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports,
+                               pi_mc_node_handle_t *node_handle) {
+  (void) session_handle;
+
+  auto mc_client = conn_mgr_mc_client(pibmv2::conn_mgr_state, dev_id);
+  try {
+    *node_handle = mc_client.c->bm_mc_node_create(
+        0, rid, convert_map(eg_ports, eg_ports_count), "");
+  } catch (InvalidMcOperation &imo) {
+    const char *what =
+        _McOperationErrorCode_VALUES_TO_NAMES.find(imo.code)->second;
+    std::cout << "Invalid multicast operation (" << imo.code << "): "
+              << what << std::endl;
+    return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + imo.code);
+  }
+
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_modify(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports) {
+  (void) session_handle;
+
+  auto mc_client = conn_mgr_mc_client(pibmv2::conn_mgr_state, dev_id);
+  try {
+    mc_client.c->bm_mc_node_update(
+        0, node_handle, convert_map(eg_ports, eg_ports_count), "");
+  } catch (InvalidMcOperation &imo) {
+    const char *what =
+        _McOperationErrorCode_VALUES_TO_NAMES.find(imo.code)->second;
+    std::cout << "Invalid multicast operation (" << imo.code << "): "
+              << what << std::endl;
+    return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + imo.code);
+  }
+
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_delete(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle) {
+  (void) session_handle;
+
+  auto mc_client = conn_mgr_mc_client(pibmv2::conn_mgr_state, dev_id);
+  try {
+    mc_client.c->bm_mc_node_destroy(0, node_handle);
+  } catch (InvalidMcOperation &imo) {
+    const char *what =
+        _McOperationErrorCode_VALUES_TO_NAMES.find(imo.code)->second;
+    std::cout << "Invalid multicast operation (" << imo.code << "): "
+              << what << std::endl;
+    return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + imo.code);
+  }
+
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_attach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  (void) session_handle;
+
+  auto mc_client = conn_mgr_mc_client(pibmv2::conn_mgr_state, dev_id);
+  try {
+    mc_client.c->bm_mc_node_associate(0, grp_handle, node_handle);
+  } catch (InvalidMcOperation &imo) {
+    const char *what =
+        _McOperationErrorCode_VALUES_TO_NAMES.find(imo.code)->second;
+    std::cout << "Invalid multicast operation (" << imo.code << "): "
+              << what << std::endl;
+    return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + imo.code);
+  }
+
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_detach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  (void) session_handle;
+
+  auto mc_client = conn_mgr_mc_client(pibmv2::conn_mgr_state, dev_id);
+  try {
+    mc_client.c->bm_mc_node_dissociate(0, grp_handle, node_handle);
+  } catch (InvalidMcOperation &imo) {
+    const char *what =
+        _McOperationErrorCode_VALUES_TO_NAMES.find(imo.code)->second;
+    std::cout << "Invalid multicast operation (" << imo.code << "): "
+              << what << std::endl;
+    return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + imo.code);
+  }
+
+  return PI_STATUS_SUCCESS;
+}
+
+}

--- a/targets/dummy/Makefile.am
+++ b/targets/dummy/Makefile.am
@@ -9,6 +9,7 @@ pi_act_prof_imp.c \
 pi_counter_imp.c \
 pi_meter_imp.c \
 pi_learn_imp.c \
+pi_mc_imp.c \
 func_counter.c \
 func_counter.h
 

--- a/targets/dummy/pi_mc_imp.c
+++ b/targets/dummy/pi_mc_imp.c
@@ -1,0 +1,120 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_mc.h>
+#include <PI/target/pi_mc_imp.h>
+
+#include "func_counter.h"
+
+pi_status_t _pi_mc_session_init(pi_mc_session_handle_t *session_handle) {
+  *session_handle = 0;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_session_cleanup(pi_mc_session_handle_t session_handle) {
+  (void)session_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_create(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id, pi_mc_grp_id_t grp_id,
+                              pi_mc_grp_handle_t *grp_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_id;
+  (void)grp_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_delete(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_grp_handle_t grp_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_create(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id, pi_mc_rid_t rid,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports,
+                               pi_mc_node_handle_t *node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)rid;
+  (void)eg_ports_count;
+  (void)eg_ports;
+  (void)node_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_modify(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)node_handle;
+  (void)eg_ports_count;
+  (void)eg_ports;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_delete(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)node_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_attach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_handle;
+  (void)node_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_detach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_handle;
+  (void)node_handle;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}

--- a/targets/rpc/Makefile.am
+++ b/targets/rpc/Makefile.am
@@ -11,6 +11,7 @@ pi_act_prof_imp.c \
 pi_counter_imp.c \
 pi_meter_imp.c \
 pi_learn_imp.c \
+pi_mc_imp.c \
 notifications.c
 
 libpi_rpc_la_LIBADD = \

--- a/targets/rpc/pi_mc_imp.c
+++ b/targets/rpc/pi_mc_imp.c
@@ -1,0 +1,109 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_mc.h>
+#include <PI/target/pi_mc_imp.h>
+
+pi_status_t _pi_mc_session_init(pi_mc_session_handle_t *session_handle) {
+  (void)session_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_session_cleanup(pi_mc_session_handle_t session_handle) {
+  (void)session_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_grp_create(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id, pi_mc_grp_id_t grp_id,
+                              pi_mc_grp_handle_t *grp_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_id;
+  (void)grp_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_grp_delete(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_grp_handle_t grp_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_node_create(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id, pi_mc_rid_t rid,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports,
+                               pi_mc_node_handle_t *node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)rid;
+  (void)eg_ports_count;
+  (void)eg_ports;
+  (void)node_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_node_modify(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)node_handle;
+  (void)eg_ports_count;
+  (void)eg_ports;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_node_delete(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)node_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_grp_attach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_handle;
+  (void)node_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_mc_grp_detach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)grp_handle;
+  (void)node_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
This required defining some lower-level PI C functions to match the
implementation of other features. The PI functions are similar to the
ones exposed by bmv2.

This commit implements the new PI functions for bmv2 although the
implementation is not tested (unfortunately there is no simple way to
test without also implementing the functions for the deprecated rpc
target and in the CLI). However, we include unit tests for the mapping
from P4Runtime message to PI. Note that most people do not use this
implementation for bmv2 anyway, but instead use simple_switch_grpc.