### PR TITLE
Use NO_TIMEOUT as default value in P4Info

### DIFF
--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -199,9 +199,8 @@ message Table {
   // this enum can be extended in the future with other behaviors, such as
   // "HARD_EVICTION"
   enum IdleTimeoutBehavior {
-    UNSPECIFIED = 0;
-    NO_TIMEOUT = 1;
-    NOTIFY_CONTROL = 2;
+    NO_TIMEOUT = 0;
+    NOTIFY_CONTROL = 1;
   }
   // is idle timeout supported for this table?
   IdleTimeoutBehavior idle_timeout_behavior = 9;


### PR DESCRIPTION
For the IdleTimeoutBehavior enum. In proto3, there is no need to use
UNSPECIFIED as the default value for enums (for backward-compatibility
purposes) as during deserialization, unrecognized enum values will be
preserved in the message. NO_TIMEOUT makes sense as the default and it
will make debug prints of the messages shorter (since most P4 tables
will use NO_TIMEOUT and default values are omitted from the debug
prints).

Fixes #379