### PR TITLE
More efficient entry reads and better default entry support in DeviceMgr

### DIFF
--- a/CLI/act_profs/act_prof_dump.c
+++ b/CLI/act_profs/act_prof_dump.c
@@ -88,7 +88,7 @@ pi_cli_status_t do_act_prof_dump(char *subcmd) {
 
   pi_act_prof_fetch_res_t *res;
   pi_status_t rc;
-  rc = pi_act_prof_entries_fetch(sess, dev_tgt.dev_id, act_prof_id, &res);
+  rc = pi_act_prof_entries_fetch(sess, dev_tgt, act_prof_id, &res);
   if (rc == PI_STATUS_SUCCESS) {
     printf("Successfully retrieved %zu member(s) and %zu group(s).\n",
            pi_act_prof_mbrs_num(res), pi_act_prof_grps_num(res));

--- a/CLI/table_delete.c
+++ b/CLI/table_delete.c
@@ -87,7 +87,7 @@ pi_cli_status_t do_table_delete_wkey(char *subcmd) {
   }
 
   pi_status_t rc;
-  rc = pi_table_entry_delete_wkey(sess, dev_tgt.dev_id, t_id, mk);
+  rc = pi_table_entry_delete_wkey(sess, dev_tgt, t_id, mk);
   if (rc == PI_STATUS_SUCCESS)
     printf("Entry was successfully removed.\n");
   else

--- a/CLI/table_dump.c
+++ b/CLI/table_dump.c
@@ -152,7 +152,7 @@ static pi_cli_status_t dump_entries(pi_p4_id_t t_id,
 static pi_cli_status_t dump_default_entry(pi_p4_id_t t_id) {
   pi_status_t rc;
   pi_table_entry_t entry;
-  rc = pi_table_default_action_get(sess, dev_tgt.dev_id, t_id, &entry);
+  rc = pi_table_default_action_get(sess, dev_tgt, t_id, &entry);
   if (rc == PI_STATUS_SUCCESS) {
     printf("Dumping default entry\n");
     print_action_entry(&entry);
@@ -177,7 +177,7 @@ pi_cli_status_t do_table_dump(char *subcmd) {
 
   pi_table_fetch_res_t *res;
   pi_status_t rc;
-  rc = pi_table_entries_fetch(sess, dev_tgt.dev_id, t_id, &res);
+  rc = pi_table_entries_fetch(sess, dev_tgt, t_id, &res);
   if (rc == PI_STATUS_SUCCESS) {
     printf("Successfully retrieved %zu entrie(s).\n",
            pi_table_entries_num(res));

--- a/CLI/table_modify.c
+++ b/CLI/table_modify.c
@@ -140,7 +140,7 @@ pi_cli_status_t do_table_modify_wkey(char *subcmd) {
   if (status != PI_CLI_STATUS_SUCCESS) return status;
 
   pi_status_t rc;
-  rc = pi_table_entry_modify_wkey(sess, dev_tgt.dev_id, t_id, mk, &t_entry);
+  rc = pi_table_entry_modify_wkey(sess, dev_tgt, t_id, mk, &t_entry);
   if (rc == PI_STATUS_SUCCESS)
     printf("Entry was successfully modified.\n");
   else

--- a/docs/msg_format.md
+++ b/docs/msg_format.md
@@ -7,8 +7,8 @@ describes these formats at the byte level.
 
 ## Match key
 
-The `pi_match_key_t` struct is defined in [include/PI/int/pi_int.h]
-(../include/PI/int/pi_int.h) as follows:
+The `pi_match_key_t` struct is defined in
+[include/PI/int/pi_int.h](../include/PI/int/pi_int.h) as follows:
 ```
 struct pi_match_key_s {
   const pi_p4info_t *p4info;
@@ -41,7 +41,7 @@ most-significant bits of the first byte are set to 0).
 
 ### LPM match
 
-Same as for [exact match] (#exact-match), but an additional 4 bytes are used to
+Same as for [exact match](#exact-match), but an additional 4 bytes are used to
 serialize the prefix length. Unlike for the field value, the prefix length is
 serialized in little-endian order.
 
@@ -49,11 +49,11 @@ serialized in little-endian order.
 
 The number of bytes used is equal to twice the width, in bytes, of the P4
 field. The field value is serialized first, then the mask, as per the
-description [above] (#exact-match).
+description [above](#exact-match).
 
 ### Range match
 
-As for [ternary match] (#ternary-match). the number of bytes used is twice the
+As for [ternary match](#ternary-match). the number of bytes used is twice the
 width of the match field. The 'start' of the range is serialized first, followed
 by the 'end' of the range.
 
@@ -98,7 +98,7 @@ ff | ff | 00 | 00 | 00 | 00
 
 ### Some remarks
 
- * As you can see from the previous [example] (#match-key-example), the size of
+ * As you can see from the previous [example](#match-key-example), the size of
    the key could be further reduced. It is not necessary to dedicate 4 bytes to
    the prefix length. It is also not necessary to explicitly represent
    information which is masked off (in the case of a lpm or ternary match). We
@@ -112,8 +112,8 @@ ff | ff | 00 | 00 | 00 | 00
 
 ## Action data
 
-The `pi_action_data_t` struct is defined in [include/PI/int/pi_int.h]
-(../include/PI/int/pi_int.h) as follows:
+The `pi_action_data_t` struct is defined in
+[include/PI/int/pi_int.h](../include/PI/int/pi_int.h) as follows:
 ```
 struct pi_action_data_s {
   const pi_p4info_t *p4info;
@@ -159,7 +159,7 @@ will contain the following bytes (represented here in hexadecimal):
 
 The PI provides a method to retrieve all the match entries in a table. The
 result is stored in an instance of the `pi_table_fetch_res_t` struct, which is
-defined in [include/PI/int/pi_int.h] (../include/PI/int/pi_int.h) as follows:
+defined in [include/PI/int/pi_int.h](../include/PI/int/pi_int.h) as follows:
 ```
 struct pi_table_fetch_res_s {
   const pi_p4info_t *p4info;
@@ -193,7 +193,7 @@ each match entry:
 For each match entry handle, we serialize the above information as follows:
 
  * the entry handle, as 8 bytes in little-endian order
- * the serialized match key, as described [above] (#match-key)
+ * the serialized match key, as described [above](#match-key)
  * the action entry type: 0 (`PI_ACTION_ENTRY_TYPE_NONE`), 1
    (`PI_ACTION_ENTRY_TYPE_DATA`) or 2 (`PI_ACTION_ENTRY_TYPE_INDIRECT)
  * the action entry:
@@ -202,10 +202,10 @@ For each match entry handle, we serialize the above information as follows:
      * the action id, as 4 bytes in little-endian order
      * the size of the serialized action data in bytes, as 4 bytes in
        little-endian order
-     * the serialized action data, as described [above] (#action-data)
+     * the serialized action data, as described [above](#action-data)
    * for `PI_ACTION_ENTRY_TYPE_INDIRECT`: the indirect handle, as 8 bytes in
      little-endian order
- * the entry properties; see description [below] (#entry-properties)
+ * the entry properties; see description [below](#entry-properties)
  * TODO: direct resources
 
 The target backend code does not need to worry about the other members of the

--- a/frontends_extra/cpp/PI/frontends/cpp/tables.h
+++ b/frontends_extra/cpp/PI/frontends/cpp/tables.h
@@ -88,6 +88,10 @@ class MatchKey {
 
   bool get_is_default() const;
 
+  pi_match_key_t *get() const {
+    return match_key;
+  }
+
   template <typename T>
   typename std::enable_if<std::is_integral<T>::value, error_code_t>::type
   set_exact(pi_p4_id_t f_id, T key);
@@ -136,10 +140,6 @@ class MatchKey {
   error_code_t format(pi_p4_id_t f_id, const char *ptr, size_t s,
                       size_t offset, size_t *written);
 
-  pi_match_key_t *get() const {
-    return match_key;
-  }
-
   const pi_p4info_t *p4info;
   pi_p4_id_t table_id;
   bool is_default{false};
@@ -184,6 +184,10 @@ class ActionData {
 
   pi_p4_id_t get_action_id() const;
 
+  pi_action_data_t *get() const {
+    return action_data;
+  }
+
   template <typename T>
   typename std::enable_if<std::is_integral<T>::value, error_code_t>::type
   set_arg(pi_p4_id_t ap_id, T arg);
@@ -201,10 +205,6 @@ class ActionData {
   template <typename T>
   error_code_t format(pi_p4_id_t ap_id, T v);
   error_code_t format(pi_p4_id_t ap_id, const char *ptr, size_t s);
-
-  pi_action_data_t *get() const {
-    return action_data;
-  }
 
   const pi_p4info_t *p4info;
 #ifdef __clang__

--- a/frontends_extra/cpp/src/tables.cpp
+++ b/frontends_extra/cpp/src/tables.cpp
@@ -666,8 +666,7 @@ MatchTable::entry_delete(pi_entry_handle_t entry_handle) {
 
 pi_status_t
 MatchTable::entry_delete_wkey(const MatchKey &match_key) {
-  return pi_table_entry_delete_wkey(sess, dev_tgt.dev_id, table_id,
-                                    match_key.get());
+  return pi_table_entry_delete_wkey(sess, dev_tgt, table_id, match_key.get());
 }
 
 pi_status_t
@@ -682,8 +681,8 @@ pi_status_t
 MatchTable::entry_modify_wkey(const MatchKey &match_key,
                               const ActionEntry &action_entry) {
   auto entry = build_table_entry(action_entry);
-  return pi_table_entry_modify_wkey(sess, dev_tgt.dev_id, table_id,
-                                    match_key.get(), &entry);
+  return pi_table_entry_modify_wkey(
+      sess, dev_tgt, table_id, match_key.get(), &entry);
 }
 
 pi_status_t

--- a/include/PI/pi_act_prof.h
+++ b/include/PI/pi_act_prof.h
@@ -100,12 +100,24 @@ typedef struct pi_act_prof_fetch_res_s pi_act_prof_fetch_res_t;
 
 //! Retrieve all entries in an action profile as one big blob
 pi_status_t pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
-                                      pi_dev_id_t dev_id,
+                                      pi_dev_tgt_t dev_tgt,
                                       pi_p4_id_t act_prof_id,
                                       pi_act_prof_fetch_res_t **res);
 
-//! Need to be called after a pi_act_prof_entries_fetch, once you wish the
-//! memory to be released.
+//! Retrieve single member, use pi_act_prof_mbrs_next to access it.
+pi_status_t pi_act_prof_mbr_fetch(pi_session_handle_t session_handle,
+                                  pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                  pi_indirect_handle_t mbr_handle,
+                                  pi_act_prof_fetch_res_t **res);
+
+//! Retrieve single group, use pi_act_prof_grps_next to access it.
+pi_status_t pi_act_prof_grp_fetch(pi_session_handle_t session_handle,
+                                  pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                  pi_indirect_handle_t grp_handle,
+                                  pi_act_prof_fetch_res_t **res);
+
+//! Need to be called after a pi_act_prof_entries_fetch, pi_act_prof_mbr_fetch
+//! or pi_act_prof_grp_fetch, once you wish the memory to be released.
 pi_status_t pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,
                                            pi_act_prof_fetch_res_t *res);
 

--- a/include/PI/pi_tables.h
+++ b/include/PI/pi_tables.h
@@ -143,13 +143,20 @@ pi_status_t pi_table_default_action_reset(pi_session_handle_t session_handle,
 
 //! Retrieve the default entry for a table.
 pi_status_t pi_table_default_action_get(pi_session_handle_t session_handle,
-                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
                                         pi_table_entry_t *table_entry);
 
 //! Need to be called after pi_table_default_action_get, once you wish the
 //! memory to be released.
 pi_status_t pi_table_default_action_done(pi_session_handle_t session_handle,
                                          pi_table_entry_t *table_entry);
+
+//! Retrieve the handle for the default action, guaranteed not to change during
+//! the lofetime of the program.
+pi_status_t pi_table_default_action_get_handle(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_p4_id_t table_id, pi_entry_handle_t *entry_handle);
 
 //! Delete an entry from a table using the entry handle. Should return an error
 //! if entry does not exist.
@@ -160,7 +167,8 @@ pi_status_t pi_table_entry_delete(pi_session_handle_t session_handle,
 //! Delete an entry from a table using the match key. Should return an error
 //! if entry does not exist.
 pi_status_t pi_table_entry_delete_wkey(pi_session_handle_t session_handle,
-                                       pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                       pi_dev_tgt_t dev_tgt,
+                                       pi_p4_id_t table_id,
                                        const pi_match_key_t *match_key);
 
 //! Modify an existing entry using the entry handle. Should return an error if
@@ -173,7 +181,8 @@ pi_status_t pi_table_entry_modify(pi_session_handle_t session_handle,
 //! Modify an existing entry using the match key. Should return an error if
 //! entry does not exist.
 pi_status_t pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
-                                       pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                       pi_dev_tgt_t dev_tgt,
+                                       pi_p4_id_t table_id,
                                        const pi_match_key_t *match_key,
                                        const pi_table_entry_t *table_entry);
 
@@ -181,11 +190,27 @@ typedef struct pi_table_fetch_res_s pi_table_fetch_res_t;
 
 //! Retrieve all entries in table as one big blob.
 pi_status_t pi_table_entries_fetch(pi_session_handle_t session_handle,
-                                   pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                   pi_dev_tgt_t dev_tgt, pi_p4_id_t table_id,
                                    pi_table_fetch_res_t **res);
 
-//! Need to be called after a pi_table_entries_fetch, once you wish the memory
-//! to be released.
+//! Retrieve a single entry from the handle.
+//! Return error if entry_handle is invalid.
+pi_status_t pi_table_entries_fetch_one(pi_session_handle_t session_handle,
+                                       pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                       pi_entry_handle_t entry_handle,
+                                       pi_table_fetch_res_t **res);
+
+//! Retrieve a single entry from the match key.
+//! Return empty pi_table_fetch_res_t (pi_table_entries_num returns 0) if no
+//! entry matches the provided match key.
+pi_status_t pi_table_entries_fetch_wkey(pi_session_handle_t session_handle,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
+                                        const pi_match_key_t *match_key,
+                                        pi_table_fetch_res_t **res);
+
+//! Need to be called after a fetch (any fetch), once you wish the memory to be
+//! released.
 pi_status_t pi_table_entries_fetch_done(pi_session_handle_t session_handle,
                                         pi_table_fetch_res_t *res);
 

--- a/include/PI/target/pi_act_prof_imp.h
+++ b/include/PI/target/pi_act_prof_imp.h
@@ -23,6 +23,10 @@
 
 #include <PI/pi_act_prof.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 pi_status_t _pi_act_prof_mbr_create(pi_session_handle_t session_handle,
                                     pi_dev_tgt_t dev_tgt,
                                     pi_p4_id_t act_prof_id,
@@ -76,13 +80,27 @@ pi_status_t _pi_act_prof_grp_deactivate_mbr(pi_session_handle_t session_handle,
                                             pi_indirect_handle_t mbr_handle);
 
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
-                                       pi_dev_id_t dev_id,
+                                       pi_dev_tgt_t dev_tgt,
                                        pi_p4_id_t act_prof_id,
                                        pi_act_prof_fetch_res_t *res);
+
+pi_status_t _pi_act_prof_mbr_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t mbr_handle,
+                                   pi_act_prof_fetch_res_t *res);
+
+pi_status_t _pi_act_prof_grp_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t grp_handle,
+                                   pi_act_prof_fetch_res_t *res);
 
 pi_status_t _pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,
                                             pi_act_prof_fetch_res_t *res);
 
 int _pi_act_prof_api_support(pi_dev_id_t dev_id);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // PI_INC_PI_TARGET_PI_ACT_PROF_IMP_H_

--- a/include/PI/target/pi_tables_imp.h
+++ b/include/PI/target/pi_tables_imp.h
@@ -43,19 +43,24 @@ pi_status_t _pi_table_default_action_reset(pi_session_handle_t session_handle,
                                            pi_p4_id_t table_id);
 
 pi_status_t _pi_table_default_action_get(pi_session_handle_t session_handle,
-                                         pi_dev_id_t dev_id,
+                                         pi_dev_tgt_t dev_id,
                                          pi_p4_id_t table_id,
                                          pi_table_entry_t *table_entry);
 
 pi_status_t _pi_table_default_action_done(pi_session_handle_t session_handle,
                                           pi_table_entry_t *table_entry);
 
+pi_status_t _pi_table_default_action_get_handle(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_p4_id_t table_id, pi_entry_handle_t *entry_handle);
+
 pi_status_t _pi_table_entry_delete(pi_session_handle_t session_handle,
                                    pi_dev_id_t dev_id, pi_p4_id_t table_id,
                                    pi_entry_handle_t entry_handle);
 
 pi_status_t _pi_table_entry_delete_wkey(pi_session_handle_t session_handle,
-                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
                                         const pi_match_key_t *match_key);
 
 pi_status_t _pi_table_entry_modify(pi_session_handle_t session_handle,
@@ -64,13 +69,25 @@ pi_status_t _pi_table_entry_modify(pi_session_handle_t session_handle,
                                    const pi_table_entry_t *table_entry);
 
 pi_status_t _pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
-                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
                                         const pi_match_key_t *match_key,
                                         const pi_table_entry_t *table_entry);
 
 pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
-                                    pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                    pi_dev_tgt_t dev_tgt, pi_p4_id_t table_id,
                                     pi_table_fetch_res_t *res);
+
+pi_status_t _pi_table_entries_fetch_one(pi_session_handle_t session_handle,
+                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_entry_handle_t entry_handle,
+                                        pi_table_fetch_res_t *res);
+
+pi_status_t _pi_table_entries_fetch_wkey(pi_session_handle_t session_handle,
+                                         pi_dev_tgt_t dev_tgt,
+                                         pi_p4_id_t table_id,
+                                         const pi_match_key_t *match_key,
+                                         pi_table_fetch_res_t *res);
 
 pi_status_t _pi_table_entries_fetch_done(pi_session_handle_t session_handle,
                                          pi_table_fetch_res_t *res);

--- a/proto/tests/matchers.cpp
+++ b/proto/tests/matchers.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <gmock/gmock.h>
+#include <google/protobuf/util/message_differencer.h>
 
 #include <cstring>
 #include <ostream>
@@ -56,6 +57,27 @@ IsOkMatcher::DescribeTo(std::ostream *os) const {
 void
 IsOkMatcher::DescribeNegationTo(std::ostream *os) const {
   *os << "is not OK";
+}
+
+ProtoEqMatcher::ProtoEqMatcher(const ::google::protobuf::Message &expected)
+    : expected(expected) { }
+
+bool
+ProtoEqMatcher::MatchAndExplain(const ::google::protobuf::Message &actual,
+                                MatchResultListener *listener) const {
+  using ::google::protobuf::util::MessageDifferencer;
+  *listener << actual.DebugString();
+  return MessageDifferencer::Equals(actual, expected);
+}
+
+void
+ProtoEqMatcher::DescribeTo(std::ostream *os) const {
+  *os << "is equal to:\n" << expected.DebugString();
+}
+
+void
+ProtoEqMatcher::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not equal to:\n" << expected.DebugString();
 }
 
 MatchKeyMatcher::MatchKeyMatcher(pi_p4_id_t t_id, const std::string &v)

--- a/proto/tests/matchers.h
+++ b/proto/tests/matchers.h
@@ -59,6 +59,34 @@ inline Matcher<::google::rpc::Status> IsOk() {
 #define ASSERT_OK(status) ASSERT_THAT(status, IsOk())
 #define EXPECT_OK(status) EXPECT_THAT(status, IsOk())
 
+// Very poor man's version of EqualsProto, which is not available in gmock yet
+// See https://github.com/google/googletest/issues/1761
+
+class ProtoEqMatcher
+    : public MatcherInterface<const ::google::protobuf::Message &> {
+ public:
+  explicit ProtoEqMatcher(const ::google::protobuf::Message &expected);
+
+ private:
+  bool MatchAndExplain(const ::google::protobuf::Message &actual,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+  const ::google::protobuf::Message &expected;
+};
+
+inline Matcher<const ::google::protobuf::Message &> ProtoEq(
+    const ::google::protobuf::Message &expected) {
+  return MakeMatcher(new ProtoEqMatcher(expected));
+}
+
+#define EXPECT_PROTO_EQ(actual, expected) \
+  EXPECT_THAT(actual, ProtoEq(expected));
+
+
 // This is a very verbose matcher but it has the advantage to print convenient
 // error messages. Not sure I could achieve such a nice result by only using
 // googlemock base matchers (e.g. Field...)

--- a/proto/tests/mock_switch.h
+++ b/proto/tests/mock_switch.h
@@ -23,6 +23,7 @@
 
 #include <gmock/gmock.h>
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -54,6 +55,9 @@ class DummySwitch;
 
 class DummySwitchMock {
  public:
+  static constexpr pi_entry_handle_t defaultEntryHandle =
+      std::numeric_limits<pi_entry_handle_t>::max();
+
   explicit DummySwitchMock(device_id_t device_id);
 
   ~DummySwitchMock();
@@ -115,6 +119,8 @@ class DummySwitchMock {
   MOCK_METHOD1(table_default_action_reset, pi_status_t(pi_p4_id_t));
   MOCK_METHOD2(table_default_action_get,
                pi_status_t(pi_p4_id_t, pi_table_entry_t *));
+  MOCK_METHOD2(table_default_action_get_handle,
+               pi_status_t(pi_p4_id_t, pi_entry_handle_t *));
   MOCK_METHOD2(table_entry_delete_wkey,
                pi_status_t(pi_p4_id_t, const pi_match_key_t *));
   MOCK_METHOD3(table_entry_modify_wkey,
@@ -122,6 +128,9 @@ class DummySwitchMock {
                            const pi_table_entry_t *));
   MOCK_METHOD2(table_entries_fetch,
                pi_status_t(pi_p4_id_t, pi_table_fetch_res_t *));
+  MOCK_METHOD3(table_entries_fetch_wkey,
+               pi_status_t(pi_p4_id_t, const pi_match_key_t *,
+                           pi_table_fetch_res_t *));
   MOCK_METHOD2(table_idle_timeout_config_set,
                pi_status_t(pi_p4_id_t, const pi_idle_timeout_config_t *));
   MOCK_METHOD3(table_entry_get_remaining_ttl,
@@ -157,6 +166,12 @@ class DummySwitchMock {
                            pi_indirect_handle_t));
   MOCK_METHOD2(action_prof_entries_fetch,
                pi_status_t(pi_p4_id_t, pi_act_prof_fetch_res_t *));
+  MOCK_METHOD3(action_prof_member_fetch,
+               pi_status_t(pi_p4_id_t, pi_indirect_handle_t,
+                           pi_act_prof_fetch_res_t *));
+  MOCK_METHOD3(action_prof_group_fetch,
+               pi_status_t(pi_p4_id_t, pi_indirect_handle_t,
+                           pi_act_prof_fetch_res_t *));
   MOCK_METHOD0(action_prof_api_support, int());
 
   MOCK_METHOD3(meter_read,

--- a/proto/tests/test_proto_fe_base.h
+++ b/proto/tests/test_proto_fe_base.h
@@ -78,6 +78,12 @@ class DeviceMgrBaseTest : public ProtoFrontendBaseTest {
       p4configv1::P4Info *p4info_proto,
       uint64_t cookie = 0,
       const std::string &device_config = defaultDeviceConfig) {
+    using ::testing::_;
+    EXPECT_CALL(*mock, action_prof_api_support())
+        .WillRepeatedly(::testing::Return(action_prof_api_choice));
+    EXPECT_CALL(*mock, table_default_action_get_handle(_, _))
+        .Times(::testing::AnyNumber());
+
     p4v1::ForwardingPipelineConfig config;
     config.set_allocated_p4info(p4info_proto);
     config.mutable_cookie()->set_cookie(cookie);
@@ -134,6 +140,7 @@ class DeviceMgrBaseTest : public ProtoFrontendBaseTest {
   static constexpr const char *invalid_p4_id_error_str = "Invalid P4 id";
 
   DeviceMgr mgr;
+  PiActProfApiSupport action_prof_api_choice{PiActProfApiSupport_BOTH};
 };
 
 class DeviceMgrUnittestBaseTest : public DeviceMgrBaseTest {
@@ -153,8 +160,6 @@ class DeviceMgrUnittestBaseTest : public DeviceMgrBaseTest {
 
   void SetUp() override {
     dummy_device_config = defaultDeviceConfig;
-    EXPECT_CALL(*mock, action_prof_api_support())
-        .WillRepeatedly(::testing::Return(action_prof_api_choice));
     EXPECT_CALL(*mock, table_idle_timeout_config_set(
         pi_p4info_table_id_from_name(p4info, "IdleTimeoutTable"),
         ::testing::_));
@@ -171,7 +176,6 @@ class DeviceMgrUnittestBaseTest : public DeviceMgrBaseTest {
   static p4configv1::P4Info p4info_proto;
 
   uint64_t cookie{666};
-  PiActProfApiSupport action_prof_api_choice{PiActProfApiSupport_BOTH};
   std::string dummy_device_config;
 };
 

--- a/proto/tests/test_proto_fe_set_pipeline_config.cpp
+++ b/proto/tests/test_proto_fe_set_pipeline_config.cpp
@@ -66,6 +66,11 @@ class DeviceMgrSetPipelineConfigTest : public DeviceMgrBaseTest {
   DeviceMgr::Status set_pipeline_config(
       p4configv1::P4Info *p4info_proto,
       p4v1::SetForwardingPipelineConfigRequest_Action action) {
+    EXPECT_CALL(*mock, action_prof_api_support())
+        .Times(AnyNumber());
+    EXPECT_CALL(*mock, table_default_action_get_handle(_, _))
+        .Times(AnyNumber());
+
     p4v1::ForwardingPipelineConfig config;
     config.set_allocated_p4info(p4info_proto);
     auto status = mgr.pipeline_config_set(action, config);

--- a/src/pi_rpc_server.c
+++ b/src/pi_rpc_server.c
@@ -467,8 +467,8 @@ static void __pi_table_default_action_get(char *req) {
 
   pi_session_handle_t sess;
   req += retrieve_session_handle(req, &sess);
-  pi_dev_id_t dev_id;
-  req += retrieve_dev_id(req, &dev_id);
+  pi_dev_tgt_t dev_tgt;
+  req += retrieve_dev_tgt(req, &dev_tgt);
   pi_p4_id_t table_id;
   req += retrieve_p4_id(req, &table_id);
 
@@ -476,7 +476,7 @@ static void __pi_table_default_action_get(char *req) {
   // not supported yet for entry retrieval
   default_entry.direct_res_config = NULL;
   pi_status_t status =
-      _pi_table_default_action_get(sess, dev_id, table_id, &default_entry);
+      _pi_table_default_action_get(sess, dev_tgt, table_id, &default_entry);
 
   size_t s = 0;
   s += sizeof(rep_hdr_t);
@@ -518,8 +518,8 @@ static void __pi_table_entry_delete_wkey(char *req) {
 
   pi_session_handle_t sess;
   req += retrieve_session_handle(req, &sess);
-  pi_dev_id_t dev_id;
-  req += retrieve_dev_id(req, &dev_id);
+  pi_dev_tgt_t dev_tgt;
+  req += retrieve_dev_tgt(req, &dev_tgt);
   pi_p4_id_t table_id;
   req += retrieve_p4_id(req, &table_id);
   pi_match_key_t match_key;
@@ -527,7 +527,7 @@ static void __pi_table_entry_delete_wkey(char *req) {
   match_key.table_id = table_id;
   req += retrieve_match_key(req, &match_key);
 
-  send_status(_pi_table_entry_delete_wkey(sess, dev_id, table_id, &match_key));
+  send_status(_pi_table_entry_delete_wkey(sess, dev_tgt, table_id, &match_key));
 }
 
 static void __pi_table_entry_modify_common(char *req, bool wkey) {
@@ -535,7 +535,12 @@ static void __pi_table_entry_modify_common(char *req, bool wkey) {
   pi_session_handle_t sess;
   req += retrieve_session_handle(req, &sess);
   pi_dev_id_t dev_id;
-  req += retrieve_dev_id(req, &dev_id);
+  pi_dev_tgt_t dev_tgt;
+  if (wkey) {
+    req += retrieve_dev_tgt(req, &dev_tgt);
+  } else {
+    req += retrieve_dev_id(req, &dev_id);
+  }
   pi_p4_id_t table_id;
   req += retrieve_p4_id(req, &table_id);
 
@@ -560,7 +565,7 @@ static void __pi_table_entry_modify_common(char *req, bool wkey) {
   pi_status_t status;
 
   if (wkey) {
-    status = _pi_table_entry_modify_wkey(sess, dev_id, table_id, &match_key,
+    status = _pi_table_entry_modify_wkey(sess, dev_tgt, table_id, &match_key,
                                          &table_entry);
   } else {
     status = _pi_table_entry_modify(sess, dev_id, table_id, h, &table_entry);
@@ -586,13 +591,13 @@ static void __pi_table_entries_fetch(char *req) {
 
   pi_session_handle_t sess;
   req += retrieve_session_handle(req, &sess);
-  pi_dev_id_t dev_id;
-  req += retrieve_dev_id(req, &dev_id);
+  pi_dev_tgt_t dev_tgt;
+  req += retrieve_dev_tgt(req, &dev_tgt);
   pi_p4_id_t table_id;
   req += retrieve_p4_id(req, &table_id);
 
   pi_table_fetch_res_t res;
-  pi_status_t status = _pi_table_entries_fetch(sess, dev_id, table_id, &res);
+  pi_status_t status = _pi_table_entries_fetch(sess, dev_tgt, table_id, &res);
 
   if (status != PI_STATUS_SUCCESS) {
     send_status(status);
@@ -780,14 +785,14 @@ static void __pi_act_prof_entries_fetch(char *req) {
 
   pi_session_handle_t sess;
   req += retrieve_session_handle(req, &sess);
-  pi_dev_id_t dev_id;
-  req += retrieve_dev_id(req, &dev_id);
+  pi_dev_tgt_t dev_tgt;
+  req += retrieve_dev_tgt(req, &dev_tgt);
   pi_p4_id_t act_prof_id;
   req += retrieve_p4_id(req, &act_prof_id);
 
   pi_act_prof_fetch_res_t res;
   pi_status_t status =
-      _pi_act_prof_entries_fetch(sess, dev_id, act_prof_id, &res);
+      _pi_act_prof_entries_fetch(sess, dev_tgt, act_prof_id, &res);
 
   if (status != PI_STATUS_SUCCESS) {
     send_status(status);

--- a/targets/bmv2/pi_act_prof_imp.cpp
+++ b/targets/bmv2/pi_act_prof_imp.cpp
@@ -273,7 +273,7 @@ pi_status_t _pi_act_prof_grp_activate_mbr(pi_session_handle_t session_handle,
   (void)act_prof_id;
   (void)grp_handle;
   (void)mbr_handle;
-  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
 }
 
 pi_status_t _pi_act_prof_grp_deactivate_mbr(pi_session_handle_t session_handle,
@@ -286,21 +286,21 @@ pi_status_t _pi_act_prof_grp_deactivate_mbr(pi_session_handle_t session_handle,
   (void)act_prof_id;
   (void)grp_handle;
   (void)mbr_handle;
-  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
 }
 
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
-                                       pi_dev_id_t dev_id,
+                                       pi_dev_tgt_t dev_tgt,
                                        pi_p4_id_t act_prof_id,
                                        pi_act_prof_fetch_res_t *res) {
   (void) session_handle;
 
-  pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_id);
+  pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(d_info->assigned);
   const pi_p4info_t *p4info = d_info->p4info;
   std::string ap_name(pi_p4info_act_prof_name_from_id(p4info, act_prof_id));
 
-  auto client = conn_mgr_client(pibmv2::conn_mgr_state, dev_id);
+  auto client = conn_mgr_client(pibmv2::conn_mgr_state, dev_tgt.dev_id);
 
   std::vector<BmMtActProfMember> members;
   std::vector<BmMtActProfGroup> groups;
@@ -375,6 +375,32 @@ pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
   }
 
   return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_act_prof_mbr_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t mbr_handle,
+                                   pi_act_prof_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)mbr_handle;
+  (void)res;
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+}
+
+pi_status_t _pi_act_prof_grp_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t grp_handle,
+                                   pi_act_prof_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)grp_handle;
+  (void)res;
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
 }
 
 pi_status_t _pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,

--- a/targets/dummy/pi_act_prof_imp.c
+++ b/targets/dummy/pi_act_prof_imp.c
@@ -19,6 +19,7 @@
  */
 
 #include "PI/pi.h"
+#include "PI/target/pi_act_prof_imp.h"
 
 #include <stdio.h>
 
@@ -157,12 +158,38 @@ pi_status_t _pi_act_prof_grp_deactivate_mbr(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
-                                       pi_dev_id_t dev_id,
+                                       pi_dev_tgt_t dev_tgt,
                                        pi_p4_id_t act_prof_id,
                                        pi_act_prof_fetch_res_t *res) {
   (void)session_handle;
+  (void)dev_tgt;
+  (void)act_prof_id;
+  (void)res;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_act_prof_mbr_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t mbr_handle,
+                                   pi_act_prof_fetch_res_t *res) {
+  (void)session_handle;
   (void)dev_id;
   (void)act_prof_id;
+  (void)mbr_handle;
+  (void)res;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_act_prof_grp_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t grp_handle,
+                                   pi_act_prof_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)grp_handle;
   (void)res;
   func_counter_increment(__func__);
   return PI_STATUS_SUCCESS;

--- a/targets/dummy/pi_tables_imp.c
+++ b/targets/dummy/pi_tables_imp.c
@@ -19,6 +19,7 @@
  */
 
 #include "PI/pi.h"
+#include "PI/target/pi_tables_imp.h"
 
 #include <stdio.h>
 
@@ -64,11 +65,11 @@ pi_status_t _pi_table_default_action_reset(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_default_action_get(pi_session_handle_t session_handle,
-                                         pi_dev_id_t dev_id,
+                                         pi_dev_tgt_t dev_tgt,
                                          pi_p4_id_t table_id,
                                          pi_table_entry_t *table_entry) {
   (void)session_handle;
-  (void)dev_id;
+  (void)dev_tgt;
   (void)table_id;
   (void)table_entry;
   func_counter_increment(__func__);
@@ -79,6 +80,17 @@ pi_status_t _pi_table_default_action_done(pi_session_handle_t session_handle,
                                           pi_table_entry_t *table_entry) {
   (void)session_handle;
   (void)table_entry;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_table_default_action_get_handle(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_p4_id_t table_id, pi_entry_handle_t *entry_handle) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)table_id;
+  (void)entry_handle;
   func_counter_increment(__func__);
   return PI_STATUS_SUCCESS;
 }
@@ -95,10 +107,11 @@ pi_status_t _pi_table_entry_delete(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_entry_delete_wkey(pi_session_handle_t session_handle,
-                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
                                         const pi_match_key_t *match_key) {
   (void)session_handle;
-  (void)dev_id;
+  (void)dev_tgt;
   (void)table_id;
   (void)match_key;
   func_counter_increment(__func__);
@@ -119,11 +132,12 @@ pi_status_t _pi_table_entry_modify(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
-                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
                                         const pi_match_key_t *match_key,
                                         const pi_table_entry_t *table_entry) {
   (void)session_handle;
-  (void)dev_id;
+  (void)dev_tgt;
   (void)table_id;
   (void)match_key;
   (void)table_entry;
@@ -132,11 +146,38 @@ pi_status_t _pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
-                                    pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                    pi_dev_tgt_t dev_tgt, pi_p4_id_t table_id,
                                     pi_table_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)table_id;
+  (void)res;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_table_entries_fetch_one(pi_session_handle_t session_handle,
+                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_entry_handle_t entry_handle,
+                                        pi_table_fetch_res_t *res) {
   (void)session_handle;
   (void)dev_id;
   (void)table_id;
+  (void)entry_handle;
+  (void)res;
+  func_counter_increment(__func__);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_table_entries_fetch_wkey(pi_session_handle_t session_handle,
+                                         pi_dev_tgt_t dev_tgt,
+                                         pi_p4_id_t table_id,
+                                         const pi_match_key_t *match_key,
+                                         pi_table_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)table_id;
+  (void)match_key;
   (void)res;
   func_counter_increment(__func__);
   return PI_STATUS_SUCCESS;

--- a/targets/rpc/pi_act_prof_imp.c
+++ b/targets/rpc/pi_act_prof_imp.c
@@ -280,7 +280,7 @@ pi_status_t _pi_act_prof_grp_deactivate_mbr(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
-                                       pi_dev_id_t dev_id,
+                                       pi_dev_tgt_t dev_tgt,
                                        pi_p4_id_t act_prof_id,
                                        pi_act_prof_fetch_res_t *res) {
   if (!state.init) return PI_STATUS_RPC_NOT_INIT;
@@ -288,7 +288,7 @@ pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
   typedef struct __attribute__((packed)) {
     req_hdr_t hdr;
     s_pi_session_handle_t sess;
-    s_pi_dev_id_t dev_id;
+    s_pi_dev_tgt_t dev_tgt;
     s_pi_p4_id_t act_prof_id;
   } req_t;
   req_t req;
@@ -296,7 +296,7 @@ pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
   pi_rpc_id_t req_id = state.req_id++;
   req_ += emit_req_hdr(req_, req_id, PI_RPC_ACT_PROF_ENTRIES_FETCH);
   req_ += emit_session_handle(req_, session_handle);
-  req_ += emit_dev_id(req_, dev_id);
+  req_ += emit_dev_tgt(req_, dev_tgt);
   req_ += emit_p4_id(req_, act_prof_id);
 
   int rc = nn_send(state.s, &req, sizeof(req), 0);
@@ -341,6 +341,30 @@ pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
 
   nn_freemsg(rep);
   return status;
+}
+
+pi_status_t _pi_act_prof_mbr_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t mbr_handle,
+                                   pi_act_prof_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)mbr_handle;
+  (void)res;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_act_prof_grp_fetch(pi_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id, pi_p4_id_t act_prof_id,
+                                   pi_indirect_handle_t grp_handle,
+                                   pi_act_prof_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)act_prof_id;
+  (void)grp_handle;
+  (void)res;
+  return PI_STATUS_SUCCESS;
 }
 
 pi_status_t _pi_act_prof_entries_fetch_done(pi_session_handle_t session_handle,

--- a/targets/rpc/pi_learn_imp.c
+++ b/targets/rpc/pi_learn_imp.c
@@ -32,7 +32,7 @@ pi_status_t _pi_learn_config_set(pi_session_handle_t session_handle,
   (void)dev_id;
   (void)learn_id;
   (void)config;
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
 }
 
 pi_status_t _pi_learn_msg_ack(pi_session_handle_t session_handle,

--- a/targets/rpc/pi_tables_imp.c
+++ b/targets/rpc/pi_tables_imp.c
@@ -18,6 +18,8 @@
  *
  */
 
+#include <PI/target/pi_tables_imp.h>
+
 #include "pi_rpc.h"
 
 #include <stdlib.h>
@@ -148,7 +150,7 @@ pi_status_t _pi_table_default_action_reset(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_default_action_get(pi_session_handle_t session_handle,
-                                         pi_dev_id_t dev_id,
+                                         pi_dev_tgt_t dev_tgt,
                                          pi_p4_id_t table_id,
                                          pi_table_entry_t *table_entry) {
   if (!state.init) return PI_STATUS_RPC_NOT_INIT;
@@ -156,7 +158,7 @@ pi_status_t _pi_table_default_action_get(pi_session_handle_t session_handle,
   typedef struct __attribute__((packed)) {
     req_hdr_t hdr;
     s_pi_session_handle_t sess;
-    s_pi_dev_id_t dev_id;
+    s_pi_dev_tgt_t dev_tgt;
     s_pi_p4_id_t table_id;
   } req_t;
   req_t req;
@@ -164,7 +166,7 @@ pi_status_t _pi_table_default_action_get(pi_session_handle_t session_handle,
   pi_rpc_id_t req_id = state.req_id++;
   req_ += emit_req_hdr(req_, req_id, PI_RPC_TABLE_DEFAULT_ACTION_GET);
   req_ += emit_session_handle(req_, session_handle);
-  req_ += emit_dev_id(req_, dev_id);
+  req_ += emit_dev_tgt(req_, dev_tgt);
   req_ += emit_p4_id(req_, table_id);
 
   int rc = nn_send(state.s, &req, sizeof(req), 0);
@@ -199,6 +201,16 @@ pi_status_t _pi_table_default_action_done(pi_session_handle_t session_handle,
   return PI_STATUS_SUCCESS;
 }
 
+pi_status_t _pi_table_default_action_get_handle(
+    pi_session_handle_t session_handle, pi_dev_tgt_t dev_tgt,
+    pi_p4_id_t table_id, pi_entry_handle_t *entry_handle) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)table_id;
+  (void)entry_handle;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
 pi_status_t _pi_table_entry_delete(pi_session_handle_t session_handle,
                                    pi_dev_id_t dev_id, pi_p4_id_t table_id,
                                    pi_entry_handle_t entry_handle) {
@@ -227,14 +239,15 @@ pi_status_t _pi_table_entry_delete(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_entry_delete_wkey(pi_session_handle_t session_handle,
-                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
                                         const pi_match_key_t *match_key) {
   if (!state.init) return PI_STATUS_RPC_NOT_INIT;
 
   size_t s = 0;
   s += sizeof(req_hdr_t);
   s += sizeof(s_pi_session_handle_t);
-  s += sizeof(s_pi_dev_id_t);
+  s += sizeof(s_pi_dev_tgt_t);
   s += sizeof(s_pi_p4_id_t);  // table_id
   s += match_key_size(match_key);
 
@@ -243,7 +256,7 @@ pi_status_t _pi_table_entry_delete_wkey(pi_session_handle_t session_handle,
   pi_rpc_id_t req_id = state.req_id++;
   req_ += emit_req_hdr(req_, req_id, PI_RPC_TABLE_ENTRY_DELETE_WKEY);
   req_ += emit_session_handle(req_, session_handle);
-  req_ += emit_dev_id(req_, dev_id);
+  req_ += emit_dev_tgt(req_, dev_tgt);
   req_ += emit_p4_id(req_, table_id);
   req_ += emit_match_key(req_, match_key);
 
@@ -290,7 +303,8 @@ pi_status_t _pi_table_entry_modify(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
-                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_dev_tgt_t dev_tgt,
+                                        pi_p4_id_t table_id,
                                         const pi_match_key_t *match_key,
                                         const pi_table_entry_t *table_entry) {
   if (!state.init) return PI_STATUS_RPC_NOT_INIT;
@@ -298,8 +312,8 @@ pi_status_t _pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
   size_t s = 0;
   s += sizeof(req_hdr_t);
   s += sizeof(s_pi_session_handle_t);
-  s += sizeof(s_pi_dev_id_t);  // dev_id
-  s += sizeof(s_pi_p4_id_t);   // table_id
+  s += sizeof(s_pi_dev_tgt_t);
+  s += sizeof(s_pi_p4_id_t);  // table_id
   s += match_key_size(match_key);
   s += table_entry_size(table_entry);
 
@@ -308,7 +322,7 @@ pi_status_t _pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
   pi_rpc_id_t req_id = state.req_id++;
   req_ += emit_req_hdr(req_, req_id, PI_RPC_TABLE_ENTRY_MODIFY_WKEY);
   req_ += emit_session_handle(req_, session_handle);
-  req_ += emit_dev_id(req_, dev_id);
+  req_ += emit_dev_tgt(req_, dev_tgt);
   req_ += emit_p4_id(req_, table_id);
   req_ += emit_match_key(req_, match_key);
   req_ += emit_table_entry(req_, table_entry);
@@ -323,14 +337,14 @@ pi_status_t _pi_table_entry_modify_wkey(pi_session_handle_t session_handle,
 }
 
 pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
-                                    pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                    pi_dev_tgt_t dev_tgt, pi_p4_id_t table_id,
                                     pi_table_fetch_res_t *res) {
   if (!state.init) return PI_STATUS_RPC_NOT_INIT;
 
   typedef struct __attribute__((packed)) {
     req_hdr_t hdr;
     s_pi_session_handle_t sess;
-    s_pi_dev_id_t dev_id;
+    s_pi_dev_tgt_t dev_tgt;
     s_pi_p4_id_t table_id;
   } req_t;
   req_t req;
@@ -338,7 +352,7 @@ pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
   pi_rpc_id_t req_id = state.req_id++;
   req_ += emit_req_hdr(req_, req_id, PI_RPC_TABLE_ENTRIES_FETCH);
   req_ += emit_session_handle(req_, session_handle);
-  req_ += emit_dev_id(req_, dev_id);
+  req_ += emit_dev_tgt(req_, dev_tgt);
   req_ += emit_p4_id(req_, table_id);
 
   int rc = nn_send(state.s, &req, sizeof(req), 0);
@@ -371,6 +385,31 @@ pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
   return status;
 }
 
+pi_status_t _pi_table_entries_fetch_one(pi_session_handle_t session_handle,
+                                        pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                        pi_entry_handle_t entry_handle,
+                                        pi_table_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_id;
+  (void)table_id;
+  (void)entry_handle;
+  (void)res;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
+pi_status_t _pi_table_entries_fetch_wkey(pi_session_handle_t session_handle,
+                                         pi_dev_tgt_t dev_tgt,
+                                         pi_p4_id_t table_id,
+                                         const pi_match_key_t *match_key,
+                                         pi_table_fetch_res_t *res) {
+  (void)session_handle;
+  (void)dev_tgt;
+  (void)table_id;
+  (void)match_key;
+  (void)res;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
+}
+
 pi_status_t _pi_table_entries_fetch_done(pi_session_handle_t session_handle,
                                          pi_table_fetch_res_t *res) {
   (void)session_handle;
@@ -385,7 +424,7 @@ pi_status_t _pi_table_idle_timeout_config_set(
   (void)dev_id;
   (void)table_id;
   (void)config;
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
 }
 
 pi_status_t _pi_table_entry_get_remaining_ttl(
@@ -396,5 +435,5 @@ pi_status_t _pi_table_entry_get_remaining_ttl(
   (void)table_id;
   (void)entry_handle;
   (void)ttl_ns;
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  return PI_STATUS_RPC_NOT_IMPLEMENTED;
 }


### PR DESCRIPTION
 * ability to read a single match entry through PI instead of always
   having to read the entire table
 * ability to read a single member / group instead of always having to
   read all members + all groups
 * ability to read default entry
 * ability to configure default resources for default entry

Fixes #399
Fixes #400
Fixes #401

New PI functions:
 * pi_table_default_action_get_handle to retrieve the entry handle of
   the default entry; we assume this handle always exists (one
   pi_update_device_start returns) and never changes (for a given table)
   during the lifetime of the P4 forwarding pipeline config.
 * pi_table_entries_fetch_one to read a single match entry (from handle)
 * pi_table_entries_fetch_wkey to read a single match entry (from match
   key)
 * pi_act_prof_mbr_fetch to retrieve a single member
 * pi_act_prof_grp_fetch to retrieve a single group

We are currently not assuming that PI table functions, which take the
entry handle (e.g. pi_table_entries_fetch_one) or the match key
(e.g. pi_table_entries_fetch_wkey) as a parameter, work for the default
entry (when passing NULL as the match key or the default handle as the
entry handle), but that may change in the future (and we may deprecate
the current PI functions which specifically exist for the default
entry). However, read / write methods for direct resources'
configuration are assumed to work when called with the default entry
handle.