### PR TITLE
Update Bazel rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --conlyopt='-std=gnu11' --cxxopt='-std=gnu++11'

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ system. This should enable other Bazel projects to easily import this
 repository. For the great majority of users who wish to build and install PI, we
 recommend using the autotools-based build system.
 
+The Bazel version we have tested is 0.23.2.
+
 To build the P4Runtime PI frontend and run the tests:
 ```
 bazel build //proto/frontend:pifeproto

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,5 +5,46 @@ PI_deps()
 
 load("@com_github_p4lang_p4runtime//bazel:deps.bzl", "p4runtime_deps")
 p4runtime_deps()
-load("@com_github_p4lang_p4runtime//bazel:rules.bzl", "p4runtime_proto_repositories")
-p4runtime_proto_repositories()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    grpc = True,
+    cc = True,
+)
+
+load("@build_stack_rules_proto//cpp:deps.bzl", "cpp_grpc_library")
+cpp_grpc_library()
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+grpc_deps()
+
+load("@build_stack_rules_proto//python:deps.bzl", "python_grpc_library")
+
+python_grpc_library()
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+
+pip_repositories()
+
+pip_import(
+    name = "protobuf_py_deps",
+    requirements = "@build_stack_rules_proto//python/requirements:protobuf.txt",
+)
+
+load("@protobuf_py_deps//:requirements.bzl", protobuf_pip_install = "pip_install")
+
+protobuf_pip_install()
+
+pip_import(
+    name = "grpc_py_deps",
+    requirements = "@build_stack_rules_proto//python:requirements.txt",
+)
+
+load("@grpc_py_deps//:requirements.bzl", grpc_pip_install = "pip_install")
+
+grpc_pip_install()

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -3,18 +3,26 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//bazel:workspace_rule.bzl", "remote_workspace")
 
+GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a";
+GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108"
+
 def PI_deps():
     """Loads dependencies needed to compile PI."""
 
     if "com_github_p4lang_p4runtime" not in native.existing_rules():
-        remote_workspace(
+        # FIXME: modify the commit when P4Runtime is ready.
+        native.local_repository(
             name = "com_github_p4lang_p4runtime",
-            remote = "https://github.com/p4lang/p4runtime",
-            # Cannot use 1.0.0 tag, we need a more recent version which includes
-            # a Bazel build fix.
-            # tag = "1.0.0",
-            commit = "98acb3c4ac8337a921b4517fd1979cf23ef52393",
+            path = "/p4runtime"
         )
+        # remote_workspace(
+        #     name = "com_github_p4lang_p4runtime",
+        #     remote = "https://github.com/p4lang/p4runtime",
+        #     # Cannot use 1.0.0 tag, we need a more recent version which includes
+        #     # a Bazel build fix.
+        #     # tag = "1.0.0",
+        #     commit = "98acb3c4ac8337a921b4517fd1979cf23ef52393",
+        # )
 
     if "judy" not in native.existing_rules():
         http_archive(
@@ -32,11 +40,12 @@ def PI_deps():
         )
 
     if "com_github_openconfig_gnmi" not in native.existing_rules():
-        remote_workspace(
+        http_archive(
             name = "com_github_openconfig_gnmi",
-            remote = "https://github.com/openconfig/gnmi",
-            commit = "9c8d9e965b3e854107ea02c12ab11b70717456f2",
-            build_file = "bazel/external/gnmi.BUILD",
+            urls = ["https://github.com/bocon13/gnmi/archive/%s.zip" % GNMI_COMMIT],
+            sha256 = GNMI_SHA,
+            strip_prefix = "gnmi-%s/proto" % GNMI_COMMIT,
+            build_file = "@//bazel:external/gnmi.BUILD",
         )
 
     if "com_google_googletest" not in native.existing_rules():
@@ -44,4 +53,18 @@ def PI_deps():
             name = "com_google_googletest",
             remote = "https://github.com/google/googletest",
             commit = "f5edb4f542e155c75bc4b516f227911d99ec167c",
+        )
+
+    if "com_google_googleapis" not in native.existing_rules():
+        remote_workspace(
+            name = "com_google_googleapis",
+            remote = "https://github.com/googleapis/googleapis",
+            commit = "1079c999f0683196d857795ae6951ced9e15ce72",
+        )
+
+    if "build_stack_rules_proto" not in native.existing_rules():
+        remote_workspace(
+            name = "build_stack_rules_proto",
+            remote = "https://github.com/stackb/rules_proto",
+            commit = "2f4e4f62a3d7a43654d69533faa0652e1c4f5082",
         )

--- a/bazel/external/gnmi.BUILD
+++ b/bazel/external/gnmi.BUILD
@@ -1,20 +1,35 @@
+load("@build_stack_rules_proto//cpp:cpp_grpc_library.bzl", "cpp_grpc_library")
+
 package(
     default_visibility = [ "//visibility:public" ],
 )
 
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
-
-genrule(
-    name = "_copy_gnmi_proto",
-    srcs = ["proto/gnmi/gnmi.proto"],
-    outs = ["gnmi/gnmi.proto"],
-    cmd = "cp $< $@",
+proto_library(
+    name = "gnmi_ext_proto",
+    srcs = ["gnmi_ext/gnmi_ext.proto"],
 )
 
-cpp_proto_library(
+proto_library(
+    name = "gnmi_proto",
+    srcs = ["gnmi/gnmi.proto"],
+    deps = [
+        ":gnmi_ext_proto",
+        "@com_google_protobuf//:descriptor_proto",
+        "@com_google_protobuf//:any_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "gnmi_ext_cc_proto",
+    deps = [":gnmi_ext_proto"]
+)
+
+cc_proto_library(
+    name = "gnmi_cc_proto",
+    deps = ["@com_github_openconfig_gnmi//:gnmi_proto"],
+)
+
+cpp_grpc_library(
     name = "gnmi_cc_grpc",
-    protos = ["gnmi/gnmi.proto"],
-    imports = ["external/com_google_protobuf/src/"],
-    inputs = ["@com_google_protobuf//:well_known_protos"],
-    with_grpc = True,
+    deps = [":gnmi_proto"],
 )

--- a/bazel/workspace_rule.bzl
+++ b/bazel/workspace_rule.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 _strict = False
 
 def _build_http_archive(
@@ -30,14 +32,14 @@ def _build_http_archive(
 
   # Generate http_archive rule
   if build_file:
-    native.http_archive(
+    http_archive(
       name = name,
       urls = urls,
       strip_prefix = prefix,
       build_file = build_file,
     )
   else:
-    native.http_archive(
+    http_archive(
       name = name,
       urls = urls,
       strip_prefix = prefix,
@@ -59,7 +61,7 @@ def _build_git_repository(
 
   # Generate the git_repository rule
   if build_file:
-    native.new_git_repository(
+    git_repository(
       name = name,
       remote = remote,
       branch = branch,
@@ -68,7 +70,7 @@ def _build_git_repository(
       build_file = build_file,
     )
   else:
-    native.git_repository(
+    git_repository(
       name = name,
       remote = remote,
       branch = branch,

--- a/bazel/workspace_rule.bzl
+++ b/bazel/workspace_rule.bzl
@@ -30,7 +30,7 @@ def _build_http_archive(
 
   # Generate http_archive rule
   if build_file:
-    native.new_http_archive(
+    native.http_archive(
       name = name,
       urls = urls,
       strip_prefix = prefix,

--- a/bazel/workspace_rule.bzl
+++ b/bazel/workspace_rule.bzl
@@ -9,6 +9,7 @@ def _build_http_archive(
     commit = None,
     tag = None,
     build_file = None,
+    patch_cmds = [],
     ):
   if not remote.startswith("https://github.com"):
     # This is only currently support for github repos
@@ -37,12 +38,14 @@ def _build_http_archive(
       urls = urls,
       strip_prefix = prefix,
       build_file = build_file,
+      patch_cmds = patch_cmds,
     )
   else:
     http_archive(
       name = name,
       urls = urls,
       strip_prefix = prefix,
+      patch_cmds = patch_cmds,
     )
   return True
 
@@ -53,6 +56,7 @@ def _build_git_repository(
     commit = None,
     tag = None,
     build_file = None,
+    patch_cmds = [],
     ):
 
   # Strip trailing / from remote
@@ -68,6 +72,7 @@ def _build_git_repository(
       commit = commit,
       tag = tag,
       build_file = build_file,
+      patch_cmds = patch_cmds,
     )
   else:
     git_repository(
@@ -76,6 +81,7 @@ def _build_git_repository(
       branch = branch,
       commit = commit,
       tag = tag,
+      patch_cmds = patch_cmds,
     )
   return True
 
@@ -87,6 +93,7 @@ def remote_workspace(
     tag = None,
     build_file = None,
     use_git = False,
+    patch_cmds = []
     ):
   ref_count = 0
   if branch:
@@ -112,12 +119,12 @@ def remote_workspace(
 
   # Prefer http_archive
   if not use_git and _build_http_archive(
-      name, remote, branch, commit, tag,build_file):
+      name, remote, branch, commit, tag, build_file, patch_cmds):
     return
 
   # Fall back to git_repository
   if _build_git_repository(
-      name, remote, branch, commit, tag,build_file):
+      name, remote, branch, commit, tag, build_file, patch_cmds):
     return
 
   fail("could not generate remote workspace for " + name)

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -10,10 +10,12 @@ cc_library(
     deps = ["@com_github_p4lang_p4runtime//:p4info_cc_proto"],
 )
 
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
+proto_library(
+    name = "p4config_proto",
+    srcs = ["p4/tmp/p4config.proto"]
+)
 
-cpp_proto_library(
-  name = "p4config_cc_proto",
-  protos = ["p4/tmp/p4config.proto"],
-  with_grpc = False,
+cc_proto_library(
+    name = "p4config_cc_proto",
+    deps = [":p4config_proto"],
 )

--- a/proto/frontend/BUILD
+++ b/proto/frontend/BUILD
@@ -11,7 +11,7 @@ cc_library(
     copts = ["-DUSE_ABSL=1"],
     deps = ["@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
             "@com_github_openconfig_gnmi//:gnmi_cc_grpc",
-            "@com_github_googleapis//:code_cc_proto",
+            "@com_google_googleapis//google/rpc:code_cc_proto",
             "//proto:piprotoutil",
             "//proto/third_party:fmt",
             "//proto:p4config_cc_proto",

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -70,6 +70,8 @@ using Code = ::google::rpc::Code;
 using common::SessionTemp;
 using common::check_proto_bytestring;
 using common::make_invalid_p4_id_status;
+using action_profile_set_map =
+  std::unordered_map<pi_indirect_handle_t, p4v1::ActionProfileActionSet>;
 
 // We don't yet have a mapping from PI error codes to ::google::rpc::Code
 // values, so for now we almost always return UNKNOWN. It is likely that we will
@@ -890,16 +892,12 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
-  typedef
-  std::unordered_map<pi_indirect_handle_t, p4v1::ActionProfileActionSet>
-  action_profile_set_map;
-
   Status parse_action_entry(
       p4_id_t table_id,
       const pi_table_entry_t *pi_entry,
       p4v1::TableEntry *entry,
-      const action_profile_set_map &oneshot_map = action_profile_set_map({})
-      ) const {
+      const action_profile_set_map &oneshot_map =
+        action_profile_set_map({})) const {
     if (pi_entry->entry_type == PI_ACTION_ENTRY_TYPE_NONE) RETURN_OK_STATUS();
 
     auto table_action = entry->mutable_action();
@@ -951,8 +949,7 @@ class DeviceMgrImp {
   // selector does not use one-shot, nothing is added to the map.
   Status build_action_profile_action_set_map(
       p4_id_t table_id,
-      std::unordered_map<pi_indirect_handle_t,
-                         p4v1::ActionProfileActionSet> *map,
+      action_profile_set_map *map,
       const SessionTemp &session) const {
     auto action_prof_id = pi_p4info_table_get_implementation(p4info.get(),
                                                              table_id);
@@ -1226,8 +1223,7 @@ class DeviceMgrImp {
     // the map is needed if the table is indirect and was programmed using the
     // oneshot programming method, to guarantee read-write symmetry
     // TODO(antonin): optimize when single entry is read
-    std::unordered_map<pi_indirect_handle_t,
-                       p4v1::ActionProfileActionSet> oneshot_map;
+    action_profile_set_map oneshot_map;
     RETURN_IF_ERROR(build_action_profile_action_set_map(
         table_id, &oneshot_map, session));
 

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -890,13 +890,16 @@ class DeviceMgrImp {
     RETURN_OK_STATUS();
   }
 
+  typedef
+  std::unordered_map<pi_indirect_handle_t, p4v1::ActionProfileActionSet>
+  action_profile_set_map;
+
   Status parse_action_entry(
       p4_id_t table_id,
       const pi_table_entry_t *pi_entry,
       p4v1::TableEntry *entry,
-      const std::unordered_map<
-        pi_indirect_handle_t,
-        p4v1::ActionProfileActionSet> &oneshot_map = {}) const {
+      const action_profile_set_map &oneshot_map = action_profile_set_map({})
+      ) const {
     if (pi_entry->entry_type == PI_ACTION_ENTRY_TYPE_NONE) RETURN_OK_STATUS();
 
     auto table_action = entry->mutable_action();


### PR DESCRIPTION
 - Use new Bazel version (>= 0.23.2)
 - Remove old version of protobuf and grpc Bazel rules
 - Deprecate unused rules
