### PR TITLE
Add device manager general error message

### DIFF
--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -114,6 +114,7 @@ class P4ErrorReporter {
         }
         auto error_any = status.add_details();
         error_any->PackFrom(p.second);
+        status.set_message(p.second.message());
       }
     }
     return status;
@@ -1523,7 +1524,7 @@ class DeviceMgrImp {
     if (pLen == 0) {
       RETURN_ERROR_STATUS(
           Code::INVALID_ARGUMENT,
-          "Invalid reprsentation of 'don't care' LPM match, "
+          "Invalid representation of 'don't care' LPM match, "
           "omit match field instead of using a prefix length of 0");
     }
     // makes sure that value ends with zeros


### PR DESCRIPTION
Depending on the data the controller sends over, the response code sometimes comes back without a string message, just an UNKNOWN code. For a stack of these errors, set the last error message to the error status. This will give the controller some idea what failed. 