### PR TITLE
P4Runtime support for response_type in GetForwardingPipelineConfig

### DIFF
--- a/proto/frontend/PI/frontends/proto/device_mgr.h
+++ b/proto/frontend/PI/frontends/proto/device_mgr.h
@@ -56,10 +56,12 @@ class DeviceMgr {
   // New pipeline_config_set and pipeline_config_get methods to replace init,
   // update_start and update_end
   Status pipeline_config_set(
-      p4::v1::SetForwardingPipelineConfigRequest_Action action,
+      p4::v1::SetForwardingPipelineConfigRequest::Action action,
       const p4::v1::ForwardingPipelineConfig &config);
 
-  Status pipeline_config_get(p4::v1::ForwardingPipelineConfig *config);
+  Status pipeline_config_get(
+      p4::v1::GetForwardingPipelineConfigRequest::ResponseType response_type,
+      p4::v1::ForwardingPipelineConfig *config);
 
   // New write and read methods, meant to replace all the methods below
   Status write(const p4::v1::WriteRequest &request);

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -416,7 +416,8 @@ class P4RuntimeServiceImpl : public p4v1::P4Runtime::Service {
     SIMPLELOG << "P4Runtime GetForwardingPipelineConfig\n";
     auto device_mgr = Devices::get(request->device_id())->get_p4_mgr();
     if (device_mgr == nullptr) return no_pipeline_config_status();
-    auto status = device_mgr->pipeline_config_get(rep->mutable_config());
+    auto status = device_mgr->pipeline_config_get(
+        request->response_type(), rep->mutable_config());
     return to_grpc_status(status);
   }
 

--- a/proto/tests/test_proto_fe_packet_io.cpp
+++ b/proto/tests/test_proto_fe_packet_io.cpp
@@ -29,6 +29,7 @@
 
 #include "google/rpc/code.pb.h"
 
+#include "matchers.h"
 #include "mock_switch.h"
 
 namespace p4v1 = ::p4::v1;
@@ -69,7 +70,7 @@ class DeviceMgrPacketIOTest : public ::testing::Test {
     // releasing resource before the assert to avoid double free in case the
     // assert is false
     config.release_p4info();
-    ASSERT_EQ(status.code(), Code::OK);
+    ASSERT_OK(status);
   }
 
   void TearDown() override { }

--- a/proto/tests/test_proto_fe_set_pipeline_config.cpp
+++ b/proto/tests/test_proto_fe_set_pipeline_config.cpp
@@ -122,7 +122,7 @@ TEST_F(DeviceMgrSetPipelineConfigTest, Reconcile) {
     auto status = set_pipeline_config(
         &p4info_proto_1,
         p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
-    ASSERT_EQ(status.code(), Code::OK);
+    ASSERT_OK(status);
   }
 
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));


### PR DESCRIPTION
A recent change to P4Runtime adds a cookie to the
ForwardingPipelineConfig message and enables the client to choose what
to retrieve when performing a GetForwardingPipelineConfig RPC (cookie
only, or cookie + p4info, or cookie + device config). The cookie is
convenient for example to verify which config is currently on the
switch, without retrieving the entire device config.

This requires storing the device config in the server. I chose to store
it in a temporary file, rather than in memory, as it can be quite large.

This commit also updates the p4runtime submodule ref point to 1.0.0-rc3.