### PR TITLE
Deprecate temporary P4DeviceConfig message

### DIFF
--- a/proto/ptf/base_test.py
+++ b/proto/ptf/base_test.py
@@ -37,7 +37,6 @@ from google.rpc import status_pb2, code_pb2
 from p4.v1 import p4runtime_pb2
 from p4.v1 import p4runtime_pb2_grpc
 from p4.config.v1 import p4info_pb2
-from p4.tmp import p4config_pb2
 import google.protobuf.text_format
 
 # See https://gist.github.com/carymrobbins/8940382
@@ -446,7 +445,7 @@ class P4RuntimeTest(BaseTest):
     def set_action(self, action, a_name, params):
         action_id = self.get_action_id(a_name)
         if action_id is None:
-            self.fail("Failed to get id of action '{}' - perhaps the action name is misspelled?".format(a_name)
+            self.fail("Failed to get id of action '{}' - perhaps the action name is misspelled?").format(a_name)
         action.action_id = action_id
         for p_name, v in params:
             param = action.params.add()

--- a/proto/ptf/bmv2/gen_bmv2_config.py
+++ b/proto/ptf/bmv2/gen_bmv2_config.py
@@ -27,8 +27,6 @@ import subprocess
 import sys
 import tempfile
 
-from p4.tmp import p4config_pb2
-
 def check_compiler_exec(path):
     try:
         with open(os.devnull, 'w') as devnull:
@@ -86,11 +84,12 @@ def main():
         print "Error when writing to", args.out_p4info
         sys.exit(1)
 
-    with open(args.out_bin, 'wf') as f_out:
-        with open(out_json, 'r') as f_json:
-            device_config = p4config_pb2.P4DeviceConfig()
-            device_config.device_data = f_json.read()
-            f_out.write(device_config.SerializeToString())
+    try:
+        shutil.copyfile(out_json, args.out_bin)
+    except:
+        print "Error when writing to", args.out_bin
+        sys.exit(1)
+
     shutil.rmtree(tmp_dir)
 
 if __name__ == '__main__':

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -43,8 +43,6 @@
 #include <tuple>
 #include <vector>
 
-#include "p4/tmp/p4config.pb.h"
-
 #include "PI/frontends/cpp/tables.h"
 #include "PI/frontends/proto/device_mgr.h"
 #include "PI/int/pi_int.h"
@@ -213,9 +211,7 @@ class DeviceMgrTest : public ::testing::Test {
     p4v1::ForwardingPipelineConfig config;
     config.set_allocated_p4info(&p4info_proto);
     config.mutable_cookie()->set_cookie(cookie);
-    p4::tmp::P4DeviceConfig dummy_device_config_;
-    dummy_device_config_.set_device_data("This is a dummy device config");
-    dummy_device_config_.SerializeToString(&dummy_device_config);
+    dummy_device_config = "This is a dummy device config";
     config.set_p4_device_config(dummy_device_config);
     EXPECT_CALL(*mock, action_prof_api_support())
         .WillRepeatedly(Return(action_prof_api_choice));
@@ -353,13 +349,10 @@ TEST_F(DeviceMgrTest, PipelineConfigGet) {
 }
 
 TEST_F(DeviceMgrTest, PipelineConfigGetLarge) {
-  std::string large_device_config;
+  std::string large_device_config(32768, 'a');
   {
     p4v1::ForwardingPipelineConfig config;
     config.mutable_p4info()->CopyFrom(p4info_proto);
-    p4::tmp::P4DeviceConfig large_device_config_;
-    large_device_config_.set_device_data(std::string(32768, 'a'));
-    large_device_config_.SerializeToString(&large_device_config);
     config.set_p4_device_config(large_device_config);
     EXPECT_CALL(*mock, table_idle_timeout_config_set(
         pi_p4info_table_id_from_name(p4info, "IdleTimeoutTable"), _));


### PR DESCRIPTION
The assumption was always that this was a temporary message. It was
required when using bmv2 simple_switch, but is no longer needed with
simple_switch_grpc.

As a result of this change, the
ForwardingPipelineConfig::p4_device_config binary string is passed on
directly to PI. For backward compatibility, the DeviceMgr still tests
whether this field is a serialized P4DeviceConfig message (and behaves
as before).