### PR TITLE
More recent compiler versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,15 @@ services:
 matrix:
   include:
     - env: CXX=g++ CC=gcc
-    - env: CXX=g++-6 CC=gcc-6
+    - env: CXX=g++-7 CC=gcc-7
     - env: CXX=clang++-3.8 CC=clang-3.8
+    - env: CXX=clang++-6.0 CC=clang-6.0
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-xenial-6.0
 
 install:
   - docker build -t pi --build-arg IMAGE_TYPE=test --build-arg CC=$CC --build-arg CXX=$CXX -f Dockerfile.bmv2 .

--- a/Dockerfile.bmv2
+++ b/Dockerfile.bmv2
@@ -15,9 +15,9 @@ ARG MAKEFLAGS=-j2
 # removed from the image.
 ARG IMAGE_TYPE=build
 
-# Select the compiler to use. GCC 5 is available as 'gcc'/'g++'. GCC 6 is
-# available as 'gcc-6'/'g++-6'. Clang 3.8 is available as
-# 'clang-3.8'/'clang++-3.8'.
+# Select the compiler to use.
+# We install the default version of GCC (GCC 5), as well as GCC 7, clang 3.8 and
+# clang 6.0.
 ARG CC=gcc
 ARG CXX=g++
 
@@ -25,8 +25,9 @@ ENV PI_DEPS automake \
             build-essential \
             clang-3.8 \
             clang-format-3.8 \
+            clang-6.0 \
             g++ \
-            g++-6 \
+            g++-7 \
             libboost-dev \
             libboost-system-dev \
             libboost-thread-dev \

--- a/README.md
+++ b/README.md
@@ -138,3 +138,6 @@ commands:
 All contributed code must pass the style checker, which can be run with
 `./tools/check_style.sh`. If the style checker fails because of a C file, you
 can format this C file with `./tools/clang_format_check.py -s Google -i <file>`.
+
+CI uses clang-format-3.8 to validate the formatting of C files, which means that
+your contribution may fail CI if you use a different version locally.

--- a/proto/tests/server/test_gnmi.cpp
+++ b/proto/tests/server/test_gnmi.cpp
@@ -649,7 +649,7 @@ TEST_F(TestGNMISysrepo, CreateUpdateAndDelete) {
   const std::string mtu_path(
       "/openconfig-interfaces:interfaces/interface[name='eth0']/config/mtu");
 
-  auto set_mtu = [&mtu_path, &iface_name, this](unsigned int mtu) {
+  auto set_mtu = [&iface_name, this](unsigned int mtu) {
     gnmi::SetRequest req;
     auto *update = req.add_update();
     GNMIPathBuilder pb(update->mutable_path());


### PR DESCRIPTION
 * added clang-6.0
 * replaced gcc-6 with gcc-7

These are the default versions in Ubuntu 18.04

We still default to clang-format-3.8 in CI for C files formatting.

Fixes #474