### PR TITLE
Include trailing OKs when reporting batch error

### DIFF
--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -171,6 +171,11 @@ class P4ErrorReporter {
         auto error_any = status.add_details();
         error_any->PackFrom(p.second);
       }
+      // add trailing OKs
+      for (; i++ < index;) {
+        auto success_any = status.add_details();
+        success_any->PackFrom(success);
+      }
     }
     return status;
   }

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -799,6 +799,12 @@ TEST_P(MatchTableTest, WriteBatchWithError) {
     update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
     expected_errors.push_back(Code::ALREADY_EXISTS);
   }
+  {
+    auto update = request.add_updates();
+    update->set_type(p4v1::Update::DELETE);
+    update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
+    expected_errors.push_back(Code::OK);
+  }
   auto status = mgr.write(request);
   EXPECT_EQ(status, expected_errors);
 }


### PR DESCRIPTION
As per
https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html#sec-error-reporting