### PR TITLE
Do not build with Werror by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+You can fork the repo and submit a pull request in Github. For more information
+send us an email (p4-dev@lists.p4.org).
+
+### Apache CLA
+
+All developers must sign the [P4.org](http://p4.org) CLA and return it to
+(membership@p4.org) before making contributions. The CLA is available
+[here](http://p4.org/wp-content/uploads/2015/07/P4_Language_Consortium_Membership_Agreement.pdf).
+
+### Building locally
+
+We recommend that you build with a recent C/C++ compiler and with `-Werror` since
+our CI tests use this flag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends $PI_DEPS $PI_RUNTIME_DEPS && \
     ./autogen.sh && \
-    ./configure --without-bmv2 --without-internal-rpc --without-cli --with-proto --with-sysrepo && \
+    ./configure --enable-Werror --without-bmv2 --without-internal-rpc --without-cli --with-proto --with-sysrepo && \
     make && \
     make install-strip && \
     (test "$IMAGE_TYPE" = "build" && \

--- a/Dockerfile.bmv2
+++ b/Dockerfile.bmv2
@@ -54,7 +54,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends $PI_DEPS $PI_RUNTIME_DEPS && \
     ./autogen.sh && \
-    ./configure --with-bmv2 --with-proto --with-sysrepo && \
+    ./configure --enable-Werror --with-bmv2 --with-proto --with-sysrepo && \
     ./proto/sysrepo/install_yangs.sh && \
     make && \
     make install-strip && \

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,10 @@ AC_ARG_WITH([cli],
 
 AM_CONDITIONAL([WITH_CLI], [test "$with_cli" = yes])
 
+AC_ARG_ENABLE([Werror],
+    AS_HELP_STRING([--enable-Werror], [Make all compiler warnings fatal]),
+    [enable_Werror="$enableval"], [enable_Werror=no])
+
 LT_INIT
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -166,17 +170,17 @@ AC_COMPILE_IFELSE(
 [CLANG=yes], [CLANG=no])
 AC_MSG_RESULT([$CLANG])
 
-EXTRA_CFLAGS=""
-AS_IF([test "x$CLANG" = "xyes"],
-      [EXTRA_CFLAGS="$EXTRA_CFLAGS -Wno-tautological-constant-out-of-range-compare"])
-
-AC_SUBST([AM_CPPFLAGS], ["-DPI_LOG_ON -isystem$INCLUDE_DIR"])
-AC_SUBST([AM_LDFLAGS], ["-L$LIB_DIR"])
-
 # Enable all warnings. -Wno-tautological-constant-out-of-range-compare is
 # necessary because clang is excessively aggressive with this warning and
 # complains about some reasonable assertions.
-AC_SUBST([AM_CFLAGS], ["$PTHREAD_CFLAGS -Wall -Werror -Wextra $EXTRA_CFLAGS"])
+EXTRA_CFLAGS="-Wall -Wextra"
+AS_IF([test "$enable_Werror" = "yes"], [EXTRA_CFLAGS="$EXTRA_CFLAGS -Werror"])
+AS_IF([test "x$CLANG" = "xyes"],
+      [EXTRA_CFLAGS="$EXTRA_CFLAGS -Wno-tautological-constant-out-of-range-compare"])
+AC_SUBST([AM_CFLAGS], ["$PTHREAD_CFLAGS $EXTRA_CFLAGS"])
+
+AC_SUBST([AM_CPPFLAGS], ["-DPI_LOG_ON -isystem$INCLUDE_DIR"])
+AC_SUBST([AM_LDFLAGS], ["-L$LIB_DIR"])
 
 # Generate makefiles
 AC_CONFIG_FILES([Makefile

--- a/frontends_extra/cpp/configure.ac
+++ b/frontends_extra/cpp/configure.ac
@@ -24,6 +24,10 @@ AC_ARG_WITH([bmv2],
 
 AM_CONDITIONAL([WITH_BMV2], [test "$want_bmv2" = yes])
 
+AC_ARG_ENABLE([Werror],
+    AS_HELP_STRING([--enable-Werror], [Make all compiler warnings fatal]),
+    [enable_Werror="$enableval"], [enable_Werror=no])
+
 AC_TYPE_UINT8_T
 AC_TYPE_UINT16_T
 AC_TYPE_UINT32_T
@@ -33,7 +37,9 @@ AC_TYPE_SIZE_T
 # check for pthreads
 AX_PTHREAD([], [AC_MSG_ERROR([Missing pthread library])])
 
-AC_SUBST([AM_CXXFLAGS], ["$PTHREAD_CFLAGS -Wall -Werror -Wextra"])
+EXTRA_CXXFLAGS="-Wall -Wextra"
+AS_IF([test "$enable_Werror" = "yes"], [EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -Werror"])
+AC_SUBST([AM_CXXFLAGS], ["$PTHREAD_CFLAGS $EXTRA_CXXFLAGS"])
 
 # Generate makefiles
 AC_CONFIG_FILES([Makefile

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -85,10 +85,16 @@ p4runtime_check_f=$ac_abs_confdir/p4/v1/p4runtime.proto
 AC_CHECK_FILE([$p4runtime_check_f], [],
               [AC_MSG_ERROR([Cannot find p4runtime; did you run 'git submodule update --init'?])])
 
+AC_ARG_ENABLE([Werror],
+    AS_HELP_STRING([--enable-Werror], [Make all compiler warnings fatal]),
+    [enable_Werror="$enableval"], [enable_Werror=no])
+
 # check for pthreads
 AX_PTHREAD([], [AC_MSG_ERROR([Missing pthread library])])
 
-AC_SUBST([AM_CXXFLAGS], ["$PTHREAD_CFLAGS -Wall -Werror -Wextra"])
+EXTRA_CXXFLAGS="-Wall -Wextra"
+AS_IF([test "$enable_Werror" = "yes"], [EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -Werror"])
+AC_SUBST([AM_CXXFLAGS], ["$PTHREAD_CFLAGS $EXTRA_CXXFLAGS"])
 
 # Determine the right way to ignore unresolved symbols in shared libraries.
 # Unfortunately this varies by platform. Right now we assume that on non-Darwin

--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -10,8 +10,6 @@ AM_CPPFLAGS = \
 -I$(top_srcdir)/p4info \
 -I$(top_srcdir)/third_party
 
-AM_CXXFLAGS = -Wall -Werror
-
 libpifeproto_la_SOURCES = \
 src/device_mgr.cpp \
 src/action_prof_mgr.h \

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -2210,6 +2210,7 @@ class DeviceMgrImp {
 
   Status construct_action_data(uint32_t table_id, const p4v1::Action &action,
                                pi::ActionEntry *action_entry) const {
+    (void) table_id;
     auto status = validate_action_data(p4info.get(), action);
     if (IS_ERROR(status)) return status;
     action_entry->init_action_data(p4info.get(), action.action_id());

--- a/proto/frontend/src/pre_clone_mgr.cpp
+++ b/proto/frontend/src/pre_clone_mgr.cpp
@@ -128,6 +128,7 @@ PreCloneMgr::session_create(const CloneSession &clone_session,
 Status
 PreCloneMgr::session_modify(const CloneSession &clone_session,
                             const SessionTemp &session) {
+  (void) session;
   auto session_id = static_cast<CloneSessionId>(clone_session.session_id());
   RETURN_IF_ERROR(validate_session_id(session_id));
   Lock lock(mutex);

--- a/targets/bmv2/configure.ac
+++ b/targets/bmv2/configure.ac
@@ -37,15 +37,22 @@ AC_CHECK_LIB([pcap], [pcap_set_immediate_mode], [pcap_fix=yes], [pcap_fix=no])
 
 AM_CONDITIONAL([WITH_PCAP_FIX], [test "$pcap_fix" = "yes"])
 
+AC_ARG_ENABLE([Werror],
+    AS_HELP_STRING([--enable-Werror], [Make all compiler warnings fatal]),
+    [enable_Werror="$enableval"], [enable_Werror=no])
+
 AC_TYPE_UINT8_T
 AC_TYPE_UINT16_T
 AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
 AC_TYPE_SIZE_T
 
+EXTRA_CXXFLAGS="-Wall -Wextra"
+AS_IF([test "$enable_Werror" = "yes"], [EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -Werror"])
+
 AC_SUBST([AM_CPPFLAGS], ["-isystem$INCLUDE_DIR"])
 AC_SUBST([AM_LDFLAGS], ["-L$LIB_DIR"])
-AC_SUBST([AM_CXXFLAGS], ["$PTHREAD_CFLAGS -Wall -Werror -Wextra"])
+AC_SUBST([AM_CXXFLAGS], ["$PTHREAD_CFLAGS $EXTRA_CXXFLAGS"])
 AC_SUBST([AM_CFLAGS], ["$PTHREAD_CFLAGS"])
 
 # Generate makefiles


### PR DESCRIPTION
In case some new warnings pop up with more recent compiler
versions. etc. We do not want users to not be able to build the code. Of
course, the CI system still uses Werror.