### PR TITLE
Add AC_CONFIG_AUX_DIR([.]) to every configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([PI], [0.1], [antonin@barefootnetworks.com])
+AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 

--- a/frontends_extra/cpp/configure.ac
+++ b/frontends_extra/cpp/configure.ac
@@ -3,6 +3,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([PI-fe-cpp], [0.1], [antonin@barefootnetworks.com])
+AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -3,6 +3,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([PI-proto], [0.1], [])
+AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 

--- a/targets/bmv2/configure.ac
+++ b/targets/bmv2/configure.ac
@@ -3,6 +3,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([PI-bmv2], [0.1], [antonin@barefootnetworks.com])
+AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
It seems that when some conditions are met (hard for me to be more
specific), we get the following error when autoreconf runs:

error: required file './ltmain.sh' not found