### PR TITLE
Add implementation for P4Runtime CloneSessionEntry message

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -10,7 +10,8 @@ PI/pi_act_prof.h \
 PI/pi_counter.h \
 PI/pi_meter.h \
 PI/pi_learn.h \
-PI/pi_mc.h
+PI/pi_mc.h \
+PI/pi_clone.h
 
 nobase_include_HEADERS += \
 PI/frontends/generic/pi.h
@@ -34,4 +35,5 @@ PI/target/pi_act_prof_imp.h \
 PI/target/pi_counter_imp.h \
 PI/target/pi_meter_imp.h \
 PI/target/pi_learn_imp.h \
-PI/target/pi_mc_imp.h
+PI/target/pi_mc_imp.h \
+PI/target/pi_clone_imp.h

--- a/include/PI/pi_base.h
+++ b/include/PI/pi_base.h
@@ -118,6 +118,8 @@ typedef uint32_t pi_session_handle_t;
 //! Forward declaration of p4info (P4 config)
 typedef struct pi_p4info_s pi_p4info_t;
 
+typedef int32_t pi_port_t;
+
 #define PI_ACTION_ID 0x01
 #define PI_TABLE_ID 0x02
 

--- a/include/PI/pi_clone.h
+++ b/include/PI/pi_clone.h
@@ -1,0 +1,71 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+//! @file
+
+#ifndef PI_INC_PI_PI_CLONE_H_
+#define PI_INC_PI_PI_CLONE_H_
+
+#include <PI/pi_base.h>
+#include <PI/pi_mc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint16_t pi_clone_session_id_t;
+typedef int32_t pi_clone_port_t;
+
+typedef enum {
+  PI_CLONE_DIRECTION_NONE = 0,
+  PI_CLONE_DIRECTION_I2E,
+  PI_CLONE_DIRECTION_E2E,
+  PI_CLONE_DIRECTION_BOTH,
+} pi_clone_direction_t;
+
+typedef struct {
+  pi_clone_direction_t direction;
+  pi_port_t eg_port;
+  bool eg_port_valid;
+  pi_mc_grp_id_t mc_grp_id;
+  bool mc_grp_id_valid;
+  bool copy_to_cpu;
+  uint16_t max_packet_length;  // 0 means no truncation
+  uint32_t cos;
+} pi_clone_session_config_t;
+
+//! Enables a cloning session. Is allowed to fail if multicast group does not
+//! exist (we leave it up to the target).
+pi_status_t pi_clone_session_set(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config);
+
+//! Resets state for a clone session. We exect this to succeed even if the
+//! session does not "exist", i.e. was not previously set.
+pi_status_t pi_clone_session_reset(pi_session_handle_t session_handle,
+                                   pi_dev_tgt_t dev_tgt,
+                                   pi_clone_session_id_t clone_session_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PI_INC_PI_PI_CLONE_H_

--- a/include/PI/pi_mc.h
+++ b/include/PI/pi_mc.h
@@ -33,7 +33,7 @@ typedef uint32_t pi_mc_session_handle_t;
 typedef uint32_t pi_mc_grp_id_t;
 typedef uint32_t pi_mc_grp_handle_t;
 typedef uint32_t pi_mc_node_handle_t;
-typedef int32_t pi_mc_port_t;
+typedef pi_port_t pi_mc_port_t;
 typedef int32_t pi_mc_rid_t;
 
 //! Init a client session for multicast.

--- a/include/PI/target/pi_clone_imp.h
+++ b/include/PI/target/pi_clone_imp.h
@@ -1,0 +1,45 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef PI_INC_PI_TARGET_PI_CLONE_IMP_H_
+#define PI_INC_PI_TARGET_PI_CLONE_IMP_H_
+
+#include <PI/pi_base.h>
+#include <PI/pi_clone.h>
+#include <PI/pi_mc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+pi_status_t _pi_clone_session_set(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config);
+
+pi_status_t _pi_clone_session_reset(pi_session_handle_t session_handle,
+                                    pi_dev_tgt_t dev_tgt,
+                                    pi_clone_session_id_t clone_session_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PI_INC_PI_TARGET_PI_CLONE_IMP_H_

--- a/include/PI/target/pi_mc_imp.h
+++ b/include/PI/target/pi_mc_imp.h
@@ -18,8 +18,6 @@
  *
  */
 
-//! @file
-
 #ifndef PI_INC_PI_TARGET_PI_MC_IMP_H_
 #define PI_INC_PI_TARGET_PI_MC_IMP_H_
 

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -28,7 +28,9 @@ src/logger.h \
 src/logging.cpp \
 src/report_error.h \
 src/pre_mc_mgr.h \
-src/pre_mc_mgr.cpp
+src/pre_mc_mgr.cpp \
+src/pre_clone_mgr.h \
+src/pre_clone_mgr.cpp
 
 libpifeproto_la_LIBADD = \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \

--- a/proto/frontend/src/pre_clone_mgr.cpp
+++ b/proto/frontend/src/pre_clone_mgr.cpp
@@ -1,0 +1,173 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <limits>
+
+#include "common.h"
+#include "pre_clone_mgr.h"
+#include "pre_mc_mgr.h"
+#include "report_error.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+using Status = PreCloneMgr::Status;
+using CloneSession = PreCloneMgr::CloneSession;
+using CloneSessionId = PreCloneMgr::CloneSessionId;
+using SessionTemp = common::SessionTemp;
+
+namespace {
+
+PreMcMgr::GroupId
+session_id_to_mc_group_id(CloneSessionId session_id) {
+  return PreMcMgr::first_reserved_group_id() + session_id;
+}
+
+PreMcMgr::GroupEntry
+make_mc_group(const CloneSession &clone_session) {
+  PreMcMgr::GroupEntry mc_group;
+  auto mc_group_id = session_id_to_mc_group_id(clone_session.session_id());
+  mc_group.set_multicast_group_id(mc_group_id);
+  mc_group.mutable_replicas()->CopyFrom(clone_session.replicas());
+  return mc_group;
+}
+
+}  // namespace
+
+/* static */ Status
+PreCloneMgr::validate_session_id(CloneSessionId session_id) {
+  if (session_id < kMinCloneSessionId || session_id >= kMaxCloneSessionId)
+    RETURN_ERROR_STATUS(Code::OUT_OF_RANGE, "Clone session id out-of-range");
+  RETURN_OK_STATUS();
+}
+
+PreCloneMgr::PreCloneMgr(pi_dev_tgt_t device_tgt, PreMcMgr* mc_mgr)
+    : device_tgt(device_tgt), mc_mgr(mc_mgr) { }
+
+Status
+PreCloneMgr::session_set(const CloneSession &clone_session,
+                         PreMcMgr::GroupId mc_group_id,
+                         const SessionTemp &session) {
+  auto session_id = static_cast<CloneSessionId>(clone_session.session_id());
+  pi_clone_session_config_t session_config = {};  // value-initialization
+  session_config.direction = PI_CLONE_DIRECTION_BOTH;
+  session_config.mc_grp_id = mc_group_id;
+  session_config.mc_grp_id_valid = true;
+  // TODO(antonin): range check?
+  session_config.max_packet_length = static_cast<uint16_t>(
+      clone_session.packet_length_bytes());
+
+  if (clone_session.class_of_service() != 0) {
+    RETURN_ERROR_STATUS(Code::UNIMPLEMENTED,
+                        "COS for clone sessions not supported yet");
+  }
+
+  auto pi_status = pi_clone_session_set(
+      session.get(), device_tgt, session_id, &session_config);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(Code::UNKNOWN,
+                        "Error when creating clone session in target");
+  }
+  RETURN_OK_STATUS();
+}
+
+Status
+PreCloneMgr::session_create(const CloneSession &clone_session,
+                            const SessionTemp &session) {
+  auto session_id = static_cast<CloneSessionId>(clone_session.session_id());
+  RETURN_IF_ERROR(validate_session_id(session_id));
+  Lock lock(mutex);
+  if (sessions[session_id]) {
+    RETURN_ERROR_STATUS(Code::ALREADY_EXISTS,
+                        "Clone session id already exists");
+  }
+  auto mc_group = make_mc_group(clone_session);
+  RETURN_IF_ERROR(
+      mc_mgr->group_create(mc_group, PreMcMgr::GroupOwner::CLONE_MGR));
+  auto status = session_set(
+      clone_session, mc_group.multicast_group_id(), session);
+  if (IS_OK(status)) {
+    sessions[session_id] = true;
+    RETURN_OK_STATUS();
+  }
+  {
+    auto status = mc_mgr->group_delete(mc_group);
+    if (IS_ERROR(status)) {
+      RETURN_ERROR_STATUS(
+          Code::INTERNAL,
+          "Clone session set failed and could not undo creation of multicast "
+          "group {}. This is a serious error which will prevent you from using "
+          "session id {} again until it is resolved",
+          mc_group.multicast_group_id(),
+          session_id);
+    }
+  }
+  return status;
+}
+
+Status
+PreCloneMgr::session_modify(const CloneSession &clone_session,
+                            const SessionTemp &session) {
+  auto session_id = static_cast<CloneSessionId>(clone_session.session_id());
+  RETURN_IF_ERROR(validate_session_id(session_id));
+  Lock lock(mutex);
+  if (!sessions[session_id])
+    RETURN_ERROR_STATUS(Code::NOT_FOUND, "Clone session id does not exist");
+  auto mc_group = make_mc_group(clone_session);
+  return mc_mgr->group_modify(mc_group);
+}
+
+Status
+PreCloneMgr::session_delete(const CloneSession &clone_session,
+                            const SessionTemp &session) {
+  auto session_id = static_cast<CloneSessionId>(clone_session.session_id());
+  RETURN_IF_ERROR(validate_session_id(session_id));
+  Lock lock(mutex);
+  if (!sessions[session_id])
+    RETURN_ERROR_STATUS(Code::NOT_FOUND, "Clone session id does not exist");
+  auto pi_status = pi_clone_session_reset(
+      session.get(), device_tgt, session_id);
+  if (pi_status != PI_STATUS_SUCCESS) {
+    RETURN_ERROR_STATUS(Code::UNKNOWN,
+                        "Error when resetting clone session in target");
+  }
+  auto mc_group = make_mc_group(clone_session);
+  auto status = mc_mgr->group_delete(mc_group);
+  if (IS_OK(status)) {
+    sessions[session_id] = false;
+    RETURN_OK_STATUS();
+  }
+  RETURN_ERROR_STATUS(
+      Code::INTERNAL,
+      "Clone session was deleted but underlying multicast group {} could not "
+      "be deleted. This is a serious error which will prevent you from using "
+      "session id {} again until it is resolved",
+      mc_group.multicast_group_id(),
+      session_id);
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi

--- a/proto/frontend/src/pre_clone_mgr.h
+++ b/proto/frontend/src/pre_clone_mgr.h
@@ -1,0 +1,91 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SRC_PRE_CLONE_MGR_H_
+#define SRC_PRE_CLONE_MGR_H_
+
+#include <PI/pi_base.h>
+#include <PI/pi_clone.h>
+
+#include <bitset>
+#include <mutex>
+#include <unordered_map>
+
+#include "google/rpc/status.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+
+#include "pre_mc_mgr.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+namespace common { struct SessionTemp; }  // namespace common
+
+// This class is used to map P4Runtime CloneSessionEntry messages to lower-level
+// PI operations. At the moment every clone session is associated to a multicast
+// group.
+class PreCloneMgr {
+ public:
+  using Status = ::google::rpc::Status;
+  using CloneSession = ::p4::v1::CloneSessionEntry;
+  using CloneSessionId = uint32_t;
+  using SessionTemp = common::SessionTemp;
+
+  PreCloneMgr(pi_dev_tgt_t device_tgt, PreMcMgr* mc_mgr);
+
+  Status session_create(const CloneSession &clone_session,
+                        const SessionTemp &session);
+  Status session_modify(const CloneSession &clone_session,
+                        const SessionTemp &session);
+  Status session_delete(const CloneSession &clone_session,
+                        const SessionTemp &session);
+
+ private:
+  using Mutex = std::mutex;
+  using Lock = std::lock_guard<Mutex>;
+
+  // TODO(antonin): this should ideally be configurable based on te target but
+  // these seem like a reasonnable place to start with.
+  static constexpr CloneSessionId kMinCloneSessionId = 1;
+  static constexpr CloneSessionId kMaxCloneSessionId = 512;
+
+  Status session_set(const CloneSession &clone_session,
+                     PreMcMgr::GroupId mc_group_id,
+                     const SessionTemp &session);
+
+  static Status validate_session_id(CloneSessionId session_id);
+
+  pi_dev_tgt_t device_tgt;
+  PreMcMgr* mc_mgr;  // non-owning pointer
+  // which sessions exist
+  std::bitset<kMaxCloneSessionId> sessions{};
+  mutable Mutex mutex{};
+};
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi
+
+#endif  // SRC_PRE_CLONE_MGR_H_

--- a/proto/frontend/src/pre_mc_mgr.cpp
+++ b/proto/frontend/src/pre_mc_mgr.cpp
@@ -127,13 +127,14 @@ PreMcMgr::detach_and_delete_node(const McSessionTemp &session,
 }
 
 Status
-PreMcMgr::group_create(const GroupEntry &group_entry) {
+PreMcMgr::group_create(const GroupEntry &group_entry, GroupOwner owner) {
   auto group_id = static_cast<GroupId>(group_entry.multicast_group_id());
   Lock lock(mutex);
   if (groups.find(group_id) != groups.end())
     RETURN_ERROR_STATUS(Code::ALREADY_EXISTS, "Multicast group already exists");
 
   Group group;
+  group.owner = owner;
   RETURN_IF_ERROR(make_new_group(group_entry, &group));
 
   McSessionTemp session;
@@ -164,6 +165,7 @@ PreMcMgr::group_modify(const GroupEntry &group_entry) {
 
   Group new_group;
   new_group.group_h = old_group.group_h;
+  new_group.owner = old_group.owner;
   RETURN_IF_ERROR(make_new_group(group_entry, &new_group));
 
   McSessionTemp session;

--- a/proto/frontend/src/pre_mc_mgr.h
+++ b/proto/frontend/src/pre_mc_mgr.h
@@ -50,12 +50,23 @@ class PreMcMgr {
   using GroupId = uint32_t;
   using RId = uint32_t;
 
+  enum class GroupOwner {
+    CLIENT,
+    CLONE_MGR,
+  };
+
   explicit PreMcMgr(pi_dev_id_t device_id)
       : device_id(device_id) { }
 
-  Status group_create(const GroupEntry &group_entry);
+  Status group_create(const GroupEntry &group_entry,
+                      GroupOwner = GroupOwner::CLIENT);
   Status group_modify(const GroupEntry &group_entry);
   Status group_delete(const GroupEntry &group_entry);
+
+  // user-defined multicast group ids must be in the range
+  // [0,first_reserved_group[; ideally this should be configurable based on the
+  // target.
+  static constexpr GroupId first_reserved_group_id() { return 1 << 15; }
 
  private:
   using Mutex = std::mutex;
@@ -69,6 +80,7 @@ class PreMcMgr {
   struct Group {
     pi_mc_grp_handle_t group_h;
     std::unordered_map<RId, Node> nodes{};
+    GroupOwner owner;
   };
 
   static Status make_new_group(const GroupEntry &group_entry, Group *group);

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -55,14 +55,6 @@ test_proto_fe_packet_io.cpp
 test_proto_fe_set_pipeline_config_SOURCES =$(proto_fe_common_source) \
 test_proto_fe_set_pipeline_config.cpp
 
-# this is an awful hack and a big time saver :)
-# thanks to this, I do not need to implement all of the _pi_* functions, only
-# the one I actually need for the tests. To me this is acceptable as I only use
-# this for unit tests
-test_proto_fe_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
-test_proto_fe_packet_io_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
-test_proto_fe_set_pipeline_config_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
-
 mock_switch_libs = \
 $(top_builddir)/p4info/libpiconvertproto.la \
 $(top_builddir)/frontend/libpifeproto.la \
@@ -92,22 +84,18 @@ $(PROTOBUF_LIBS) $(GRPC_LIBS)
 
 test_server_no_pipeline_config_SOURCES = $(test_server_common_source) \
 server/test_no_pipeline_config.cpp
-test_server_no_pipeline_config_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_server_no_pipeline_config_LDADD = $(test_server_libs)
 
 test_server_gnmi_SOURCES = $(test_server_common_source) \
 server/test_gnmi.cpp
-test_server_gnmi_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_server_gnmi_LDADD = $(test_server_libs)
 
 test_server_arbitration_SOURCES = $(test_server_common_source) \
 server/test_arbitration.cpp
-test_server_arbitration_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_server_arbitration_LDADD = $(test_server_libs)
 
 test_pi_server_SOURCES = $(test_server_common_source) \
 server/test_pi_server.cpp
-test_pi_server_LDFLAGS = $(LD_IGNORE_UNRESOLVED_SYMBOLS)
 test_pi_server_LDADD = $(test_server_libs)
 
 check_PROGRAMS = \

--- a/proto/tests/matchers.h
+++ b/proto/tests/matchers.h
@@ -30,6 +30,7 @@
 #include "p4/v1/p4runtime.pb.h"
 
 #include "PI/pi.h"
+#include "PI/pi_clone.h"
 
 namespace pi {
 namespace proto {
@@ -196,6 +197,28 @@ class TableEntryMatcher_Indirect
 inline Matcher<const pi_table_entry_t *> CorrectTableEntryIndirect(
     pi_indirect_handle_t h) {
   return MakeMatcher(new TableEntryMatcher_Indirect(h));
+}
+
+class CloneSessionConfigMatcher
+    : public MatcherInterface<const pi_clone_session_config_t *> {
+ public:
+  explicit CloneSessionConfigMatcher(
+      const p4::v1::CloneSessionEntry &session_entry);
+
+  bool MatchAndExplain(const pi_clone_session_config_t *session_config,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+ private:
+  p4::v1::CloneSessionEntry session_entry;
+};
+
+inline Matcher<const pi_clone_session_config_t *> CorrectCloneSessionConfig(
+    const p4::v1::CloneSessionEntry &session_entry) {
+  return MakeMatcher(new CloneSessionConfigMatcher(session_entry));
 }
 
 }  // namespace testing

--- a/proto/tests/mock_switch.cpp
+++ b/proto/tests/mock_switch.cpp
@@ -535,6 +535,19 @@ class DummyPRE {
     return PI_STATUS_SUCCESS;
   }
 
+  pi_status_t clone_session_set(
+      pi_clone_session_id_t clone_session_id,
+      const pi_clone_session_config_t *clone_session_config) {
+    (void)clone_session_id;
+    (void)clone_session_config;
+    return PI_STATUS_SUCCESS;
+  }
+
+  pi_status_t clone_session_reset(pi_clone_session_id_t clone_session_id) {
+    (void)clone_session_id;
+    return PI_STATUS_SUCCESS;
+  }
+
  private:
   struct McNode {
     pi_mc_node_handle_t node_handle;
@@ -744,6 +757,16 @@ class DummySwitch {
     return pre.mc_grp_detach_node(grp_handle, node_handle);
   }
 
+  pi_status_t clone_session_set(
+      pi_clone_session_id_t clone_session_id,
+      const pi_clone_session_config_t *clone_session_config) {
+    return pre.clone_session_set(clone_session_id, clone_session_config);
+  }
+
+  pi_status_t clone_session_reset(pi_clone_session_id_t clone_session_id) {
+    return pre.clone_session_reset(clone_session_id);
+  }
+
   void set_p4info(const pi_p4info_t *p4info) {
     this->p4info = p4info;
   }
@@ -872,6 +895,11 @@ DummySwitchMock::DummySwitchMock(device_id_t device_id)
       .WillByDefault(Invoke(sw_, &DummySwitch::mc_grp_attach_node));
   ON_CALL(*this, mc_grp_detach_node(_, _))
       .WillByDefault(Invoke(sw_, &DummySwitch::mc_grp_detach_node));
+
+  ON_CALL(*this, clone_session_set(_, _))
+      .WillByDefault(Invoke(sw_, &DummySwitch::clone_session_set));
+  ON_CALL(*this, clone_session_reset(_))
+      .WillByDefault(Invoke(sw_, &DummySwitch::clone_session_reset));
 }
 
 DummySwitchMock::~DummySwitchMock() = default;
@@ -1296,6 +1324,22 @@ pi_status_t _pi_mc_grp_detach_node(pi_mc_session_handle_t,
                                    pi_mc_node_handle_t node_handle) {
   return DeviceResolver::get_switch(dev_id)->mc_grp_detach_node(
       grp_handle, node_handle);
+}
+
+pi_status_t _pi_clone_session_set(
+    pi_session_handle_t,
+    pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config) {
+  return DeviceResolver::get_switch(dev_tgt.dev_id)->clone_session_set(
+      clone_session_id, clone_session_config);
+}
+
+pi_status_t _pi_clone_session_reset(pi_session_handle_t,
+                                    pi_dev_tgt_t dev_tgt,
+                                    pi_clone_session_id_t clone_session_id) {
+  return DeviceResolver::get_switch(dev_tgt.dev_id)->clone_session_reset(
+      clone_session_id);
 }
 
 pi_status_t _pi_learn_msg_ack(pi_session_handle_t,

--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -31,6 +31,7 @@
 #include <cstdint>
 
 #include "PI/pi.h"
+#include "PI/pi_clone.h"
 #include "PI/pi_mc.h"
 
 namespace pi {
@@ -159,6 +160,11 @@ class DummySwitchMock {
                pi_status_t(pi_mc_grp_handle_t, pi_mc_node_handle_t));
   MOCK_METHOD2(mc_grp_detach_node,
                pi_status_t(pi_mc_grp_handle_t, pi_mc_node_handle_t));
+
+  MOCK_METHOD2(clone_session_set,
+               pi_status_t(pi_clone_session_id_t,
+                           const pi_clone_session_config_t *));
+  MOCK_METHOD1(clone_session_reset, pi_status_t(pi_clone_session_id_t));
 
  private:
   std::unique_ptr<DummySwitch> sw;

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -211,7 +211,7 @@ class DeviceMgrTest : public ::testing::Test {
   DeviceMgr::Status add_entry(p4v1::TableEntry *entry) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
+    update->set_type(p4v1::Update::INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_table_entry(entry);
     auto status = mgr.write(request);
@@ -403,7 +403,7 @@ class MatchTableTest
                                 int priority = 0,
                                 uint64_t controller_metadata = 0);
 
-  DeviceMgr::Status generic_write(p4v1::Update_Type type,
+  DeviceMgr::Status generic_write(p4v1::Update::Type type,
                                   p4v1::TableEntry *entry);
   DeviceMgr::Status add_one(p4v1::TableEntry *entry);
   DeviceMgr::Status remove(p4v1::TableEntry *entry);
@@ -417,7 +417,8 @@ class MatchTableTest
 };
 
 DeviceMgr::Status
-MatchTableTest::generic_write(p4v1::Update_Type type, p4v1::TableEntry *entry) {
+MatchTableTest::generic_write(p4v1::Update::Type type,
+                              p4v1::TableEntry *entry) {
   p4v1::WriteRequest request;
   auto update = request.add_updates();
   update->set_type(type);
@@ -430,17 +431,17 @@ MatchTableTest::generic_write(p4v1::Update_Type type, p4v1::TableEntry *entry) {
 
 DeviceMgr::Status
 MatchTableTest::add_one(p4v1::TableEntry *entry) {
-  return generic_write(p4v1::Update_Type_INSERT, entry);
+  return generic_write(p4v1::Update::INSERT, entry);
 }
 
 DeviceMgr::Status
 MatchTableTest::remove(p4v1::TableEntry *entry) {
-  return generic_write(p4v1::Update_Type_DELETE, entry);
+  return generic_write(p4v1::Update::DELETE, entry);
 }
 
 DeviceMgr::Status
 MatchTableTest::modify(p4v1::TableEntry *entry) {
-  return generic_write(p4v1::Update_Type_MODIFY, entry);
+  return generic_write(p4v1::Update::MODIFY, entry);
 }
 
 p4v1::TableEntry
@@ -717,19 +718,19 @@ TEST_P(MatchTableTest, WriteBatchWithError) {
   p4v1::WriteRequest request;
   {
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_DELETE);
+    update->set_type(p4v1::Update::DELETE);
     update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
     expected_errors.push_back(Code::NOT_FOUND);
   }
   {
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
+    update->set_type(p4v1::Update::INSERT);
     update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
     expected_errors.push_back(Code::OK);
   }
   {
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
+    update->set_type(p4v1::Update::INSERT);
     update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
     expected_errors.push_back(Code::ALREADY_EXISTS);
   }
@@ -784,7 +785,7 @@ class ActionProfTest : public DeviceMgrTest {
     return member;
   }
 
-  DeviceMgr::Status write_member(p4v1::Update_Type type,
+  DeviceMgr::Status write_member(p4v1::Update::Type type,
                                  p4v1::ActionProfileMember *member) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
@@ -797,15 +798,15 @@ class ActionProfTest : public DeviceMgrTest {
   }
 
   DeviceMgr::Status create_member(p4v1::ActionProfileMember *member) {
-    return write_member(p4v1::Update_Type_INSERT, member);
+    return write_member(p4v1::Update::INSERT, member);
   }
 
   DeviceMgr::Status modify_member(p4v1::ActionProfileMember *member) {
-    return write_member(p4v1::Update_Type_MODIFY, member);
+    return write_member(p4v1::Update::MODIFY, member);
   }
 
   DeviceMgr::Status delete_member(p4v1::ActionProfileMember *member) {
-    return write_member(p4v1::Update_Type_DELETE, member);
+    return write_member(p4v1::Update::DELETE, member);
   }
 
   void add_member_to_group(p4v1::ActionProfileGroup *group,
@@ -833,7 +834,7 @@ class ActionProfTest : public DeviceMgrTest {
     return make_group(group_id, members.begin(), members.end());
   }
 
-  DeviceMgr::Status write_group(p4v1::Update_Type type,
+  DeviceMgr::Status write_group(p4v1::Update::Type type,
                                 p4v1::ActionProfileGroup *group) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
@@ -846,15 +847,15 @@ class ActionProfTest : public DeviceMgrTest {
   }
 
   DeviceMgr::Status create_group(p4v1::ActionProfileGroup *group) {
-    return write_group(p4v1::Update_Type_INSERT, group);
+    return write_group(p4v1::Update::INSERT, group);
   }
 
   DeviceMgr::Status modify_group(p4v1::ActionProfileGroup *group) {
-    return write_group(p4v1::Update_Type_MODIFY, group);
+    return write_group(p4v1::Update::MODIFY, group);
   }
 
   DeviceMgr::Status delete_group(p4v1::ActionProfileGroup *group) {
-    return write_group(p4v1::Update_Type_DELETE, group);
+    return write_group(p4v1::Update::DELETE, group);
   }
 };
 
@@ -1136,7 +1137,7 @@ class MatchTableIndirectTest : public DeviceMgrTest {
     auto member = make_member(member_id, param_v);
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
+    update->set_type(p4v1::Update::INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_action_profile_member(&member);
     auto status = mgr.write(request);
@@ -1168,7 +1169,7 @@ class MatchTableIndirectTest : public DeviceMgrTest {
     auto group = make_group(group_id, members_begin, members_end);
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
+    update->set_type(p4v1::Update::INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_action_profile_group(&group);
     auto status = mgr.write(request);
@@ -1193,7 +1194,7 @@ class MatchTableIndirectTest : public DeviceMgrTest {
   DeviceMgr::Status add_indirect_entry(p4v1::TableEntry *entry) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
+    update->set_type(p4v1::Update::INSERT);
     auto entity = update->mutable_entity();
     entity->set_allocated_table_entry(entry);
     auto status = mgr.write(request);
@@ -1334,7 +1335,7 @@ class DirectMeterTest : public ExactOneTest {
   DeviceMgr::Status set_meter(p4v1::DirectMeterEntry *direct_meter_entry) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_MODIFY);
+    update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_direct_meter_entry(direct_meter_entry);
     auto status = mgr.write(request);
@@ -1491,7 +1492,7 @@ class IndirectMeterTest : public DeviceMgrTest  {
   DeviceMgr::Status write_meter(p4v1::MeterEntry *meter_entry) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_MODIFY);
+    update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_meter_entry(meter_entry);
     auto status = mgr.write(request);
@@ -1567,7 +1568,7 @@ class DirectCounterTest : public ExactOneTest {
       p4v1::DirectCounterEntry *direct_counter_entry) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_MODIFY);
+    update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_direct_counter_entry(direct_counter_entry);
     auto status = mgr.write(request);
@@ -1738,7 +1739,7 @@ class IndirectCounterTest : public DeviceMgrTest  {
   DeviceMgr::Status write_counter(p4v1::CounterEntry *counter_entry) {
     p4v1::WriteRequest request;
     auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_MODIFY);
+    update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
     entity->set_allocated_counter_entry(counter_entry);
     auto status = mgr.write(request);
@@ -2278,50 +2279,68 @@ TEST_F(TernaryTwoTest, MissingMatchField) {
 }
 
 
-class PREMulticastTest : public DeviceMgrTest {
+template <typename Entry,
+          Entry *(::p4v1::PacketReplicationEngineEntry::*Accessor)()>
+class PRETestBase : public DeviceMgrTest {
  protected:
-  using GroupEntry = ::p4v1::MulticastGroupEntry;
-
-  DeviceMgr::Status create_group(const GroupEntry &group) {
-    return write_group(group, p4v1::Update_Type_INSERT);
+  DeviceMgr::Status create_entry(const Entry &entry) {
+    return write_entry(entry, p4v1::Update::INSERT);
   }
 
-  DeviceMgr::Status modify_group(const GroupEntry &group) {
-    return write_group(group, p4v1::Update_Type_MODIFY);
+  DeviceMgr::Status modify_entry(const Entry &entry) {
+    return write_entry(entry, p4v1::Update::MODIFY);
   }
 
-  DeviceMgr::Status delete_group(const GroupEntry &group) {
-    return write_group(group, p4v1::Update_Type_DELETE);
+  DeviceMgr::Status delete_entry(const Entry &entry) {
+    return write_entry(entry, p4v1::Update::DELETE);
   }
 
   struct ReplicaMgr {
-    explicit ReplicaMgr(GroupEntry *group)
-        : group(group) { }
+    explicit ReplicaMgr(Entry *entry)
+        : entry(entry) { }
 
     ReplicaMgr &push_back(int32_t port, int32_t rid) {
-      auto r = group->add_replicas();
+      auto r = entry->add_replicas();
       r->set_egress_port(port);
       r->set_instance(rid);
       return *this;
     }
 
     void pop_back() {
-      group->mutable_replicas()->RemoveLast();
+      entry->mutable_replicas()->RemoveLast();
     }
 
-    GroupEntry *group;
+    Entry *entry;
   };
 
  private:
-  DeviceMgr::Status write_group(const GroupEntry &group,
-                                p4v1::Update_Type type) {
+  DeviceMgr::Status write_entry(const Entry &entry, p4v1::Update::Type type) {
     p4v1::WriteRequest request;
     auto *update = request.add_updates();
     update->set_type(type);
     auto *entity = update->mutable_entity();
     auto *pre_entry = entity->mutable_packet_replication_engine_entry();
-    pre_entry->mutable_multicast_group_entry()->CopyFrom(group);
+    (pre_entry->*Accessor)()->CopyFrom(entry);
     return mgr.write(request);
+  }
+};
+
+class PREMulticastTest : public PRETestBase<
+  ::p4v1::MulticastGroupEntry,
+  &::p4v1::PacketReplicationEngineEntry::mutable_multicast_group_entry> {
+ protected:
+  using GroupEntry = ::p4v1::MulticastGroupEntry;
+
+  DeviceMgr::Status create_group(const GroupEntry &group) {
+    return create_entry(group);
+  }
+
+  DeviceMgr::Status modify_group(const GroupEntry &group) {
+    return modify_entry(group);
+  }
+
+  DeviceMgr::Status delete_group(const GroupEntry &group) {
+    return delete_entry(group);
   }
 };
 
@@ -2399,17 +2418,60 @@ TEST_F(PREMulticastTest, Read) {
   EXPECT_EQ(status.code(), Code::UNIMPLEMENTED);
 }
 
-class PRECloningTest : public DeviceMgrTest { };
+class PRECloningTest : public PRETestBase<
+  ::p4v1::CloneSessionEntry,
+  &::p4v1::PacketReplicationEngineEntry::mutable_clone_session_entry> {
+ protected:
+  using SessionEntry = ::p4v1::CloneSessionEntry;
+
+  DeviceMgr::Status create_session(const SessionEntry &session) {
+    return create_entry(session);
+  }
+
+  DeviceMgr::Status modify_session(const SessionEntry &session) {
+    return modify_entry(session);
+  }
+
+  DeviceMgr::Status delete_session(const SessionEntry &session) {
+    return delete_entry(session);
+  }
+};
 
 TEST_F(PRECloningTest, Write) {
-  p4v1::WriteRequest request;
-  auto *update = request.add_updates();
-  update->set_type(p4v1::Update_Type_MODIFY);
-  auto *entity = update->mutable_entity();
-  auto *pre_entry = entity->mutable_packet_replication_engine_entry();
-  pre_entry->mutable_clone_session_entry();
-  auto status = mgr.write(request);
-  EXPECT_EQ(status, OneExpectedError(Code::UNIMPLEMENTED));
+  int32_t session_id = 66;
+  SessionEntry session;
+  session.set_session_id(session_id);
+  int32_t port1 = 1, port2 = 2, rid = 1;
+  ReplicaMgr replicas(&session);
+  replicas.push_back(port1, rid).push_back(port2, rid);
+  EXPECT_CALL(*mock, mc_grp_create(_, _));
+  EXPECT_CALL(*mock, mc_node_create(rid, _, _, _))
+      .With(Args<2, 1>(ElementsAre(port1, port2)));
+  EXPECT_CALL(*mock, mc_grp_attach_node(_, _));
+  EXPECT_CALL(
+      *mock, clone_session_set(session_id, CorrectCloneSessionConfig(session)));
+  {
+    auto status = create_session(session);
+    ASSERT_EQ(status.code(), Code::OK);
+  }
+  auto grp_h = mock->get_mc_grp_handle();
+
+  replicas.pop_back();
+  EXPECT_CALL(*mock, mc_node_modify(_, _, _))
+      .With(Args<2, 1>(ElementsAre(port1)));
+  {
+    auto status = modify_session(session);
+    ASSERT_EQ(status.code(), Code::OK);
+  }
+
+  EXPECT_CALL(*mock, mc_grp_detach_node(grp_h, _));
+  EXPECT_CALL(*mock, mc_node_delete(_));
+  EXPECT_CALL(*mock, mc_grp_delete(grp_h));
+  EXPECT_CALL(*mock, clone_session_reset(session_id));
+  {
+    auto status = delete_session(session);
+    ASSERT_EQ(status.code(), Code::OK);
+  }
 }
 
 TEST_F(PRECloningTest, Read) {
@@ -2508,7 +2570,7 @@ class PVSTest : public DeviceMgrTest { };
 TEST_F(PVSTest, Write) {
   p4v1::WriteRequest request;
   auto *update = request.add_updates();
-  update->set_type(p4v1::Update_Type_MODIFY);
+  update->set_type(p4v1::Update::MODIFY);
   auto *entity = update->mutable_entity();
   auto *pvs_entry = entity->mutable_value_set_entry();
   (void) pvs_entry;
@@ -2533,7 +2595,7 @@ class RegisterTest : public DeviceMgrTest { };
 TEST_F(RegisterTest, Write) {
   p4v1::WriteRequest request;
   auto *update = request.add_updates();
-  update->set_type(p4v1::Update_Type_MODIFY);
+  update->set_type(p4v1::Update::MODIFY);
   auto *entity = update->mutable_entity();
   auto *register_entry = entity->mutable_register_entry();
   (void) register_entry;
@@ -2557,7 +2619,7 @@ class DigestTest : public DeviceMgrTest { };
 TEST_F(DigestTest, Write) {
   p4v1::WriteRequest request;
   auto *update = request.add_updates();
-  update->set_type(p4v1::Update_Type_MODIFY);
+  update->set_type(p4v1::Update::MODIFY);
   auto *entity = update->mutable_entity();
   auto *register_entry = entity->mutable_register_entry();
   (void) register_entry;
@@ -2617,28 +2679,28 @@ TEST_F(ReadExclusiveAccess, ConcurrentReadAndWrites) {
     {
       auto &request = requests.at(0);
       auto *update = request.add_updates();
-      update->set_type(p4v1::Update_Type_INSERT);
+      update->set_type(p4v1::Update::INSERT);
       auto *entity = update->mutable_entity();
       entity->mutable_action_profile_member()->CopyFrom(member);
     }
     {
       auto &request = requests.at(1);
       auto *update = request.add_updates();
-      update->set_type(p4v1::Update_Type_INSERT);
+      update->set_type(p4v1::Update::INSERT);
       auto *entity = update->mutable_entity();
       entity->mutable_table_entry()->CopyFrom(entry);
     }
     {
       auto &request = requests.at(2);
       auto *update = request.add_updates();
-      update->set_type(p4v1::Update_Type_DELETE);
+      update->set_type(p4v1::Update::DELETE);
       auto *entity = update->mutable_entity();
       entity->mutable_table_entry()->CopyFrom(entry);
     }
     {
       auto &request = requests.at(3);
       auto *update = request.add_updates();
-      update->set_type(p4v1::Update_Type_DELETE);
+      update->set_type(p4v1::Update::DELETE);
       auto *entity = update->mutable_entity();
       entity->mutable_action_profile_member()->CopyFrom(member);
     }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,7 @@ pi_meter.c \
 pi_learn.c \
 pi_value.c \
 pi_mc.c \
+pi_clone.c \
 device_map.c \
 device_map.h
 

--- a/src/pi_clone.c
+++ b/src/pi_clone.c
@@ -1,0 +1,40 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_base.h>
+#include <PI/pi_clone.h>
+#include <PI/pi_mc.h>
+#include <PI/target/pi_clone_imp.h>
+
+#include <stdlib.h>
+
+pi_status_t pi_clone_session_set(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config) {
+  return _pi_clone_session_set(session_handle, dev_tgt, clone_session_id,
+                               clone_session_config);
+}
+
+pi_status_t pi_clone_session_reset(pi_session_handle_t session_handle,
+                                   pi_dev_tgt_t dev_tgt,
+                                   pi_clone_session_id_t clone_session_id) {
+  return _pi_clone_session_reset(session_handle, dev_tgt, clone_session_id);
+}

--- a/targets/bmv2/Makefile.am
+++ b/targets/bmv2/Makefile.am
@@ -14,6 +14,7 @@ pi_counter_imp.cpp \
 pi_meter_imp.cpp \
 pi_learn_imp.cpp \
 pi_mc_imp.cpp \
+pi_clone_imp.cpp \
 conn_mgr.h \
 conn_mgr.cpp \
 common.h \

--- a/targets/bmv2/pi_clone_imp.cpp
+++ b/targets/bmv2/pi_clone_imp.cpp
@@ -1,0 +1,49 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_clone.h>
+#include <PI/pi_mc.h>
+#include <PI/target/pi_clone_imp.h>
+
+extern "C" {
+
+pi_status_t _pi_clone_session_set(
+    pi_session_handle_t session_handle,
+    pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)clone_session_id;
+  (void)clone_session_config;
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+}
+
+pi_status_t _pi_clone_session_reset(
+    pi_session_handle_t session_handle,
+    pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)clone_session_id;
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+}
+
+}

--- a/targets/dummy/Makefile.am
+++ b/targets/dummy/Makefile.am
@@ -10,6 +10,7 @@ pi_counter_imp.c \
 pi_meter_imp.c \
 pi_learn_imp.c \
 pi_mc_imp.c \
+pi_clone_imp.c \
 func_counter.c \
 func_counter.h
 

--- a/targets/dummy/pi_clone_imp.c
+++ b/targets/dummy/pi_clone_imp.c
@@ -1,0 +1,47 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_clone.h>
+#include <PI/pi_mc.h>
+#include <PI/target/pi_clone_imp.h>
+
+#include "func_counter.h"
+
+pi_status_t _pi_clone_session_set(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)clone_session_id;
+  (void)clone_session_config;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_clone_session_reset(pi_session_handle_t session_handle,
+                                    pi_dev_tgt_t dev_tgt,
+                                    pi_clone_session_id_t clone_session_id) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)clone_session_id;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}

--- a/targets/rpc/Makefile.am
+++ b/targets/rpc/Makefile.am
@@ -12,6 +12,7 @@ pi_counter_imp.c \
 pi_meter_imp.c \
 pi_learn_imp.c \
 pi_mc_imp.c \
+pi_clone_imp.c \
 notifications.c
 
 libpi_rpc_la_LIBADD = \

--- a/targets/rpc/pi_clone_imp.c
+++ b/targets/rpc/pi_clone_imp.c
@@ -1,0 +1,43 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <PI/pi_clone.h>
+#include <PI/pi_mc.h>
+#include <PI/target/pi_clone_imp.h>
+
+pi_status_t _pi_clone_session_set(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)clone_session_id;
+  (void)clone_session_config;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_clone_session_reset(pi_session_handle_t session_handle,
+                                    pi_dev_tgt_t dev_tgt,
+                                    pi_clone_session_id_t clone_session_id) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)clone_session_id;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
This required defining some lower-level PI C functions to match the
implementation of other features. The PI functions are similar to the
ones exposed by bmv2.

This commit implements the new PI functions for bmv2 although the
implementation is not tested (unfortunately there is no simple way to
test without also implementing the functions for the deprecated rpc
target and in the CLI). However, we include unit tests for the mapping
from P4Runtime message to PI. Note that most people do not use this
implementation for bmv2 anyway, but instead use simple_switch_grpc.