### PR TITLE
Change locking model in DeviceMgr

### DIFF
--- a/proto/frontend/Makefile.am
+++ b/proto/frontend/Makefile.am
@@ -12,6 +12,8 @@ AM_CPPFLAGS = \
 
 libpifeproto_la_SOURCES = \
 src/device_mgr.cpp \
+src/access_arbitration.h \
+src/access_arbitration.cpp \
 src/action_prof_mgr.h \
 src/action_prof_mgr.cpp \
 src/table_info_store.h \

--- a/proto/frontend/src/access_arbitration.cpp
+++ b/proto/frontend/src/access_arbitration.cpp
@@ -1,0 +1,214 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, noware
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "access_arbitration.h"
+
+#include <mutex>
+#include <set>
+
+#include "p4/v1/p4runtime.pb.h"
+
+namespace p4v1 = ::p4::v1;
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+namespace {
+
+template <typename InputIterator1, typename InputIterator2>
+bool do_sets_intersect(InputIterator1 first1, InputIterator1 last1,
+                       InputIterator2 first2, InputIterator2 last2) {
+  while (first1 != last1 && first2 != last2) {
+    if (*first1 < *first2) {
+      ++first1;
+    } else if (*first2 < *first1) {
+      ++first2;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+AccessArbitration::Access::Access(AccessArbitration *arbitrator)
+    : arbitrator(arbitrator) { }
+
+AccessArbitration::Access::~Access() = default;
+
+AccessArbitration::WriteAccess::WriteAccess(AccessArbitration *arbitrator)
+    : AccessArbitration::Access(arbitrator) { }
+
+AccessArbitration::WriteAccess::~WriteAccess() {
+  arbitrator->release_write_access(*this);
+}
+
+AccessArbitration::ReadAccess::ReadAccess(AccessArbitration *arbitrator)
+    : AccessArbitration::Access(arbitrator) { }
+
+AccessArbitration::ReadAccess::~ReadAccess() {
+  arbitrator->release_read_access();
+}
+
+AccessArbitration::NoWriteAccess::NoWriteAccess(AccessArbitration *arbitrator)
+    : AccessArbitration::Access(arbitrator) { }
+
+AccessArbitration::NoWriteAccess::~NoWriteAccess() {
+  arbitrator->release_no_write_access(*this);
+}
+
+AccessArbitration::WriteAccess
+AccessArbitration::write_access(const p4v1::WriteRequest &request) {
+  WriteAccess access(this);
+  auto &p4_ids = access.p4_ids;
+
+  for (const auto &update : request.updates()) {
+    const auto &entity = update.entity();
+    switch (entity.entity_case()) {
+      case p4v1::Entity::kExternEntry:
+        break;
+      case p4v1::Entity::kTableEntry:
+        p4_ids.insert(entity.table_entry().table_id());
+        break;
+      case p4v1::Entity::kActionProfileMember:
+        p4_ids.insert(entity.action_profile_member().action_profile_id());
+        break;
+      case p4v1::Entity::kActionProfileGroup:
+        p4_ids.insert(entity.action_profile_group().action_profile_id());
+        break;
+      case p4v1::Entity::kMeterEntry:
+        p4_ids.insert(entity.meter_entry().meter_id());
+        break;
+      case p4v1::Entity::kDirectMeterEntry:
+        p4_ids.insert(entity.direct_meter_entry().table_entry().table_id());
+        break;
+      case p4v1::Entity::kCounterEntry:
+        p4_ids.insert(entity.counter_entry().counter_id());
+        break;
+      case p4v1::Entity::kDirectCounterEntry:
+        p4_ids.insert(entity.direct_counter_entry().table_entry().table_id());
+        break;
+      case p4v1::Entity::kPacketReplicationEngineEntry:
+        break;
+      case p4v1::Entity::kValueSetEntry:
+        p4_ids.insert(entity.value_set_entry().value_set_id());
+        break;
+      case p4v1::Entity::kRegisterEntry:
+        p4_ids.insert(entity.register_entry().register_id());
+        break;
+      case p4v1::Entity::kDigestEntry:
+        break;
+      default:
+        break;
+    }
+  }
+
+  std::unique_lock<std::mutex> lock(mutex);
+  cv.wait(lock, [this, &p4_ids]() -> bool {
+      return (read_cnt == 0) &&
+          !do_sets_intersect(p4_ids_busy.begin(), p4_ids_busy.end(),
+                             p4_ids.begin(), p4_ids.end());
+  });
+  write_cnt++;
+  p4_ids_busy.insert(p4_ids.begin(), p4_ids.end());
+
+  return access;
+}
+
+AccessArbitration::WriteAccess
+AccessArbitration::write_access(common::p4_id_t p4_id) {
+  WriteAccess access(this);
+  access.p4_ids.insert(p4_id);
+
+  std::unique_lock<std::mutex> lock(mutex);
+  cv.wait(lock, [this, p4_id]() -> bool {
+      return (read_cnt == 0) && (p4_ids_busy.count(p4_id) == 0);
+  });
+  write_cnt++;
+  p4_ids_busy.insert(p4_id);
+
+  return access;
+}
+
+AccessArbitration::NoWriteAccess
+AccessArbitration::no_write_access(common::p4_id_t p4_id) {
+  NoWriteAccess access(this);
+  access.p4_id = p4_id;
+
+  std::unique_lock<std::mutex> lock(mutex);
+  cv.wait(lock, [this, p4_id]() -> bool {
+      return (p4_ids_busy.count(p4_id) == 0);
+  });
+  no_write_cnt++;
+  p4_ids_busy.insert(p4_id);
+
+  return access;
+}
+
+AccessArbitration::ReadAccess
+AccessArbitration::read_access() {
+  ReadAccess access(this);
+
+  std::unique_lock<std::mutex> lock(mutex);
+  cv.wait(lock, [this]() -> bool {
+      return (write_cnt == 0);
+  });
+  read_cnt++;
+
+  return access;
+}
+
+AccessArbitration::UniqueAccess
+AccessArbitration::unique_access() {
+  return UniqueAccess(mutex);
+}
+
+void
+AccessArbitration::release_write_access(const WriteAccess &access) {
+  std::unique_lock<std::mutex> lock(mutex);
+  write_cnt--;
+  for (auto p4_id : access.p4_ids) p4_ids_busy.erase(p4_id);
+  cv.notify_all();
+}
+
+void
+AccessArbitration::release_read_access() {
+  std::unique_lock<std::mutex> lock(mutex);
+  read_cnt--;
+  cv.notify_all();
+}
+
+void
+AccessArbitration::release_no_write_access(const NoWriteAccess &access) {
+  std::unique_lock<std::mutex> lock(mutex);
+  no_write_cnt--;
+  p4_ids_busy.erase(access.p4_id);
+  cv.notify_all();
+}
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi

--- a/proto/frontend/src/access_arbitration.h
+++ b/proto/frontend/src/access_arbitration.h
@@ -21,6 +21,9 @@
 #ifndef SRC_ACCESS_ARBITRATION_H_
 #define SRC_ACCESS_ARBITRATION_H_
 
+#include <PI/p4info.h>
+#include <PI/proto/util.h>
+
 #include <condition_variable>
 #include <mutex>
 #include <set>
@@ -91,7 +94,8 @@ class AccessArbitration {
 
   using UniqueAccess = std::unique_lock<std::mutex>;
 
-  WriteAccess write_access(const ::p4::v1::WriteRequest &request);
+  WriteAccess write_access(const ::p4::v1::WriteRequest &request,
+                           const pi_p4info_t *p4info);
   WriteAccess write_access(common::p4_id_t p4_id);
 
   NoWriteAccess no_write_access(common::p4_id_t p4_id);

--- a/proto/frontend/src/access_arbitration.h
+++ b/proto/frontend/src/access_arbitration.h
@@ -1,0 +1,124 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SRC_ACCESS_ARBITRATION_H_
+#define SRC_ACCESS_ARBITRATION_H_
+
+#include <condition_variable>
+#include <mutex>
+#include <set>
+
+#include "common.h"
+
+namespace p4 {
+namespace v1 {
+class WriteRequest;
+}  // namespace v1
+}  // namespace p4
+
+namespace pi {
+
+namespace fe {
+
+namespace proto {
+
+// Arbitrates access between different concurrent RPCs. There are 4 different
+// levels of access:
+//   * UniqueAccess: exclusive, no concurrent access possible
+//   * WriteAccess: exclusive access to a specific set of P4Info objects
+//   * ReadAccess: shared access to the entire set of P4Info objects; other
+//     ReadAccess instances can exist concurrently, and so can NoWriteAccess
+//     instances, but it is not possible to have a concurrent WriteAccess
+//     instance
+//   * NoWriteAccess: access to a specific P4Info object that tolerates
+//     concurrent ReadAccess instances, but not concurrent WriteAccess /
+//     NoWriteAccess instances with an overlapping subset of P4Info objects
+class AccessArbitration {
+ public:
+  class Access {
+   protected:
+    explicit Access(AccessArbitration *arbitrator);
+    ~Access();
+
+    AccessArbitration *arbitrator;
+  };
+
+  class WriteAccess : public Access {
+   public:
+    ~WriteAccess();
+
+   private:
+    friend class AccessArbitration;
+    explicit WriteAccess(AccessArbitration *arbitrator);
+    std::set<common::p4_id_t> p4_ids;
+  };
+
+  class ReadAccess : public Access {
+   public:
+    ~ReadAccess();
+
+   private:
+    friend class AccessArbitration;
+    explicit ReadAccess(AccessArbitration *arbitrator);
+  };
+
+  class NoWriteAccess : public Access {
+   public:
+    ~NoWriteAccess();
+
+   private:
+    friend class AccessArbitration;
+    explicit NoWriteAccess(AccessArbitration *arbitrator);
+    common::p4_id_t p4_id;
+  };
+
+  using UniqueAccess = std::unique_lock<std::mutex>;
+
+  WriteAccess write_access(const ::p4::v1::WriteRequest &request);
+  WriteAccess write_access(common::p4_id_t p4_id);
+
+  NoWriteAccess no_write_access(common::p4_id_t p4_id);
+
+  ReadAccess read_access();
+
+  UniqueAccess unique_access();
+
+ private:
+  void release_write_access(const WriteAccess &access);
+
+  void release_no_write_access(const NoWriteAccess &access);
+
+  void release_read_access();
+
+  mutable std::mutex mutex;
+  mutable std::condition_variable cv;
+  std::set<common::p4_id_t> p4_ids_busy;
+  int read_cnt{0};
+  int write_cnt{0};
+  int no_write_cnt{0};
+};
+
+}  // namespace proto
+
+}  // namespace fe
+
+}  // namespace pi
+
+#endif  // SRC_ACCESS_ARBITRATION_H_

--- a/proto/frontend/src/action_prof_mgr.cpp
+++ b/proto/frontend/src/action_prof_mgr.cpp
@@ -209,7 +209,6 @@ ActionProfMgr::member_create(const p4v1::ActionProfileMember &member,
                              const SessionTemp &session) {
   RETURN_IF_ERROR(validate_action(member.action()));
   auto action_data = construct_action_data(member.action());
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::MANUAL));
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
   // we check if the member id already exists
@@ -278,7 +277,6 @@ ActionProfMgr::group_create(const p4v1::ActionProfileGroup &group,
                             const SessionTemp &session) {
   auto max_size = validate_max_group_size(group.max_size());
   RETURN_IF_ERROR(max_size.status());
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::MANUAL));
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
   // we check if the group id already exists
@@ -302,7 +300,6 @@ ActionProfMgr::member_modify(const p4v1::ActionProfileMember &member,
                              const SessionTemp &session) {
   RETURN_IF_ERROR(validate_action(member.action()));
   auto action_data = construct_action_data(member.action());
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::MANUAL));
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
   auto member_state = member_map.access_member_state(member.member_id());
@@ -324,7 +321,6 @@ ActionProfMgr::member_modify(const p4v1::ActionProfileMember &member,
 Status
 ActionProfMgr::group_modify(const p4v1::ActionProfileGroup &group,
                             const SessionTemp &session) {
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::MANUAL));
   auto group_id = group.group_id();
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
@@ -349,7 +345,6 @@ ActionProfMgr::group_modify(const p4v1::ActionProfileGroup &group,
 Status
 ActionProfMgr::member_delete(const p4v1::ActionProfileMember &member,
                              const SessionTemp &session) {
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::MANUAL));
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
   auto member_state = member_map.access_member_state(member.member_id());
@@ -381,7 +376,6 @@ ActionProfMgr::member_delete(const p4v1::ActionProfileMember &member,
 Status
 ActionProfMgr::group_delete(const p4v1::ActionProfileGroup &group,
                             const SessionTemp &session) {
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::MANUAL));
   pi::ActProf ap(session.get(), device_tgt, p4info, act_prof_id);
   auto group_h = group_bimap.retrieve_handle(group.group_id());
@@ -517,7 +511,6 @@ ActionProfMgr::oneshot_group_create(
         "Sum of weights exceeds static max_group_size (from P4Info)");
   }
 
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::ONESHOT));
   session->cleanup_scope_push();
   pi::ActProf ap(session->get(), device_tgt, p4info, act_prof_id);
@@ -575,7 +568,6 @@ ActionProfMgr::oneshot_group_create(
 Status
 ActionProfMgr::oneshot_group_delete(pi_indirect_handle_t group_h,
                                     const SessionTemp &session) {
-  Lock lock(mutex);
   RETURN_IF_ERROR(check_selector_usage(SelectorUsage::ONESHOT));
   auto members_it = oneshot_group_members.find(group_h);
   assert(members_it != oneshot_group_members.end());
@@ -601,7 +593,6 @@ bool
 ActionProfMgr::oneshot_group_get_members(
     pi_indirect_handle_t group_h,
     std::vector<OneShotMember> *members) const {
-  Lock lock(mutex);
   auto it = oneshot_group_members.find(group_h);
   if (it == oneshot_group_members.end()) return false;
   *members = it->second;
@@ -610,7 +601,6 @@ ActionProfMgr::oneshot_group_get_members(
 
 ActionProfMgr::SelectorUsage
 ActionProfMgr::get_selector_usage() const {
-  Lock lock(mutex);
   return selector_usage;
 }
 
@@ -911,7 +901,6 @@ ActionProfMgr::group_update_members(pi::ActProf &ap,
 bool
 ActionProfMgr::retrieve_member_handle(const Id &member_id,
                                       pi_indirect_handle_t *member_h) const {
-  Lock lock(mutex);
   auto *h_ptr = member_map.get_first_handle(member_id);
   if (!h_ptr) return false;
   *member_h = *h_ptr;
@@ -921,7 +910,6 @@ ActionProfMgr::retrieve_member_handle(const Id &member_id,
 bool
 ActionProfMgr::retrieve_group_handle(const Id &group_id,
                                      pi_indirect_handle_t *group_h) const {
-  Lock lock(mutex);
   auto *h_ptr = group_bimap.retrieve_handle(group_id);
   if (!h_ptr) return false;
   *group_h = *h_ptr;
@@ -931,7 +919,6 @@ ActionProfMgr::retrieve_group_handle(const Id &group_id,
 bool
 ActionProfMgr::retrieve_member_id(pi_indirect_handle_t member_h,
                                   Id *member_id) const {
-  Lock lock(mutex);
   auto *id_ptr = member_map.retrieve_id(member_h);
   if (!id_ptr) return false;
   *member_id = *id_ptr;
@@ -941,7 +928,6 @@ ActionProfMgr::retrieve_member_id(pi_indirect_handle_t member_h,
 bool
 ActionProfMgr::retrieve_group_id(pi_indirect_handle_t group_h,
                                  Id *group_id) const {
-  Lock lock(mutex);
   auto *id_ptr = group_bimap.retrieve_id(group_h);
   if (!id_ptr) return false;
   *group_id = *id_ptr;

--- a/proto/frontend/src/action_prof_mgr.h
+++ b/proto/frontend/src/action_prof_mgr.h
@@ -25,7 +25,6 @@
 #include <PI/pi.h>
 
 #include <map>
-#include <mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -268,12 +267,9 @@ class ActionProfMgr {
       pi::ActProf &ap,  // NOLINT(runtime/references)
       ActionProfMemberMap::MemberState *member_state);
 
-  // these 2 methods require the lock to held by the caller
   Status check_selector_usage(SelectorUsage attempted_usage) const;
   void reset_selector_usage();
 
-  using Mutex = std::mutex;
-  using Lock = std::lock_guard<ActionProfMgr::Mutex>;
   pi_dev_tgt_t device_tgt;
   pi_p4_id_t act_prof_id;
   pi_p4info_t *p4info;
@@ -287,7 +283,6 @@ class ActionProfMgr {
   // set at construction time, cannot be changed durting the lifetime of the
   // object
   PiApiChoice pi_api_choice;
-  mutable Mutex mutex{};
 };
 
 }  // namespace proto

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -531,7 +531,7 @@ class DeviceMgrImp {
   }
 
   Status write(const p4v1::WriteRequest &request) {
-    auto write_access = access_arbitration.write_access(request);
+    auto write_access = access_arbitration.write_access(request, p4info.get());
     return write_(request);
   }
 
@@ -2745,7 +2745,6 @@ class DeviceMgrImp {
   // has non-owning pointer to table_info_store
   IdleTimeoutBuffer idle_timeout_buffer;
 
-  // ActionProfMgr is not movable because of mutex
   std::unordered_map<pi_p4_id_t, std::unique_ptr<ActionProfMgr> >
   action_profs{};
 

--- a/proto/frontend/src/table_info_store.h
+++ b/proto/frontend/src/table_info_store.h
@@ -72,9 +72,7 @@ class TableInfoStore {
 
   ~TableInfoStore();
 
-  // Let the client (DeviceMgr) be responsible for locking the table
-  // state. This is the only way to guarantee that updates to the state are
-  // consistent with lower level driver operations.
+  // Let the client be responsible for locking the table state if needed.
   Lock lock_table(pi_p4_id_t t_id) const;
 
   void add_table(pi_p4_id_t t_id);

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -25,6 +25,7 @@ test_proto_fe \
 test_proto_fe_digest \
 test_proto_fe_packet_io \
 test_proto_fe_set_pipeline_config \
+test_proto_fe_access_arbitration \
 test_server_no_pipeline_config \
 test_server_gnmi \
 test_server_arbitration \
@@ -50,7 +51,9 @@ proto_fe_common_source = $(common_source) \
 mock_switch.h \
 mock_switch.cpp \
 matchers.h \
-matchers.cpp
+matchers.cpp \
+test_proto_fe_base.h \
+test_proto_fe_base.cpp
 
 test_proto_fe_SOURCES = $(proto_fe_common_source) test_proto_fe.cpp
 test_proto_fe_digest_SOURCES = $(proto_fe_common_source) \
@@ -59,6 +62,8 @@ test_proto_fe_packet_io_SOURCES = $(proto_fe_common_source) \
 test_proto_fe_packet_io.cpp
 test_proto_fe_set_pipeline_config_SOURCES =$(proto_fe_common_source) \
 test_proto_fe_set_pipeline_config.cpp
+test_proto_fe_access_arbitration_SOURCES = $(proto_fe_common_source) \
+test_proto_fe_access_arbitration.cpp
 
 test_task_queue_SOURCES = $(proto_fe_common_source) test_task_queue.cpp
 
@@ -79,6 +84,7 @@ test_proto_fe_LDADD = $(proto_fe_libs)
 test_proto_fe_digest_LDADD = $(proto_fe_libs)
 test_proto_fe_packet_io_LDADD = $(proto_fe_libs)
 test_proto_fe_set_pipeline_config_LDADD = $(proto_fe_libs)
+test_proto_fe_access_arbitration_LDADD = $(proto_fe_libs)
 
 test_task_queue_LDADD = $(proto_fe_libs)
 
@@ -115,6 +121,7 @@ test_proto_fe_digest \
 test_proto_fe_packet_io \
 test_proto_fe_set_pipeline_config \
 test_server_no_pipeline_config \
+test_proto_fe_access_arbitration \
 test_server_gnmi \
 test_server_arbitration \
 test_pi_server \

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -3198,6 +3198,8 @@ TEST_F(DigestTest, WriteAndRead) {
   EXPECT_OK(mgr.write(request));
 }
 
+// TODO(antonin): remove this test now that we are using AccessArbitration?
+
 // This test verifies that the ReadRequest gets a unique lock (no concurrent
 // writes).
 // We inherit from MatchTableIndirectTest as a convenience (to access all table

--- a/proto/tests/test_proto_fe_access_arbitration.cpp
+++ b/proto/tests/test_proto_fe_access_arbitration.cpp
@@ -140,6 +140,8 @@ class AccessArbitrationTest : public DeviceMgrUnittestBaseTest {
 
 /* static */ constexpr std::chrono::milliseconds AccessArbitrationTest::timeout;
 
+// TODO(antonin): unify test code when possible
+
 TEST_F(AccessArbitrationTest, ConcurrentWrites) {
   int x = 0;
   auto action = [this, &x]() -> pi_status_t {
@@ -193,11 +195,7 @@ TEST_F(AccessArbitrationTest, ExclusiveWrites) {
   thread2.join();
 }
 
-class DISABLED_AccessArbitrationTest : public AccessArbitrationTest {};
-
-// TODO(antonin): this test doesn't pass at the moment because each table store
-// instance has a unique lock.
-TEST_F(DISABLED_AccessArbitrationTest, ConcurrentReads1) {
+TEST_F(AccessArbitrationTest, ConcurrentReadsSameObject) {
   int x = 0;
   auto action = [this, &x] {
     std::unique_lock<std::mutex> lock(mutex);
@@ -226,7 +224,7 @@ TEST_F(DISABLED_AccessArbitrationTest, ConcurrentReads1) {
   thread2.join();
 }
 
-TEST_F(AccessArbitrationTest, ConcurrentReads2) {
+TEST_F(AccessArbitrationTest, ConcurrentReadsDifferentObjects) {
   int x = 0;
   auto action = [this, &x] {
     std::unique_lock<std::mutex> lock(mutex);

--- a/proto/tests/test_proto_fe_access_arbitration.cpp
+++ b/proto/tests/test_proto_fe_access_arbitration.cpp
@@ -1,0 +1,289 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "PI/int/pi_int.h"
+
+#include "test_proto_fe_base.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
+
+namespace {
+
+std::string uint_to_bytes(unsigned int p) {
+  std::string res(4, '\x00');
+  for (int i = 0; i < 4; i++)
+    res[3 - i] = static_cast<char>(p >> (i * 8));
+  return res;
+}
+
+// fake entries_fetch because gmock does not let us use DoDefault in a composite
+// action
+pi_status_t fake_entries_fetch(pi_p4_id_t, pi_table_fetch_res_t *res) {
+  res->num_entries = 0;
+  res->entries = new char[32];
+  return PI_STATUS_SUCCESS;
+}
+
+}  // namespace
+
+class AccessArbitrationTest : public DeviceMgrUnittestBaseTest {
+ protected:
+  AccessArbitrationTest() {
+    t1_id = pi_p4info_table_id_from_name(p4info, "ExactOne");
+    t2_id = pi_p4info_table_id_from_name(p4info, "LpmOne");
+    a_id = pi_p4info_action_id_from_name(p4info, "actionA");
+    param_id = pi_p4info_action_param_id_from_name(p4info, a_id, "param");
+  }
+
+  template <typename MfGen>
+  p4v1::WriteRequest make_wreq(pi_p4_id_t t_id, MfGen g,
+                               unsigned int start = 0,
+                               unsigned int count = 1) const {
+    p4v1::WriteRequest req;
+    for (unsigned int i = start; i < count; i++) {
+      auto update = req.add_updates();
+      update->set_type(p4v1::Update::INSERT);
+      auto entry = update->mutable_entity()->mutable_table_entry();
+      entry->set_table_id(t_id);
+      entry->add_match()->CopyFrom(g(i));
+      auto action = entry->mutable_action()->mutable_action();
+      action->set_action_id(a_id);
+      auto param = action->add_params();
+      param->set_param_id(param_id);
+      param->set_value(std::string(6, '\x00'));
+    }
+    return req;
+  }
+
+  p4v1::WriteRequest make_wreq_t1(unsigned int start = 0,
+                                  unsigned int count = 1) const {
+    auto mf_id = pi_p4info_table_match_field_id_from_name(
+        p4info, t1_id, "header_test.field32");
+    return make_wreq(t1_id, [mf_id](unsigned int i) {
+        p4v1::FieldMatch mf;
+        mf.set_field_id(mf_id);
+        mf.mutable_exact()->set_value(uint_to_bytes(i));
+        return mf;
+    }, start, count);
+  }
+
+  p4v1::WriteRequest make_wreq_t2(unsigned int start = 0,
+                                  unsigned int count = 1) const {
+    auto mf_id = pi_p4info_table_match_field_id_from_name(
+        p4info, t2_id, "header_test.field32");
+    return make_wreq(t2_id, [mf_id](unsigned int i) {
+        p4v1::FieldMatch mf;
+        mf.set_field_id(mf_id);
+        mf.mutable_lpm()->set_value(uint_to_bytes(i));
+        mf.mutable_lpm()->set_prefix_len(32);
+        return mf;
+    }, start, count);
+  }
+
+  p4v1::ReadRequest make_rreq(pi_p4_id_t t_id) const {
+    p4v1::ReadRequest req;
+    auto entity = req.add_entities();
+    auto entry = entity->mutable_table_entry();
+    entry->set_table_id(t_id);
+    return req;
+  }
+
+  p4v1::ReadRequest make_rreq_t1() const {
+    return make_rreq(t1_id);
+  }
+
+  p4v1::ReadRequest make_rreq_t2() const {
+    return make_rreq(t2_id);
+  }
+
+  pi_p4_id_t t1_id;
+  pi_p4_id_t t2_id;
+  pi_p4_id_t a_id;
+  pi_p4_id_t param_id;
+
+  mutable std::condition_variable cv;
+  mutable std::mutex mutex;
+
+  static constexpr std::chrono::milliseconds timeout{200};
+};
+
+/* static */ constexpr std::chrono::milliseconds AccessArbitrationTest::timeout;
+
+TEST_F(AccessArbitrationTest, ConcurrentWrites) {
+  int x = 0;
+  auto action = [this, &x]() -> pi_status_t {
+    std::unique_lock<std::mutex> lock(mutex);
+    // first thread sets x to 1 and wait for value to change back to 0
+    if (x == 0) {
+      x = 1;
+      cv.notify_one();
+      EXPECT_TRUE(cv.wait_for(lock, timeout, [&x] { return x == 0; }));
+    } else {
+      x = 0;
+      cv.notify_one();
+    }
+    return PI_STATUS_SUCCESS;
+  };
+  EXPECT_CALL(*mock, table_entry_add(_, _, _, _))
+      .WillOnce(InvokeWithoutArgs(action))
+      .WillOnce(InvokeWithoutArgs(action));
+  // different tables
+  auto req1 = make_wreq_t1();
+  auto req2 = make_wreq_t2();
+  std::thread thread1([&req1, this] { mgr.write(req1); });
+  std::thread thread2([&req2, this] { mgr.write(req2); });
+  thread1.join();
+  thread2.join();
+}
+
+TEST_F(AccessArbitrationTest, ExclusiveWrites) {
+  int x = 0;
+  auto action = [this, &x]() -> pi_status_t {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (x == 0) {
+      x = 1;
+      cv.notify_one();
+      EXPECT_FALSE(cv.wait_for(lock, timeout, [&x] { return x == 0; }));
+    } else {
+      x = 0;
+      cv.notify_one();
+    }
+    return PI_STATUS_SUCCESS;
+  };
+  EXPECT_CALL(*mock, table_entry_add(_, _, _, _))
+      .WillOnce(InvokeWithoutArgs(action))
+      .WillOnce(InvokeWithoutArgs(action));
+  // same table
+  auto req1 = make_wreq_t1(0, 1);
+  auto req2 = make_wreq_t1(1, 2);
+  std::thread thread1([&req1, this] { mgr.write(req1); });
+  std::thread thread2([&req2, this] { mgr.write(req2); });
+  thread1.join();
+  thread2.join();
+}
+
+class DISABLED_AccessArbitrationTest : public AccessArbitrationTest {};
+
+// TODO(antonin): this test doesn't pass at the moment because each table store
+// instance has a unique lock.
+TEST_F(DISABLED_AccessArbitrationTest, ConcurrentReads1) {
+  int x = 0;
+  auto action = [this, &x] {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (x == 0) {
+      x = 1;
+      cv.notify_one();
+      EXPECT_TRUE(cv.wait_for(lock, timeout, [&x] { return x == 0; }));
+    } else {
+      x = 0;
+      cv.notify_one();
+    }
+  };
+  EXPECT_CALL(*mock, table_entries_fetch(_, _))
+      .WillOnce(DoAll(InvokeWithoutArgs(action), Invoke(fake_entries_fetch)))
+      .WillOnce(DoAll(InvokeWithoutArgs(action), Invoke(fake_entries_fetch)));
+  auto req = make_rreq_t1();
+  std::thread thread1([&req, this] {
+      p4v1::ReadResponse rep;
+      mgr.read(req, &rep);
+  });
+  std::thread thread2([&req, this] {
+      p4v1::ReadResponse rep;
+      mgr.read(req, &rep);
+  });
+  thread1.join();
+  thread2.join();
+}
+
+TEST_F(AccessArbitrationTest, ConcurrentReads2) {
+  int x = 0;
+  auto action = [this, &x] {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (x == 0) {
+      x = 1;
+      cv.notify_one();
+      EXPECT_TRUE(cv.wait_for(lock, timeout, [&x] { return x == 0; }));
+    } else {
+      x = 0;
+      cv.notify_one();
+    }
+  };
+  EXPECT_CALL(*mock, table_entries_fetch(_, _))
+      .WillOnce(DoAll(InvokeWithoutArgs(action), Invoke(fake_entries_fetch)))
+      .WillOnce(DoAll(InvokeWithoutArgs(action), Invoke(fake_entries_fetch)));
+  auto req1 = make_rreq_t1();
+  auto req2 = make_rreq_t2();
+  std::thread thread1([&req1, this] {
+      p4v1::ReadResponse rep;
+      mgr.read(req1, &rep);
+  });
+  std::thread thread2([&req2, this] {
+      p4v1::ReadResponse rep;
+      mgr.read(req2, &rep);
+  });
+  thread1.join();
+  thread2.join();
+}
+
+TEST_F(AccessArbitrationTest, ExclusiveReadAndWrite) {
+  int x = 0;
+  auto action = [this, &x] {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (x == 0) {
+      x = 1;
+      cv.notify_one();
+      EXPECT_FALSE(cv.wait_for(lock, timeout, [&x] { return x == 0; }));
+    } else {
+      x = 0;
+      cv.notify_one();
+    }
+  };
+  EXPECT_CALL(*mock, table_entries_fetch(_, _))
+      .WillOnce(DoAll(InvokeWithoutArgs(action), Invoke(fake_entries_fetch)));
+  EXPECT_CALL(*mock, table_entry_add(_, _, _, _))
+      .WillOnce(DoAll(InvokeWithoutArgs(action), Return(PI_STATUS_SUCCESS)));
+  auto wreq = make_wreq_t1();
+  auto rreq = make_rreq_t1();
+  std::thread thread1([&wreq, this] { mgr.write(wreq); });
+  std::thread thread2([&rreq, this] {
+      p4v1::ReadResponse rep;
+      mgr.read(rreq, &rep);
+  });
+  thread1.join();
+  thread2.join();
+}
+
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi

--- a/proto/tests/test_proto_fe_base.cpp
+++ b/proto/tests/test_proto_fe_base.cpp
@@ -1,0 +1,34 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "test_proto_fe_base.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+
+constexpr const char *DeviceMgrBaseTest::invalid_p4_id_error_str;
+
+pi_p4info_t *DeviceMgrUnittestBaseTest::p4info = nullptr;
+p4configv1::P4Info DeviceMgrUnittestBaseTest::p4info_proto;
+
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi

--- a/proto/tests/test_proto_fe_base.h
+++ b/proto/tests/test_proto_fe_base.h
@@ -1,0 +1,175 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef PROTO_TESTS_TEST_PROTO_FE_BASE_H_
+#define PROTO_TESTS_TEST_PROTO_FE_BASE_H_
+
+#include <gmock/gmock.h>
+
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+
+#include <fstream>  // std::ifstream
+#include <string>
+
+#include "PI/frontends/proto/device_mgr.h"
+#include "PI/p4info.h"
+
+#include "PI/proto/p4info_to_and_from_proto.h"
+
+#include "google/rpc/code.pb.h"
+
+#include "matchers.h"
+#include "mock_switch.h"
+
+namespace p4v1 = ::p4::v1;
+namespace p4configv1 = ::p4::config::v1;
+
+namespace pi {
+namespace proto {
+namespace testing {
+
+using pi::fe::proto::DeviceMgr;
+using Code = ::google::rpc::Code;
+
+class DeviceMgrBaseTest : public ::testing::Test {
+  // apparently cannot be "protected" because of the use of WithParamInterface
+  // in one of the subclasses
+ public:
+  DeviceMgrBaseTest()
+      : mock(wrapper.sw()), device_id(wrapper.device_id()), mgr(device_id) { }
+
+  static void SetUpTestCase() {
+    DeviceMgr::init(256);
+  }
+
+  static void TearDownTestCase() {
+    DeviceMgr::destroy();
+  }
+
+  DeviceMgr::Status set_pipeline_config(
+      p4configv1::P4Info *p4info_proto,
+      uint64_t cookie = 0,
+      const std::string &device_config = defaultDeviceConfig) {
+    p4v1::ForwardingPipelineConfig config;
+    config.set_allocated_p4info(p4info_proto);
+    config.mutable_cookie()->set_cookie(cookie);
+    config.set_p4_device_config(device_config);
+    auto status = mgr.pipeline_config_set(
+        p4v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT, config);
+    config.release_p4info();
+    return status;
+  }
+
+  DeviceMgr::Status generic_write(p4v1::Update::Type type,
+                                  p4v1::TableEntry *entry) {
+    p4v1::WriteRequest request;
+    auto update = request.add_updates();
+    update->set_type(type);
+    auto entity = update->mutable_entity();
+    entity->set_allocated_table_entry(entry);
+    auto status = mgr.write(request);
+    entity->release_table_entry();
+    return status;
+  }
+
+  DeviceMgr::Status add_entry(p4v1::TableEntry *entry) {
+    return generic_write(p4v1::Update::INSERT, entry);
+  }
+
+  DeviceMgr::Status remove_entry(p4v1::TableEntry *entry) {
+    return generic_write(p4v1::Update::DELETE, entry);
+  }
+
+  DeviceMgr::Status modify_entry(p4v1::TableEntry *entry) {
+    return generic_write(p4v1::Update::MODIFY, entry);
+  }
+
+  DeviceMgr::Status read_table_entries(pi_p4_id_t t_id,
+                                       p4v1::ReadResponse *response) {
+    p4v1::Entity entity;
+    auto table_entry = entity.mutable_table_entry();
+    table_entry->set_table_id(t_id);
+    return mgr.read_one(entity, response);
+  }
+
+  DeviceMgr::Status read_table_entry(p4v1::TableEntry *table_entry,
+                                     p4v1::ReadResponse *response) {
+    p4v1::Entity entity;
+    entity.set_allocated_table_entry(table_entry);
+    auto status = mgr.read_one(entity, response);
+    entity.release_table_entry();
+    return status;
+  }
+
+  static constexpr const char *defaultDeviceConfig =
+      "This is a dummy device config";
+  static constexpr const char *invalid_p4_id_error_str = "Invalid P4 id";
+
+  DummySwitchWrapper wrapper{};
+  DummySwitchMock *mock;
+  device_id_t device_id;
+  DeviceMgr mgr;
+};
+
+class DeviceMgrUnittestBaseTest : public DeviceMgrBaseTest {
+ public:
+  static void SetUpTestCase() {
+    DeviceMgrBaseTest::SetUpTestCase();
+    std::ifstream istream(input_path);
+    google::protobuf::io::IstreamInputStream istream_(&istream);
+    google::protobuf::TextFormat::Parse(&istream_, &p4info_proto);
+    pi::p4info::p4info_proto_reader(p4info_proto, &p4info);
+  }
+
+  static void TearDownTestCase() {
+    pi_destroy_config(p4info);
+    DeviceMgrBaseTest::TearDownTestCase();
+  }
+
+  void SetUp() override {
+    dummy_device_config = defaultDeviceConfig;
+    EXPECT_CALL(*mock, action_prof_api_support())
+        .WillRepeatedly(::testing::Return(action_prof_api_choice));
+    EXPECT_CALL(*mock, table_idle_timeout_config_set(
+        pi_p4info_table_id_from_name(p4info, "IdleTimeoutTable"),
+        ::testing::_));
+    auto status = set_pipeline_config(
+        &p4info_proto, cookie, dummy_device_config);
+    ASSERT_OK(status);
+  }
+
+  void TearDown() override { }
+
+  static constexpr const char *input_path =
+           TESTDATADIR "/" "unittest.p4info.txt";
+  static pi_p4info_t *p4info;
+  static p4configv1::P4Info p4info_proto;
+
+  uint64_t cookie{666};
+  PiActProfApiSupport action_prof_api_choice{PiActProfApiSupport_BOTH};
+  std::string dummy_device_config;
+};
+
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi
+
+#endif  // PROTO_TESTS_TEST_PROTO_FE_BASE_H_

--- a/proto/tests/test_proto_fe_digest.cpp
+++ b/proto/tests/test_proto_fe_digest.cpp
@@ -43,9 +43,7 @@
 
 #include "matchers.h"
 #include "mock_switch.h"
-
-namespace p4v1 = ::p4::v1;
-namespace p4configv1 = ::p4::config::v1;
+#include "test_proto_fe_base.h"
 
 namespace pi {
 namespace proto {
@@ -54,7 +52,6 @@ namespace {
 
 using pi::fe::proto::DigestMgr;
 using Status = DigestMgr::Status;
-using Code = ::google::rpc::Code;
 using Clock = std::chrono::steady_clock;
 using SessionTemp = pi::fe::proto::common::SessionTemp;
 
@@ -88,14 +85,13 @@ class Sample {
   std::vector<std::string> values{};
 };
 
-class DigestMgrTest : public ::testing::Test {
+class DigestMgrTest : public DeviceMgrBaseTest {
  public:
   DigestMgrTest()
-      : mock(wrapper.sw()),
-        device_id(wrapper.device_id()),
-        digest_mgr(device_id) { }
+      : digest_mgr(device_id) { }
 
   static void SetUpTestCase() {
+    DeviceMgrBaseTest::SetUpTestCase();
     std::ifstream istream(input_path);
     google::protobuf::io::IstreamInputStream istream_(&istream);
     google::protobuf::TextFormat::Parse(&istream_, &p4info_proto);
@@ -108,8 +104,6 @@ class DigestMgrTest : public ::testing::Test {
     }
     ASSERT_NE(digest_id, 0u);
   }
-
-  static void TearDownTestCase() { }
 
   void SetUp() override {
     auto status = digest_mgr.p4_change(p4info_proto);
@@ -202,9 +196,6 @@ class DigestMgrTest : public ::testing::Test {
   static pi_p4_id_t digest_id;
   static constexpr std::chrono::milliseconds defaultTimeout{100};
 
-  DummySwitchWrapper wrapper{};
-  DummySwitchMock *mock;
-  device_id_t device_id;
   std::queue<p4v1::DigestList> digests;
   mutable std::mutex mutex;
   mutable std::condition_variable cvar;

--- a/proto/tests/test_proto_fe_set_pipeline_config.cpp
+++ b/proto/tests/test_proto_fe_set_pipeline_config.cpp
@@ -37,6 +37,7 @@
 
 #include "matchers.h"
 #include "mock_switch.h"
+#include "test_proto_fe_base.h"
 
 namespace p4v1 = ::p4::v1;
 namespace p4configv1 = ::p4::config::v1;
@@ -52,19 +53,8 @@ using Code = ::google::rpc::Code;
 using ::testing::_;
 using ::testing::AnyNumber;
 
-class DeviceMgrSetPipelineConfigTest : public ::testing::Test {
+class DeviceMgrSetPipelineConfigTest : public DeviceMgrBaseTest {
  public:
-  DeviceMgrSetPipelineConfigTest()
-      : mock(wrapper.sw()), device_id(wrapper.device_id()), mgr(device_id) { }
-
-  static void SetUpTestCase() {
-    DeviceMgr::init(256);
-  }
-
-  static void TearDownTestCase() {
-    DeviceMgr::destroy();
-  }
-
   p4configv1::P4Info read_p4info(const std::string &p4info_path) {
     p4configv1::P4Info p4info_proto;
     std::ifstream istream(p4info_path);
@@ -82,22 +72,6 @@ class DeviceMgrSetPipelineConfigTest : public ::testing::Test {
     config.release_p4info();
     return status;
   }
-
-  DeviceMgr::Status add_entry(p4v1::TableEntry *entry) {
-    p4v1::WriteRequest request;
-    auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
-    auto entity = update->mutable_entity();
-    entity->set_allocated_table_entry(entry);
-    auto status = mgr.write(request);
-    entity->release_table_entry();
-    return status;
-  }
-
-  DummySwitchWrapper wrapper{};
-  DummySwitchMock *mock;
-  device_id_t device_id;
-  DeviceMgr mgr;
 };
 
 TEST_F(DeviceMgrSetPipelineConfigTest, Reconcile) {


### PR DESCRIPTION
Before processing each WriteRequest batch, we now ensure that the thread
processing the batch has exclusive access to all the objects modified in
the batch. This means that the underlying target can safely assume that
individual P4 forwarding elements are not accessed by concurrent
threads. This probably has some non neglectable overhead as we need to
iterate over the entire batch before we start processing it and we have
to perform some set operations.

This change means that we can probably get rid of some other mutexes in
the implementation (e.g. the ActionProfMgr mutex), but this needs to be
done carefully. We may be able to change TableStore locking as well; one
issue is the idle-timeout thread that accesses the store to convert the
PI match key to a P4Runtime match key.