### PR TITLE
Add selector groups size checks as per P4Runtime specification

### DIFF
--- a/include/PI/p4info/act_profs.h
+++ b/include/PI/p4info/act_profs.h
@@ -54,6 +54,9 @@ bool pi_p4info_act_prof_is_action_of(const pi_p4info_t *p4info,
 size_t pi_p4info_act_prof_max_size(const pi_p4info_t *p4info,
                                    pi_p4_id_t act_prof_id);
 
+size_t pi_p4info_act_prof_max_grp_size(const pi_p4info_t *p4info,
+                                       pi_p4_id_t act_prof_id);
+
 pi_p4_id_t pi_p4info_act_prof_begin(const pi_p4info_t *p4info);
 pi_p4_id_t pi_p4info_act_prof_next(const pi_p4info_t *p4info, pi_p4_id_t id);
 pi_p4_id_t pi_p4info_act_prof_end(const pi_p4info_t *p4info);

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -1317,6 +1317,12 @@ class DeviceMgrImp {
                             "Cannot map group handle to group id");
       }
       group->set_group_id(group_id);
+      size_t max_size;
+      if (!action_prof_mgr->group_get_max_size_user(group_id, &max_size)) {
+        RETURN_ERROR_STATUS(Code::INTERNAL,
+                            "Cannot retrieve max_size for group {}", group_id);
+      }
+      group->set_max_size(static_cast<int>(max_size));
       for (size_t j = 0; j < num; j++) {
         ActionProfMgr::Id member_id;
         if (!action_prof_mgr->retrieve_member_id(members_h[j], &member_id)) {

--- a/proto/p4info/p4info_to_and_from_proto.cpp
+++ b/proto/p4info/p4info_to_and_from_proto.cpp
@@ -164,6 +164,9 @@ void read_act_profs(const p4configv1::P4Info &p4info_proto,
     for (const auto table_id : act_prof.table_ids())
       pi_p4info_act_prof_add_table(p4info, pre.id(), table_id);
 
+    pi_p4info_act_prof_set_max_grp_size(
+        p4info, pre.id(), act_prof.max_group_size());
+
     import_common(pre, p4info);
   }
 }
@@ -468,6 +471,7 @@ void p4info_serialize_act_profs(const pi_p4info_t *p4info,
       act_prof->add_table_ids(table_ids[i]);
     act_prof->set_with_selector(pi_p4info_act_prof_has_selector(p4info, id));
     act_prof->set_size(pi_p4info_act_prof_max_size(p4info, id));
+    act_prof->set_max_group_size(pi_p4info_act_prof_max_grp_size(p4info, id));
   }
 }
 

--- a/src/config_readers/native_json_reader.c
+++ b/src/config_readers/native_json_reader.c
@@ -231,6 +231,10 @@ static pi_status_t read_act_profs(cJSON *root, pi_p4info_t *p4info) {
       pi_p4_id_t id = table->valueint;
       pi_p4info_act_prof_add_table(p4info, pi_id, id);
     }
+
+    item = cJSON_GetObjectItem(act_prof, "max_group_size");
+    if (item)
+      pi_p4info_act_prof_set_max_grp_size(p4info, pi_id, item->valueint);
   }
 
   return PI_STATUS_SUCCESS;

--- a/src/p4info/act_profs.c
+++ b/src/p4info/act_profs.c
@@ -38,6 +38,7 @@ typedef struct _act_prof_data_s {
   id_vector_t table_ids;
   bool with_selector;
   size_t max_size;
+  size_t max_grp_size;
 } _act_prof_data_t;
 
 static _act_prof_data_t *get_act_prof(const pi_p4info_t *p4info,
@@ -85,6 +86,8 @@ void pi_p4info_act_prof_serialize(cJSON *root, const pi_p4info_t *p4info) {
 
     cJSON_AddNumberToObject(aObject, "max_size", act_prof->max_size);
 
+    cJSON_AddNumberToObject(aObject, "max_group_size", act_prof->max_grp_size);
+
     p4info_common_serialize(aObject, &act_prof->common);
 
     cJSON_AddItemToArray(aArray, aObject);
@@ -107,6 +110,7 @@ void pi_p4info_act_prof_add(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
   act_prof->num_tables = 0;
   act_prof->with_selector = with_selector;
   act_prof->max_size = max_size;
+  act_prof->max_grp_size = 0;
 }
 
 void pi_p4info_act_prof_add_table(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
@@ -114,6 +118,13 @@ void pi_p4info_act_prof_add_table(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
   _act_prof_data_t *act_prof = get_act_prof(p4info, act_prof_id);
   ID_VECTOR_PUSH_BACK(act_prof->table_ids, table_id);
   act_prof->num_tables++;
+}
+
+void pi_p4info_act_prof_set_max_grp_size(pi_p4info_t *p4info,
+                                         pi_p4_id_t act_prof_id,
+                                         size_t max_grp_size) {
+  _act_prof_data_t *act_prof = get_act_prof(p4info, act_prof_id);
+  act_prof->max_grp_size = max_grp_size;
 }
 
 pi_p4_id_t pi_p4info_act_prof_id_from_name(const pi_p4info_t *p4info,
@@ -167,6 +178,12 @@ size_t pi_p4info_act_prof_max_size(const pi_p4info_t *p4info,
                                    pi_p4_id_t act_prof_id) {
   _act_prof_data_t *act_prof = get_act_prof(p4info, act_prof_id);
   return act_prof->max_size;
+}
+
+size_t pi_p4info_act_prof_max_grp_size(const pi_p4info_t *p4info,
+                                       pi_p4_id_t act_prof_id) {
+  _act_prof_data_t *act_prof = get_act_prof(p4info, act_prof_id);
+  return act_prof->max_grp_size;
 }
 
 pi_p4_id_t pi_p4info_act_prof_begin(const pi_p4info_t *p4info) {

--- a/src/p4info/act_profs_int.h
+++ b/src/p4info/act_profs_int.h
@@ -38,6 +38,10 @@ void pi_p4info_act_prof_add(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
 void pi_p4info_act_prof_add_table(pi_p4info_t *p4info, pi_p4_id_t act_prof_id,
                                   pi_p4_id_t table_id);
 
+void pi_p4info_act_prof_set_max_grp_size(pi_p4info_t *p4info,
+                                         pi_p4_id_t act_prof_id,
+                                         size_t max_grp_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/testdata/unittest.p4
+++ b/tests/testdata/unittest.p4
@@ -134,6 +134,7 @@ control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metad
     }
 
     @name(".ActProfWS")
+    @max_group_size(200)
     action_selector(HashAlgorithm.crc16, 32w128, 32w16) ActProfWS;
 
     @name(".IndirectWS")

--- a/tests/testdata/unittest.p4info.txt
+++ b/tests/testdata/unittest.p4info.txt
@@ -370,6 +370,7 @@ action_profiles {
   table_ids: 33586946
   with_selector: true
   size: 128
+  max_group_size: 200
 }
 counters {
   preamble {


### PR DESCRIPTION
We enforce everything we can in the DeviceMgr implementation and return
the appropriate error code. If both the dynamic max size (provided at
group creation time) and the statis max size (from P4Info) are 0,
pi_act_prof_grp_create is called with a max_size of 0. It is the
responsibility of the PI target implementation to behave accordingly to
the spec then ("the target should use the maximum value it can
support").

Fixes #452