### PR TITLE
Remove deprecated packet IO methods from DeviceMgr

### DIFF
--- a/proto/frontend/PI/frontends/proto/device_mgr.h
+++ b/proto/frontend/PI/frontends/proto/device_mgr.h
@@ -44,10 +44,7 @@ class DeviceMgr {
  public:
   using device_id_t = uint64_t;
   using p4_id_t = uint32_t;
-  // may change when we introduce specific error namespace
   using Status = ::google::rpc::Status;
-  using PacketInCb =
-      std::function<void(device_id_t, p4::v1::PacketIn *packet, void *cookie)>;
   using StreamMessageResponseCb = std::function<void(
       device_id_t, p4::v1::StreamMessageResponse *msg, void *cookie)>;
 
@@ -65,7 +62,6 @@ class DeviceMgr {
       p4::v1::GetForwardingPipelineConfigRequest::ResponseType response_type,
       p4::v1::ForwardingPipelineConfig *config);
 
-  // New write and read methods, meant to replace all the methods below
   Status write(const p4::v1::WriteRequest &request);
 
   Status read(const p4::v1::ReadRequest &request,
@@ -73,16 +69,8 @@ class DeviceMgr {
   Status read_one(const p4::v1::Entity &entity,
                   p4::v1::ReadResponse *response) const;
 
-  // TODO(antonin): deprecate and use stream_message_request_handle() for
-  // PacketOut as well
-  Status packet_out_send(const p4::v1::PacketOut &packet) const;
-
   Status stream_message_request_handle(
       const p4::v1::StreamMessageRequest &request);
-
-  // TODO(antonin): deprecate and use StreamMessageResponseCb for PacketIn as
-  // well.
-  void packet_in_register_cb(PacketInCb cb, void *cookie);
 
   void stream_message_response_register_cb(StreamMessageResponseCb cb,
                                            void *cookie);

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -67,7 +67,6 @@ namespace proto {
 using device_id_t = DeviceMgr::device_id_t;
 using p4_id_t = DeviceMgr::p4_id_t;
 using Status = DeviceMgr::Status;
-using PacketInCb = DeviceMgr::PacketInCb;
 using StreamMessageResponseCb = DeviceMgr::StreamMessageResponseCb;
 using Code = ::google::rpc::Code;
 using common::SessionTemp;
@@ -1408,13 +1407,10 @@ class DeviceMgrImp {
     RETURN_ERROR_STATUS(Code::UNKNOWN);  // unreachable
   }
 
-  void packet_in_register_cb(PacketInCb cb, void *cookie) {
-    packet_io.packet_in_register_cb(std::move(cb), cookie);
-  }
-
   void stream_message_response_register_cb(StreamMessageResponseCb cb,
                                            void *cookie) {
-    digest_mgr.stream_message_response_register_cb(std::move(cb), cookie);
+    packet_io.packet_in_register_cb(cb, cookie);
+    digest_mgr.stream_message_response_register_cb(cb, cookie);
   }
 
   Status counter_write(p4v1::Update::Type update,
@@ -2757,19 +2753,9 @@ DeviceMgr::read_one(const p4v1::Entity &entity,
 }
 
 Status
-DeviceMgr::packet_out_send(const p4v1::PacketOut &packet) const {
-  return pimp->packet_out_send(packet);
-}
-
-Status
 DeviceMgr::stream_message_request_handle(
     const p4::v1::StreamMessageRequest &request) {
   return pimp->stream_message_request_handle(request);
-}
-
-void
-DeviceMgr::packet_in_register_cb(PacketInCb cb, void *cookie) {
-  return pimp->packet_in_register_cb(std::move(cb), cookie);
 }
 
 void

--- a/proto/frontend/src/packet_io_mgr.h
+++ b/proto/frontend/src/packet_io_mgr.h
@@ -43,7 +43,7 @@ class PacketOutMutate;
 class PacketIOMgr {
  public:
   using device_id_t = DeviceMgr::device_id_t;
-  using PacketInCb = DeviceMgr::PacketInCb;
+  using StreamMessageResponseCb = DeviceMgr::StreamMessageResponseCb;
   using Status = DeviceMgr::Status;
 
   explicit PacketIOMgr(device_id_t device_id);
@@ -53,7 +53,7 @@ class PacketIOMgr {
 
   Status packet_out_send(const p4::v1::PacketOut &packet) const;
 
-  void packet_in_register_cb(PacketInCb cb, void *cookie);
+  void packet_in_register_cb(StreamMessageResponseCb cb, void *cookie);
 
   PacketIOMgr(const PacketIOMgr &) = delete;
   PacketIOMgr &operator=(const PacketIOMgr &) = delete;
@@ -71,7 +71,7 @@ class PacketIOMgr {
   std::unique_ptr<PacketInMutate> packet_in_mutate;
   std::unique_ptr<PacketOutMutate> packet_out_mutate;
 
-  PacketInCb cb_;
+  StreamMessageResponseCb cb_;
   void *cookie_;
 };
 

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -175,24 +175,16 @@ class DeviceState {
     return device_mgr.get();
   }
 
-  void send_packet_in(p4v1::PacketIn *packet) {
-    std::lock_guard<std::mutex> lock(m);
-    auto master = get_master();
-    if (master == nullptr) return;
-    auto stream = master->stream();
-    p4v1::StreamMessageResponse response;
-    response.set_allocated_packet(packet);
-    if (stream->Write(response)) pkt_in_count++;
-    response.release_packet();
-  }
-
   void send_stream_message(p4v1::StreamMessageResponse *msg) {
     std::lock_guard<std::mutex> lock(m);
     auto master = get_master();
     if (master == nullptr) return;
     auto stream = master->stream();
     auto success = stream->Write(*msg);
-    if (msg->has_packet() && success) pkt_in_count++;
+    if (msg->has_packet() && success) {
+      SIMPLELOG << "PACKET IN\n";
+      pkt_in_count++;
+    }
   }
 
   uint64_t get_pkt_in_count() {
@@ -251,16 +243,6 @@ class DeviceState {
     if (was_master) notify_all();
   }
 
-  void process_packet_out(Connection *connection,
-                          const p4v1::PacketOut &packet_out) {
-    std::lock_guard<std::mutex> lock(m);
-    SIMPLELOG << "PACKET OUT\n";
-    if (!is_master(connection)) return;
-    if (device_mgr == nullptr) return;
-    device_mgr->packet_out_send(packet_out);
-    pkt_out_count++;
-  }
-
   void process_stream_message_request(
       Connection *connection, const p4v1::StreamMessageRequest &request) {
     // these are handled directly by StreamChannel
@@ -269,8 +251,10 @@ class DeviceState {
     if (!is_master(connection)) return;
     if (device_mgr == nullptr) return;
     device_mgr->stream_message_request_handle(request);
-    if (request.update_case() == p4v1::StreamMessageRequest::kPacket)
+    if (request.update_case() == p4v1::StreamMessageRequest::kPacket) {
+      SIMPLELOG << "PACKET OUT\n";
       pkt_out_count++;
+    }
   }
 
   uint64_t get_pkt_out_count() {
@@ -365,9 +349,6 @@ class Devices {
                      std::unique_ptr<DeviceState> > device_map{};
 };
 
-void packet_in_cb(DeviceMgr::device_id_t device_id, p4v1::PacketIn *packet,
-                  void *cookie);
-
 void stream_message_response_cb(DeviceMgr::device_id_t device_id,
                                 p4v1::StreamMessageResponse *msg,
                                 void *cookie);
@@ -428,7 +409,6 @@ class P4RuntimeServiceImpl : public p4v1::P4Runtime::Service {
     auto device_mgr = device->get_or_add_p4_mgr();
     auto status = device_mgr->pipeline_config_set(
         request->action(), request->config());
-    device_mgr->packet_in_register_cb(packet_in_cb, NULL);
     device_mgr->stream_message_response_register_cb(
         stream_message_response_cb, NULL);
     return to_grpc_status(status);
@@ -500,13 +480,6 @@ class P4RuntimeServiceImpl : public p4v1::P4Runtime::Service {
           }
           break;
         case p4v1::StreamMessageRequest::kPacket:
-          {
-            if (connection_status.connection == nullptr) break;
-            auto device_id = connection_status.device_id;
-            Devices::get(device_id)->process_packet_out(
-                connection_status.connection.get(), request.packet());
-          }
-          break;
         case p4v1::StreamMessageRequest::kDigestAck:
           {
             if (connection_status.connection == nullptr) break;
@@ -526,13 +499,6 @@ class P4RuntimeServiceImpl : public p4v1::P4Runtime::Service {
     return Uint128(from.high(), from.low());
   }
 };
-
-void packet_in_cb(DeviceMgr::device_id_t device_id, p4v1::PacketIn *packet,
-                  void *cookie) {
-  (void) cookie;
-  SIMPLELOG << "PACKET IN\n";
-  Devices::get(device_id)->send_packet_in(packet);
-}
 
 void stream_message_response_cb(DeviceMgr::device_id_t device_id,
                                 p4v1::StreamMessageResponse *msg,
@@ -555,7 +521,10 @@ struct ServerData {
 namespace testing {
 
 void send_packet_in(DeviceMgr::device_id_t device_id, p4v1::PacketIn *packet) {
-  packet_in_cb(device_id, packet, nullptr);
+  p4v1::StreamMessageResponse msg;
+  msg.set_allocated_packet(packet);
+  Devices::get(device_id)->send_stream_message(&msg);
+  msg.release_packet();
 }
 
 size_t max_connections() { return DeviceState::max_connections; }


### PR DESCRIPTION
We now have generic methods to handle all stream messages.