### PR TITLE
Add ability to register a third party gNMI service

### DIFF
--- a/proto/server/PI/proto/pi_server.h
+++ b/proto/server/PI/proto/pi_server.h
@@ -38,7 +38,7 @@ void PIGrpcServerRunAddr(const char *server_address);
 // service. Note that the implementation will expect the void* must be a
 // pointer of type gnmi::gNMI::Service, and free it as a part of
 // PIGrpcServerCleanup
-void PIGrpcServerRunAddrGnmi(const char *server_address, void* gnmi_service);
+void PIGrpcServerRunAddrGnmi(const char *server_address, void *gnmi_service);
 
 // Get port number bound to the server
 int PIGrpcServerGetPort();

--- a/proto/server/PI/proto/pi_server.h
+++ b/proto/server/PI/proto/pi_server.h
@@ -22,18 +22,23 @@
 
 #include "stdint.h"
 
-#include "gnmi/gnmi.grpc.pb.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // Start server and bind to default address (0.0.0.0:50051)
-void PIGrpcServerRun(gnmi::gNMI::Service* gnmi_service = nullptr);
+void PIGrpcServerRun();
+
 // Start server and bind to given address (eg. localhost:1234,
 // 192.168.1.1:31416, [::1]:27182, etc.)
-void PIGrpcServerRunAddr(const char *server_address,
-    gnmi::gNMI::Service* gnmi_service = nullptr);
+void PIGrpcServerRunAddr(const char *server_address);
+
+// Start server and bind to given address (eg. localhost:1234,
+// 192.168.1.1:31416, [::1]:27182, etc.) and an optional third-party gNMI
+// service. Note that the implementation will expect the void* must be a
+// pointer of type gnmi::gNMI::Service, and free it as a part of
+// PIGrpcServerCleanup
+void PIGrpcServerRunAddrGnmi(const char *server_address, void* gnmi_service);
 
 // Get port number bound to the server
 int PIGrpcServerGetPort();

--- a/proto/server/PI/proto/pi_server.h
+++ b/proto/server/PI/proto/pi_server.h
@@ -22,15 +22,18 @@
 
 #include "stdint.h"
 
+#include "gnmi/gnmi.grpc.pb.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // Start server and bind to default address (0.0.0.0:50051)
-void PIGrpcServerRun();
+void PIGrpcServerRun(gnmi::gNMI::Service* gnmi_service = nullptr);
 // Start server and bind to given address (eg. localhost:1234,
 // 192.168.1.1:31416, [::1]:27182, etc.)
-void PIGrpcServerRunAddr(const char *server_address);
+void PIGrpcServerRunAddr(const char *server_address,
+    gnmi::gNMI::Service* gnmi_service = nullptr);
 
 // Get port number bound to the server
 int PIGrpcServerGetPort();

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -538,7 +538,7 @@ pi::server::ServerData *server_data;
 
 extern "C" {
 
-void PIGrpcServerRunAddrGnmi(const char *server_address, void* gnmi_service) {
+void PIGrpcServerRunAddrGnmi(const char *server_address, void *gnmi_service) {
   server_data = new ::pi::server::ServerData();
   server_data->server_address = std::string(server_address);
   auto &builder = server_data->builder;
@@ -548,7 +548,7 @@ void PIGrpcServerRunAddrGnmi(const char *server_address, void* gnmi_service) {
   builder.RegisterService(&server_data->pi_service);
   if (gnmi_service != nullptr) {
     server_data->gnmi_service = std::unique_ptr<gnmi::gNMI::Service>(
-            static_cast<gnmi::gNMI::Service*>(gnmi_service));
+            static_cast<gnmi::gNMI::Service *>(gnmi_service));
   } else {
 #ifdef WITH_SYSREPO
     server_data->gnmi_service = ::pi::server::make_gnmi_service_sysrepo();

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -538,8 +538,7 @@ pi::server::ServerData *server_data;
 
 extern "C" {
 
-void PIGrpcServerRunAddr(const char *server_address,
-  gnmi::gNMI::Service* gnmi_service) {
+void PIGrpcServerRunAddrGnmI(const char *server_address, void* gnmi_service) {
   server_data = new ::pi::server::ServerData();
   server_data->server_address = std::string(server_address);
   auto &builder = server_data->builder;
@@ -548,7 +547,8 @@ void PIGrpcServerRunAddr(const char *server_address,
     &server_data->server_port);
   builder.RegisterService(&server_data->pi_service);
   if (gnmi_service != nullptr) {
-    server_data->gnmi_service.reset(gnmi_service);
+    server_data->gnmi_service = std::unique_ptr<gnmi::gNMI::Service>(
+            static_cast<gnmi::gNMI::Service*>(gnmi_service));
   } else {
 #ifdef WITH_SYSREPO
     server_data->gnmi_service = ::pi::server::make_gnmi_service_sysrepo();
@@ -563,8 +563,12 @@ void PIGrpcServerRunAddr(const char *server_address,
   std::cout << "Server listening on " << server_data->server_address << "\n";
 }
 
-void PIGrpcServerRun(gnmi::gNMI::Service* gnmi_service) {
-  PIGrpcServerRunAddr("0.0.0.0:50051", gnmi_service);
+void PIGrpcServerRunAddr(const char *server_address) {
+  PIGrpcServerRunAddrGnmi(server_address, nullptr);
+}
+
+void PIGrpcServerRun() {
+  PIGrpcServerRunAddrGnmi("0.0.0.0:50051", nullptr);
 }
 
 int PIGrpcServerGetPort() {

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -538,7 +538,7 @@ pi::server::ServerData *server_data;
 
 extern "C" {
 
-void PIGrpcServerRunAddrGnmI(const char *server_address, void* gnmi_service) {
+void PIGrpcServerRunAddrGnmi(const char *server_address, void* gnmi_service) {
   server_data = new ::pi::server::ServerData();
   server_data->server_address = std::string(server_address);
   auto &builder = server_data->builder;


### PR DESCRIPTION
This PR allows a third-party gNMI service to be registered with the pi server