### PR TITLE
Support gRPC 1.17.2

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -121,6 +121,7 @@ p4v1pydir = $(pythondir)/p4/v1
 nodist_p4v1py_PYTHON = \
 py_out/p4/v1/p4data_pb2.py \
 py_out/p4/v1/p4runtime_pb2.py \
+py_out/p4/v1/p4runtime_pb2_grpc.py \
 py_out/p4/v1/__init__.py
 
 p4configpydir = $(pythondir)/p4/config
@@ -152,7 +153,8 @@ py_out/google/rpc/__init__.py
 gnmipydir = $(pythondir)/gnmi
 nodist_gnmipy_PYTHON = \
 py_out/gnmi/__init__.py \
-py_out/gnmi/gnmi_pb2.py
+py_out/gnmi/gnmi_pb2.py \
+py_out/gnmi/gnmi_pb2_grpc.py
 
 BUILT_SOURCES += \
 $(nodist_p4py_PYTHON) \

--- a/proto/README.md
+++ b/proto/README.md
@@ -83,7 +83,7 @@ Here is an example of a supported `ONCE` subscription request from a Python
 client:
 ```
 channel = grpc.insecure_channel(<SERVER_ADDR>)
-stub = gnmi_pb2.gNMIStub(channel)
+stub = gnmi_pb2_grpc.gNMIStub(channel)
 
 def req_iterator():
     while True:

--- a/proto/ptf/base_test.py
+++ b/proto/ptf/base_test.py
@@ -35,6 +35,7 @@ import grpc
 
 from google.rpc import status_pb2, code_pb2
 from p4.v1 import p4runtime_pb2
+from p4.v1 import p4runtime_pb2_grpc
 from p4.config.v1 import p4info_pb2
 from p4.tmp import p4config_pb2
 import google.protobuf.text_format
@@ -209,7 +210,7 @@ class P4RuntimeTest(BaseTest):
             grpc_addr = 'localhost:50051'
 
         self.channel = grpc.insecure_channel(grpc_addr)
-        self.stub = p4runtime_pb2.P4RuntimeStub(self.channel)
+        self.stub = p4runtime_pb2_grpc.P4RuntimeStub(self.channel)
 
         proto_txt_path = testutils.test_param_get("p4info")
         print "Importing p4info proto from", proto_txt_path

--- a/proto/ptf/bmv2/gen_bmv2_config.py
+++ b/proto/ptf/bmv2/gen_bmv2_config.py
@@ -66,14 +66,13 @@ def main():
     tmp_dir = tempfile.mkdtemp()
     out_json = os.path.join(tmp_dir, 'dp.json')
     out_p4info = os.path.join(tmp_dir, 'p4info.proto.txt')
-    cmd = [args.compiler, '--p4-16', args.src, '-o', out_json,
+    cmd = [args.compiler, '--std', 'p4-16', args.src, '-o', out_json,
            '--p4runtime-format', 'text', '--p4runtime-file', out_p4info]
     print ' '.join(cmd)
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError:
         print "Error when compiling P4 program"
-        print out
         shutil.rmtree(tmp_dir)
         sys.exit(1)
     except OSError:

--- a/proto/ptf/ptf_runner.py
+++ b/proto/ptf/ptf_runner.py
@@ -31,6 +31,7 @@ import sys
 
 import grpc
 from p4.v1 import p4runtime_pb2
+from p4.v1 import p4runtime_pb2_grpc
 from p4.config.v1 import p4info_pb2
 import google.protobuf.text_format
 
@@ -64,7 +65,7 @@ def update_config(config_path, p4info_path, grpc_addr, device_id):
     P4Info and binary device config
     '''
     channel = grpc.insecure_channel(grpc_addr)
-    stub = p4runtime_pb2.P4RuntimeStub(channel)
+    stub = p4runtime_pb2_grpc.P4RuntimeStub(channel)
 
     info("Sending P4 config")
     request = p4runtime_pb2.SetForwardingPipelineConfigRequest()


### PR DESCRIPTION
Along with Protobuf 3.6.1
The officially supported version is still 1.3.2 (along with Protobuf
3.2.0).