### PR TITLE
Use highest election_id in MasterArbitrationUpdate response

### DIFF
--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -288,7 +288,8 @@ class DeviceState {
       to->set_high(from.high());
       to->set_low(from.low());
     };
-    convert_u128(connection->election_id(), arbitration->mutable_election_id());
+    auto master_connection = get_master();
+    convert_u128(master_connection->election_id(), arbitration->mutable_election_id());
     auto status = arbitration->mutable_status();
     if (is_master) {
       status->set_code(::google::rpc::Code::OK);

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -289,7 +289,8 @@ class DeviceState {
       to->set_low(from.low());
     };
     auto master_connection = get_master();
-    convert_u128(master_connection->election_id(), arbitration->mutable_election_id());
+    convert_u128(master_connection->election_id(),
+                 arbitration->mutable_election_id());
     auto status = arbitration->mutable_status();
     if (is_master) {
       status->set_code(::google::rpc::Code::OK);


### PR DESCRIPTION
Spec says:

> After the controller sends a StreamMessageRequest message to the P4Runtime server, the server sends a StreamMessageResponse message back to the controller, in which it populates the MasterArbitrationUpdate message using the device_id, role, and election_id it previously received from all the controllers via the StreamMessageRequest message. **The election_id populated in the response is always the highest election_id, referring to the current master after the request was processed.**