### PR TITLE
Restrict Python interpreter detection to python2.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,8 +17,12 @@ AC_PROG_CC_C99
 # long as --with-bmv2 / --with-fe-cpp / --with-proto is not specified of course)
 AC_PROG_CXX
 
-# TODO: make this conditional on the PD if possible
-AM_PATH_PYTHON([2.7],, [:])
+# TODO: this can be removed when the Python scripts are updated to work with
+# python3 or when the PD generator code is removed altogether.
+m4_define_default([_AM_PYTHON_INTERPRETER_LIST], [python2 python2.7])
+AM_PATH_PYTHON([2.7],, [
+    AC_MSG_WARN([Cannot detect python2.7, is it installed? As a result we will skip installation of the PD generator (deprecated).])])
+AM_CONDITIONAL([HAVE_PYTHON2], [test "$PYTHON" != :])
 
 DX_DOT_FEATURE([ON])
 DX_PDF_FEATURE([ON])

--- a/generators/pd/Makefile.am
+++ b/generators/pd/Makefile.am
@@ -1,5 +1,7 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
+if HAVE_PYTHON2
+
 python_PYTHON = \
 gen_pd.py \
 tenjin_wrapper.py
@@ -41,3 +43,5 @@ templates/thrift-src/pd_rpc_server.cpp \
 templates/thrift-src/pd_rpc_server.h
 
 CLEANFILES = $(bin_SCRIPTS)
+
+endif  # HAVE_PYTHON2

--- a/generators/pd/tenjin_wrapper.py
+++ b/generators/pd/tenjin_wrapper.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright 2013-present Barefoot Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
On recent systems, python defaults to python3 which triggers an error
message during the installation phase. A poor man's solution is to force
configure to pick python2.

Fixes #464