### PR TITLE
Change defaults for configure flags --with-cli and --with-internal-rpc

### DIFF
--- a/Dockerfile.bmv2
+++ b/Dockerfile.bmv2
@@ -54,7 +54,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends $PI_DEPS $PI_RUNTIME_DEPS && \
     ./autogen.sh && \
-    ./configure --enable-Werror --with-bmv2 --with-proto --with-sysrepo && \
+    ./configure --enable-Werror --with-bmv2 --with-proto --with-cli --with-internal-rpc --with-sysrepo && \
     ./proto/sysrepo/install_yangs.sh && \
     make && \
     make install-strip && \

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ to install different dependencies.
 | `--with-bmv2`         | no  | bmv2 and its deps | Implies `--with-fe-cpp` |
 | `--with-proto`        | no  | protobuf, grpc, libboost-thread-dev | - |
 | `--with-fe-cpp`       | no  | - | - |
-| `--with-internal-rpc` | yes | nanomsg | - |
-| `--with-cli`          | yes | readline | - |
+| `--with-internal-rpc` | no  | nanomsg | - |
+| `--with-cli`          | no  | readline | - |
 | `--with-sysrepo`      | no  | same as `--with-proto` + sysrepo and its deps| - |
 
 ### Additional CI tests dependencies
@@ -86,7 +86,7 @@ To include `p4runtime.proto` in the build, please run `configure` with
 
 ```
 ./autogen.sh
-./configure --with-proto --without-internal-rpc [--without-cli]
+./configure --with-proto
 make
 make check
 [sudo] make install
@@ -123,7 +123,8 @@ For now the PI CLI supports an experimental version of `table_add` and
 `table_delete`. Because these two functions have been implemented in the bmv2 PI
 implementation, you can test the PI CLI with the bmv2 `simple_switch`. Assuming
 bmv2 is installed on your system, build the PI and the CLI with `./configure
---with-bmv2 && make`. You can then experiment with the following commands:
+--with-bmv2 --with-cli && make`. You can then experiment with the following
+commands:
 
     simple_switch tests/testdata/simple_router.json  // to start the switch
     ./CLI/pi_CLI_bmv2 -c tests/testdata/simple_router.json  // to start the CLI

--- a/configure.ac
+++ b/configure.ac
@@ -63,14 +63,14 @@ AM_COND_IF([WITH_GTEST], [
 
 AC_ARG_WITH([internal-rpc],
     AS_HELP_STRING([--with-internal-rpc],
-                   [Build internal rpc (nanomsg) code @<:@default=yes@:>@]),
-    [with_internal_rpc="$withval"], [with_internal_rpc=yes])
+                   [Build internal rpc (nanomsg) code @<:@default=no@:>@]),
+    [with_internal_rpc="$withval"], [with_internal_rpc=no])
 
 AM_CONDITIONAL([WITH_INTERNAL_RPC], [test "$with_internal_rpc" = yes])
 
 AC_ARG_WITH([cli],
-    AS_HELP_STRING([--with-cli], [Build PI C CLI @<:@default=yes@:>@]),
-    [with_cli="$withval"], [with_cli=yes])
+    AS_HELP_STRING([--with-cli], [Build PI C CLI @<:@default=no@:>@]),
+    [with_cli="$withval"], [with_cli=no])
 
 AM_CONDITIONAL([WITH_CLI], [test "$with_cli" = yes])
 


### PR DESCRIPTION
These options are mostly deprecated now. The internal RPC mechanism
predates P4Runtime, and the CLI (very incomplete) should ideally be
replaced by one built over P4Runtime. I think it makes sense at this
point to disable these features by default.