### PR TITLE
Remove gNMI dependency from pifeproto bazel target

### DIFF
--- a/proto/frontend/BUILD
+++ b/proto/frontend/BUILD
@@ -10,7 +10,6 @@ cc_library(
     includes = ["."],
     copts = ["-DUSE_ABSL=1"],
     deps = ["@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
-            "@com_github_openconfig_gnmi//:gnmi_cc_grpc",
             "@com_google_googleapis//google/rpc:code_cc_proto",
             "//proto:piprotoutil",
             "//proto/third_party:fmt",

--- a/proto/server/BUILD
+++ b/proto/server/BUILD
@@ -11,5 +11,6 @@ cc_library(
             "uint128.cpp"],
     hdrs = ["PI/proto/pi_server.h", "pi_server_testing.h", "gnmi.h"],
     deps = ["@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+            "@com_github_openconfig_gnmi//:gnmi_cc_grpc",
             "//proto/frontend:pifeproto"],
 )


### PR DESCRIPTION
Remove gNMI dependency since we are not using it in "pifepproro"