### PR TITLE
Introduce intent based API for action profile group programming in PI

### DIFF
--- a/frontends_extra/cpp/PI/frontends/cpp/tables.h
+++ b/frontends_extra/cpp/PI/frontends/cpp/tables.h
@@ -357,6 +357,10 @@ class ActProf {
   pi_status_t group_remove_member(pi_indirect_handle_t group_handle,
                                   pi_indirect_handle_t member_handle);
 
+  pi_status_t group_set_members(pi_indirect_handle_t group_handle,
+                                size_t num_members,
+                                const pi_indirect_handle_t *member_handles);
+
  private:
   pi_session_handle_t sess;
   pi_dev_tgt_t dev_tgt;

--- a/frontends_extra/cpp/src/tables.cpp
+++ b/frontends_extra/cpp/src/tables.cpp
@@ -740,4 +740,12 @@ ActProf::group_remove_member(pi_indirect_handle_t group_handle,
                                     group_handle, member_handle);
 }
 
+pi_status_t
+ActProf::group_set_members(pi_indirect_handle_t group_handle,
+                           size_t num_members,
+                           const pi_indirect_handle_t *member_handles) {
+  return pi_act_prof_grp_set_mbrs(sess, dev_tgt.dev_id, act_prof_id,
+                                  group_handle, num_members, member_handles);
+}
+
 }  // namespace pi

--- a/include/PI/pi_act_prof.h
+++ b/include/PI/pi_act_prof.h
@@ -70,6 +70,13 @@ pi_status_t pi_act_prof_grp_remove_mbr(pi_session_handle_t session_handle,
                                        pi_indirect_handle_t grp_handle,
                                        pi_indirect_handle_t mbr_handle);
 
+//! Set all members of a group in one go.
+pi_status_t pi_act_prof_grp_set_mbrs(pi_session_handle_t session_handle,
+                                     pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                     pi_indirect_handle_t grp_handle,
+                                     size_t num_mbrs,
+                                     const pi_indirect_handle_t *mbr_handles);
+
 typedef struct pi_act_prof_fetch_res_s pi_act_prof_fetch_res_t;
 
 //! Retrieve all entries in an action profile as one big blob
@@ -98,6 +105,13 @@ size_t pi_act_prof_mbrs_next(pi_act_prof_fetch_res_t *res,
 size_t pi_act_prof_grps_next(pi_act_prof_fetch_res_t *res,
                              pi_indirect_handle_t **mbrs, size_t *num_mbrs,
                              pi_indirect_handle_t *grp_handle);
+
+typedef enum {
+  PI_ACT_PROF_API_SUPPORT_GRP_SET_MBRS = 1 << 0,
+  PI_ACT_PROF_API_SUPPORT_GRP_ADD_AND_REMOVE_MBR = 1 << 1,
+} pi_act_prof_api_support_t;
+
+int pi_act_prof_api_support(pi_dev_id_t dev_id);
 
 #ifdef __cplusplus
 }

--- a/include/PI/target/pi_act_prof_imp.h
+++ b/include/PI/target/pi_act_prof_imp.h
@@ -58,6 +58,13 @@ pi_status_t _pi_act_prof_grp_remove_mbr(pi_session_handle_t session_handle,
                                         pi_indirect_handle_t grp_handle,
                                         pi_indirect_handle_t mbr_handle);
 
+pi_status_t _pi_act_prof_grp_set_mbrs(pi_session_handle_t session_handle,
+                                      pi_dev_id_t dev_id,
+                                      pi_p4_id_t act_prof_id,
+                                      pi_indirect_handle_t grp_handle,
+                                      size_t num_mbrs,
+                                      const pi_indirect_handle_t *mbr_handles);
+
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
                                        pi_dev_id_t dev_id,
                                        pi_p4_id_t act_prof_id,
@@ -65,5 +72,7 @@ pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
 
 pi_status_t _pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,
                                             pi_act_prof_fetch_res_t *res);
+
+int _pi_act_prof_api_support(pi_dev_id_t dev_id);
 
 #endif  // PI_INC_PI_TARGET_PI_ACT_PROF_IMP_H_

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -33,7 +33,8 @@ src/pre_clone_mgr.h \
 src/pre_clone_mgr.cpp \
 src/task_queue.h \
 src/digest_mgr.h \
-src/digest_mgr.cpp
+src/digest_mgr.cpp \
+src/statusor.h
 
 libpifeproto_la_LIBADD = \
 $(top_builddir)/../frontends_extra/cpp/libpifecpp.la \

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -339,11 +339,14 @@ class DeviceMgrImp {
     }
 
     action_profs.clear();
+    // TODO(antonin): use something like Google's ASSIGN_OR_RETURN
+    auto pi_api_choice = ActionProfMgr::choose_pi_api(device_id);
+    RETURN_IF_ERROR(pi_api_choice.status());
     for (auto act_prof_id = pi_p4info_act_prof_begin(p4info_new);
          act_prof_id != pi_p4info_act_prof_end(p4info_new);
          act_prof_id = pi_p4info_act_prof_next(p4info_new, act_prof_id)) {
-      std::unique_ptr<ActionProfMgr> mgr(
-          new ActionProfMgr(device_tgt, act_prof_id, p4info_new));
+      std::unique_ptr<ActionProfMgr> mgr(new ActionProfMgr(
+          device_tgt, act_prof_id, p4info_new, pi_api_choice.ValueOrDie()));
       action_profs.emplace(act_prof_id, std::move(mgr));
     }
 

--- a/proto/frontend/src/statusor.h
+++ b/proto/frontend/src/statusor.h
@@ -1,0 +1,134 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// adapted from
+// https://github.com/google/lmctfy/blob/master/util/task/statusor.h
+
+#ifndef SRC_STATUSOR_H_
+#define SRC_STATUSOR_H_
+
+#include <cassert>
+
+#include "google/rpc/code.pb.h"
+#include "google/rpc/status.pb.h"
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+// A StatusOr holds a Status (in the case of an error), or a value T.
+template <typename T>
+class StatusOr {
+ public:
+  using Code = ::google::rpc::Code;
+  using Status = ::google::rpc::Status;
+
+  // Has status UNKNOWN.
+  inline StatusOr();
+
+  // Builds from a non-OK status. Crashes if an OK status is specified.
+  inline StatusOr(const Status& status);  // NOLINT
+
+  // Builds from the specified value.
+  inline StatusOr(const T& value);  // NOLINT
+
+  // Copy constructor.
+  inline StatusOr(const StatusOr& other);
+
+  // Conversion copy constructor, T must be copy constructible from U.
+  template <typename U>
+  inline StatusOr(const StatusOr<U>& other);
+
+  // Assignment operator.
+  inline const StatusOr& operator=(const StatusOr& other);
+
+  // Conversion assignment operator, T must be assignable from U
+  template<typename U>
+  inline const StatusOr& operator=(const StatusOr<U>& other);
+
+  // Accessors.
+  inline const Status& status() const { return status_; }
+
+  // Checks if status is ok.
+  inline bool ok() const { return (status_.code() == Code::OK); }
+
+  // Returns value or crashes if ok() is false.
+  inline const T& ValueOrDie() const {
+    assert(ok());
+    return value_;
+  }
+
+  template<typename U> friend class StatusOr;
+
+ private:
+  Status status_;
+  T value_;
+};
+
+// Implementation.
+
+template <typename T>
+inline StatusOr<T>::StatusOr() {
+  status_.set_code(Code::UNKNOWN);
+}
+
+template <typename T>
+inline StatusOr<T>::StatusOr(const Status& status)
+    : status_(status) {
+  assert(status.code() != Code::OK);
+}
+
+template <typename T>
+inline StatusOr<T>::StatusOr(const T& value)
+    : value_(value) {}
+
+template <typename T>
+inline StatusOr<T>::StatusOr(const StatusOr& other)
+    : status_(other.status_), value_(other.value_) {
+}
+
+template <typename T>
+template <typename U>
+inline StatusOr<T>::StatusOr(const StatusOr<U>& other)
+    : status_(other.status_), value_(other.value_) {
+}
+
+template <typename T>
+inline const StatusOr<T>& StatusOr<T>::operator=(const StatusOr& other) {
+  status_ = other.status_;
+  if (ok()) {
+    value_ = other.value_;
+  }
+  return *this;
+}
+
+template<typename T>
+template<typename U>
+inline const StatusOr<T>& StatusOr<T>::operator=(const StatusOr<U>& other) {
+  status_ = other.status_;
+  if (ok()) {
+    value_ = other.value_;
+  }
+  return *this;
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi
+
+#endif  // SRC_STATUSOR_H_

--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -42,6 +42,14 @@ namespace testing {
 
 using device_id_t = uint64_t;
 
+enum PiActProfApiSupport {
+  PiActProfApiSupport_SET_MBRS = PI_ACT_PROF_API_SUPPORT_GRP_SET_MBRS,
+  PiActProfApiSupport_ADD_AND_REMOVE_MBR =
+    PI_ACT_PROF_API_SUPPORT_GRP_ADD_AND_REMOVE_MBR,
+  PiActProfApiSupport_BOTH = PI_ACT_PROF_API_SUPPORT_GRP_SET_MBRS |
+    PI_ACT_PROF_API_SUPPORT_GRP_ADD_AND_REMOVE_MBR,
+};
+
 class DummySwitch;
 
 class DummySwitchMock {
@@ -127,8 +135,12 @@ class DummySwitchMock {
   MOCK_METHOD3(action_prof_group_remove_member,
                pi_status_t(pi_p4_id_t, pi_indirect_handle_t,
                            pi_indirect_handle_t));
+  MOCK_METHOD4(action_prof_group_set_members,
+               pi_status_t(pi_p4_id_t, pi_indirect_handle_t,
+                           size_t, const pi_indirect_handle_t *));
   MOCK_METHOD2(action_prof_entries_fetch,
                pi_status_t(pi_p4_id_t, pi_act_prof_fetch_res_t *));
+  MOCK_METHOD0(action_prof_api_support, int());
 
   MOCK_METHOD3(meter_read,
                pi_status_t(pi_p4_id_t, size_t, pi_meter_spec_t *));

--- a/src/pi_act_prof.c
+++ b/src/pi_act_prof.c
@@ -80,6 +80,15 @@ pi_status_t pi_act_prof_grp_remove_mbr(pi_session_handle_t session_handle,
                                      grp_handle, mbr_handle);
 }
 
+pi_status_t pi_act_prof_grp_set_mbrs(pi_session_handle_t session_handle,
+                                     pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                     pi_indirect_handle_t grp_handle,
+                                     size_t num_mbrs,
+                                     const pi_indirect_handle_t *mbr_handles) {
+  return _pi_act_prof_grp_set_mbrs(session_handle, dev_id, act_prof_id,
+                                   grp_handle, num_mbrs, mbr_handles);
+}
+
 pi_status_t pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
                                       pi_dev_id_t dev_id,
                                       pi_p4_id_t act_prof_id,
@@ -163,4 +172,8 @@ size_t pi_act_prof_grps_next(pi_act_prof_fetch_res_t *res,
   res->curr_groups = curr;
 
   return res->idx_groups++;
+}
+
+int pi_act_prof_api_support(pi_dev_id_t dev_id) {
+  return _pi_act_prof_api_support(dev_id);
 }

--- a/targets/bmv2/pi_act_prof_imp.cpp
+++ b/targets/bmv2/pi_act_prof_imp.cpp
@@ -246,6 +246,21 @@ pi_status_t _pi_act_prof_grp_remove_mbr(pi_session_handle_t session_handle,
   return PI_STATUS_SUCCESS;
 }
 
+pi_status_t _pi_act_prof_grp_set_mbrs(pi_session_handle_t session_handle,
+                                      pi_dev_id_t dev_id,
+                                      pi_p4_id_t act_prof_id,
+                                      pi_indirect_handle_t grp_handle,
+                                      size_t num_mbrs,
+                                      const pi_indirect_handle_t *mbr_handles) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)grp_handle;
+  (void)num_mbrs;
+  (void)mbr_handles;
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+}
+
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
                                        pi_dev_id_t dev_id,
                                        pi_p4_id_t act_prof_id,
@@ -342,6 +357,11 @@ pi_status_t _pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,
   delete[] res->entries_groups;
   delete[] res->mbr_handles;
   return PI_STATUS_SUCCESS;
+}
+
+int _pi_act_prof_api_support(pi_dev_id_t dev_id) {
+  (void)dev_id;
+  return PI_ACT_PROF_API_SUPPORT_GRP_ADD_AND_REMOVE_MBR;
 }
 
 }

--- a/targets/dummy/pi_act_prof_imp.c
+++ b/targets/dummy/pi_act_prof_imp.c
@@ -113,6 +113,22 @@ pi_status_t _pi_act_prof_grp_remove_mbr(pi_session_handle_t session_handle,
   return PI_STATUS_SUCCESS;
 }
 
+pi_status_t _pi_act_prof_grp_set_mbrs(pi_session_handle_t session_handle,
+                                      pi_dev_id_t dev_id,
+                                      pi_p4_id_t act_prof_id,
+                                      pi_indirect_handle_t grp_handle,
+                                      size_t num_mbrs,
+                                      const pi_indirect_handle_t *mbr_handles) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)grp_handle;
+  (void)num_mbrs;
+  (void)mbr_handles;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
                                        pi_dev_id_t dev_id,
                                        pi_p4_id_t act_prof_id,
@@ -131,4 +147,11 @@ pi_status_t _pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,
   (void)res;
   func_counter_increment(__func__);
   return PI_STATUS_SUCCESS;
+}
+
+int _pi_act_prof_api_support(pi_dev_id_t dev_id) {
+  (void)dev_id;
+  func_counter_increment(__func__);
+  return PI_ACT_PROF_API_SUPPORT_GRP_SET_MBRS |
+         PI_ACT_PROF_API_SUPPORT_GRP_ADD_AND_REMOVE_MBR;
 }

--- a/targets/rpc/pi_act_prof_imp.c
+++ b/targets/rpc/pi_act_prof_imp.c
@@ -239,6 +239,21 @@ pi_status_t _pi_act_prof_grp_remove_mbr(pi_session_handle_t session_handle,
                             mbr_handle, PI_RPC_ACT_PROF_GRP_REMOVE_MBR);
 }
 
+pi_status_t _pi_act_prof_grp_set_mbrs(pi_session_handle_t session_handle,
+                                      pi_dev_id_t dev_id,
+                                      pi_p4_id_t act_prof_id,
+                                      pi_indirect_handle_t grp_handle,
+                                      size_t num_mbrs,
+                                      const pi_indirect_handle_t *mbr_handles) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)grp_handle;
+  (void)num_mbrs;
+  (void)mbr_handles;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
                                        pi_dev_id_t dev_id,
                                        pi_p4_id_t act_prof_id,
@@ -310,4 +325,10 @@ pi_status_t _pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,
   free(res->entries_groups);
   free(res->mbr_handles);
   return PI_STATUS_SUCCESS;
+}
+
+int _pi_act_prof_api_support(pi_dev_id_t dev_id) {
+  (void)dev_id;
+  return PI_ACT_PROF_API_SUPPORT_GRP_SET_MBRS |
+         PI_ACT_PROF_API_SUPPORT_GRP_ADD_AND_REMOVE_MBR;
 }


### PR DESCRIPTION
We introduce a new API, pi_act_prof_grp_set_mbrs, which can be used to
set the group membership in one go.

Targets are free to implement either programming methods (add / remove
based or memberhsip based), or both methods. To indicate to the client
which method is supported (without requiring the client to tentatively
call the desired API), we introduce a new function,
pi_act_prof_api_support, to be implemented by targets.

The P4Runtime server implementation currently supports both methods. It
will query the target with pi_act_prof_api_support and choose one method
appropriately. If both are supported by the target, the new one
(intent-based) will be preferred. The gtests for the P4Runtime
implementation have been updated (value-parameterized) to exercise both
code paths.

This commit also includes some minor improvements in the P4Runtime
action profile manager object. In particular, error codes were updated
to improve conformance with the P4Runtime specification.