### PR TITLE
Support for one-shot action selector programming mode

### DIFF
--- a/proto/frontend/src/common.h
+++ b/proto/frontend/src/common.h
@@ -23,10 +23,14 @@
 
 #include <PI/pi.h>
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
+
+#include "report_error.h"
 
 namespace pi {
 
@@ -39,6 +43,28 @@ using Status = ::google::rpc::Status;
 
 namespace common {
 
+struct SessionTemp;
+
+struct LocalCleanupIface {
+  virtual ~LocalCleanupIface() { }
+
+  virtual Status cleanup(const SessionTemp &session) = 0;
+  virtual void cancel() = 0;
+};
+
+// SessionTemp is used to manage a P4Runtime WriteRequest message. All
+// operations in the message are executed as part of the same PI batch, the
+// SessionTemp destructor will block until all operations have been completed in
+// HW.
+// SessionTemp also has a mechanism to perform some low-level cleanup tasks in
+// case of an unexpected error during an unexpected error (in the lower layers
+// of the stack). For example, when using one-shot action selector programming
+// for an indirect table, a single P4Runtime update may map to many PI calls. If
+// one of these calls fail, it may be desirable to undo all previous PI
+// calls. This isn't as powerful as the P4Runtime semantics (not implemented
+// yet), but should be ok for simple things like action profile programming. If
+// one of the rollback / cleanup operations fail, we return a (serious) INTERNAL
+// error.
 struct SessionTemp {
   explicit SessionTemp(bool batch = false)
       : batch(batch) {
@@ -53,8 +79,48 @@ struct SessionTemp {
 
   pi_session_handle_t get() const { return sess; }
 
+  Status local_cleanup() {
+    int error_cnt = 0;
+    Status status;
+    for (auto task_it = cleanup_tasks.rbegin();
+         task_it != cleanup_tasks.rend();
+         ++task_it) {
+      status = (*task_it)->cleanup(*this);
+      if (IS_ERROR(status)) error_cnt++;
+    }
+    cleanup_tasks.clear();
+    cleanup_scopes.clear();
+    if (error_cnt == 0) RETURN_OK_STATUS();
+    if (error_cnt == 1) return status;
+    RETURN_ERROR_STATUS(
+        Code::INTERNAL,
+        "{} serious errors when encountered during cleanup; you may need to "
+        "reboot the device");
+  }
+
+  void cleanup_scope_push() {
+    cleanup_scopes.push_back(cleanup_tasks.size());
+  }
+
+  void cleanup_scope_pop() {
+    cleanup_tasks.resize(cleanup_scopes.back());
+    cleanup_scopes.pop_back();
+  }
+
+  LocalCleanupIface *cleanup_task_push(
+      std::unique_ptr<LocalCleanupIface> task) {
+    cleanup_tasks.push_back(std::move(task));
+    return cleanup_tasks.back().get();
+  }
+
+  LocalCleanupIface *cleanup_task_back() {
+    return cleanup_tasks.back().get();
+  }
+
   pi_session_handle_t sess;
   bool batch;
+  std::vector<std::unique_ptr<LocalCleanupIface> > cleanup_tasks;
+  std::vector<size_t> cleanup_scopes;
 };
 
 Code check_proto_bytestring(const std::string &str, size_t nbits);
@@ -65,10 +131,7 @@ std::string range_default_lo(size_t nbits);
 std::string range_default_hi(size_t nbits);
 
 inline Status make_invalid_p4_id_status() {
-  Status status;
-  status.set_code(Code::INVALID_ARGUMENT);
-  status.set_message("Invalid P4 id");
-  return status;
+  RETURN_ERROR_STATUS(Code::INVALID_ARGUMENT, "Invalid P4 id");
 }
 
 }  // namespace common

--- a/proto/frontend/src/table_info_store.h
+++ b/proto/frontend/src/table_info_store.h
@@ -45,13 +45,20 @@ class TableInfoStore {
   // operator.
   using MatchKey = pi::MatchKey;
 
-  // wish I could use boost::variant for these
   struct Data {
     Data(pi_entry_handle_t handle, uint64_t controller_metadata)
         : handle(handle), controller_metadata(controller_metadata) { }
 
+    Data(pi_entry_handle_t handle, uint64_t controller_metadata,
+         pi_indirect_handle_t oneshot_group_handle)
+        : handle(handle), controller_metadata(controller_metadata),
+          is_oneshot(true), oneshot_group_handle(oneshot_group_handle) { }
+
     const pi_entry_handle_t handle{0};
     uint64_t controller_metadata{0};
+    // wish I could use boost::optional here
+    bool is_oneshot{false};
+    pi_indirect_handle_t oneshot_group_handle{0};
   };
 
   using Mutex = std::mutex;

--- a/proto/tests/matchers.cpp
+++ b/proto/tests/matchers.cpp
@@ -30,6 +30,8 @@
 #include "PI/pi.h"
 #include "PI/pi_clone.h"
 
+#include "google/rpc/code.pb.h"
+
 #include "matchers.h"
 
 using p4::v1::CounterData;
@@ -38,6 +40,23 @@ using p4::v1::MeterConfig;
 namespace pi {
 namespace proto {
 namespace testing {
+
+bool
+IsOkMatcher::MatchAndExplain(::google::rpc::Status status,
+                             MatchResultListener *listener) const {
+  (void) listener;
+  return status.code() == ::google::rpc::Code::OK;
+}
+
+void
+IsOkMatcher::DescribeTo(std::ostream *os) const {
+  *os << "is OK";
+}
+
+void
+IsOkMatcher::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not OK";
+}
 
 MatchKeyMatcher::MatchKeyMatcher(pi_p4_id_t t_id, const std::string &v)
     : t_id(t_id), v(v) { }

--- a/proto/tests/matchers.h
+++ b/proto/tests/matchers.h
@@ -41,6 +41,22 @@ using ::testing::Matcher;
 using ::testing::MatcherInterface;
 using ::testing::MatchResultListener;
 
+class IsOkMatcher : public MatcherInterface<::google::rpc::Status> {
+  bool MatchAndExplain(::google::rpc::Status status,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+};
+
+inline Matcher<::google::rpc::Status> IsOk() {
+  return MakeMatcher(new IsOkMatcher());
+}
+
+#define ASSERT_OK(status) ASSERT_THAT(status, IsOk())
+#define EXPECT_OK(status) EXPECT_THAT(status, IsOk())
+
 // This is a very verbose matcher but it has the advantage to print convenient
 // error messages. Not sure I could achieve such a nice result by only using
 // googlemock base matchers (e.g. Field...)


### PR DESCRIPTION
P4Runtime has introduced a new mode to enable easier programming of
indirect tables which use an action selector. This new mode is called
"one shot". This commit introduces support for this in the reference
P4Runtime implementation built on top of PI.

Because one P4Runtime operation for one-shot programming may translate
to many PI function calls, we add the ability to do some rollback in
case of failure. This is not as powerful as the P4Runtime transation
semantics, but it should work for simple operations, like rolling back
creation of members & groups.

We chose to implement one-shot table MODIFY by first creating a new
group and adding the necessary members, then swapping the old group
pointer with the new one in the table entry. This means that we need
enough space in memory to hold the extra group. Note that the current
implementation always creates a group, even if the P4Runtime
ActionProfileActionSet only includes a single action.

The specification states that the 2 programming modes cannot be used
simultaneously for a given action selector. This commit implements this
check. If the action selector becomes empty, we enable the client to
switch modes.

Just like for "manual" action selector programming, we do not have any
support for weight and watch yet.

Finally this commit also adds the ASSERT_OK and EXPECT_OK macros for
gTest which enable us top check if the Status object returned by
DeviceMgr is OK in a less verbose fashion. Note that existing unit tests
haven't been updated yet to use these new macros.