### PR TITLE
Add ability to drop tasks in the TaskQueue if too large

### DIFF
--- a/proto/frontend/src/idle_timeout_buffer.h
+++ b/proto/frontend/src/idle_timeout_buffer.h
@@ -24,6 +24,7 @@
 #include <PI/frontends/cpp/tables.h>
 #include <PI/frontends/proto/device_mgr.h>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -81,6 +82,10 @@ class IdleTimeoutBuffer {
   void *cookie{nullptr};
   std::thread task_queue_thread;
   p4::v1::IdleTimeoutNotification notifications;
+  std::atomic<size_t> drop_count{0};
+
+  // start dropping notifications if queue grows too large
+  static constexpr size_t max_queue_size = 1000;
 };
 
 }  // namespace proto

--- a/proto/tests/test_task_queue.cpp
+++ b/proto/tests/test_task_queue.cpp
@@ -71,7 +71,8 @@ struct Task : public TaskIface {
 TEST_F(TaskQueueTest, ImmediateTask) {
   std::promise<int> promise;
   auto future = promise.get_future();
-  task_queue.execute_task(std::unique_ptr<TaskIface>(new Task(promise, 99)));
+  ASSERT_EQ(task_queue.execute_task(
+      std::unique_ptr<TaskIface>(new Task(promise, 99))), 1u);
   future.wait();
   EXPECT_EQ(future.get(), 99);
 }
@@ -79,8 +80,9 @@ TEST_F(TaskQueueTest, ImmediateTask) {
 TEST_F(TaskQueueTest, TaskIn) {
   std::promise<int> promise;
   auto future = promise.get_future();
-  task_queue.execute_task_in(std::unique_ptr<TaskIface>(new Task(promise, 99)),
-                             std::chrono::milliseconds(200));
+  ASSERT_EQ(task_queue.execute_task_in(
+      std::unique_ptr<TaskIface>(new Task(promise, 99)),
+      std::chrono::milliseconds(200)), 1u);
   auto start = Clock::now();
   future.wait();
   auto end = Clock::now();
@@ -95,8 +97,9 @@ TEST_F(TaskQueueTest, TaskAt) {
   std::promise<int> promise;
   auto future = promise.get_future();
   auto start = Clock::now();
-  task_queue.execute_task_at(std::unique_ptr<TaskIface>(new Task(promise, 99)),
-                             start + std::chrono::milliseconds(200));
+  ASSERT_EQ(task_queue.execute_task_at(
+      std::unique_ptr<TaskIface>(new Task(promise, 99)),
+      start + std::chrono::milliseconds(200)), 1u);
   future.wait();
   auto end = Clock::now();
   EXPECT_EQ(future.get(), 99);
@@ -120,8 +123,8 @@ struct PeriodicTask : public CancellableTask {
 TEST_F(TaskQueueTest, PeriodicTask) {
   std::vector<Clock::time_point> tps;
   auto *task = new PeriodicTask(&tps);
-  task_queue.execute_periodic_task(
-      std::unique_ptr<TaskIface>(task), std::chrono::milliseconds(200));
+  ASSERT_EQ(task_queue.execute_periodic_task(
+      std::unique_ptr<TaskIface>(task), std::chrono::milliseconds(200)), 1u);
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
   task->cancel();
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -142,14 +145,30 @@ TEST_F(TaskQueueTest, ReorderTasks) {
   };
   std::promise<Clock::time_point> promise1;
   auto future1 = promise1.get_future();
-  task_queue.execute_task_in(std::unique_ptr<TaskIface>(new Task(promise1)),
-                             std::chrono::milliseconds(200));
+  ASSERT_EQ(task_queue.execute_task_in(
+      std::unique_ptr<TaskIface>(new Task(promise1)),
+      std::chrono::milliseconds(200)), 1u);
   std::promise<Clock::time_point> promise2;
   auto future2 = promise2.get_future();
-  task_queue.execute_task(std::unique_ptr<TaskIface>(new Task(promise2)));
+  ASSERT_EQ(task_queue.execute_task(
+      std::unique_ptr<TaskIface>(new Task(promise2))), 1u);
   future1.wait();
   future2.wait();
   EXPECT_LT(future2.get(), future1.get());
+}
+
+TEST_F(TaskQueueTest, ExecuteTaskOrDrop) {
+  static constexpr size_t max_size = 100;
+  task_queue.stop();
+  size_t count = 0;
+  std::promise<int> promise;
+  for (size_t i = 0; i < max_size; i++) {
+    count += task_queue.execute_task_or_drop(
+        std::unique_ptr<TaskIface>(new Task(promise, 99)), max_size);
+  }
+  EXPECT_EQ(count, max_size);
+  EXPECT_EQ(task_queue.execute_task_or_drop(
+      std::unique_ptr<TaskIface>(new Task(promise, 99)), max_size), 0u);
 }
 
 }  // namespace


### PR DESCRIPTION
The TaskQueue instance processing idle timeout notifications could
potentially be flooded and it seems reasonnable to bound the size of the
queue.