### PR TITLE
Better cleanup in DeviceMgr when pi_mc_* calls fail

### DIFF
--- a/proto/frontend/src/common.h
+++ b/proto/frontend/src/common.h
@@ -45,49 +45,27 @@ namespace common {
 
 using p4_id_t = uint32_t;
 
-struct SessionTemp;
+class SessionTemp;
 
-struct LocalCleanupIface {
-  virtual ~LocalCleanupIface() { }
-
-  virtual Status cleanup(const SessionTemp &session) = 0;
-  virtual void cancel() = 0;
-};
-
-// SessionTemp is used to manage a P4Runtime WriteRequest message. All
-// operations in the message are executed as part of the same PI batch, the
-// SessionTemp destructor will block until all operations have been completed in
-// HW.
-// SessionTemp also has a mechanism to perform some low-level cleanup tasks in
-// case of an unexpected error during an unexpected error (in the lower layers
-// of the stack). For example, when using one-shot action selector programming
-// for an indirect table, a single P4Runtime update may map to many PI calls. If
-// one of these calls fail, it may be desirable to undo all previous PI
-// calls. This isn't as powerful as the P4Runtime semantics (not implemented
-// yet), but should be ok for simple things like action profile programming. If
-// one of the rollback / cleanup operations fail, we return a (serious) INTERNAL
-// error.
-struct SessionTemp {
-  explicit SessionTemp(bool batch = false)
-      : batch(batch) {
-    pi_session_init(&sess);
-    if (batch) pi_batch_begin(sess);
-  }
-
-  ~SessionTemp() {
-    if (batch) pi_batch_end(sess, true  /* hw_sync */);
-    pi_session_cleanup(sess);
-  }
-
-  pi_session_handle_t get() const { return sess; }
-
+// A mechanism for different sessions (main session, multicast session) to
+// perform some low-level cleanup tasks in case of an unexpected error during an
+// unexpected error (in the lower layers of the stack). For example, when using
+// one-shot action selector programming for an indirect table, a single
+// P4Runtime update may map to many PI calls. If one of these calls fail, it may
+// be desirable to undo all previous PI calls. This isn't as powerful as the
+// P4Runtime semantics (not implemented yet), but should be ok for simple things
+// like action profile programming. If one of the rollback / cleanup operations
+// fail, we return a (serious) INTERNAL error.
+template <typename S, typename T>
+class SessionCleanup {
+ public:
   Status local_cleanup() {
     int error_cnt = 0;
     Status status;
     for (auto task_it = cleanup_tasks.rbegin();
          task_it != cleanup_tasks.rend();
          ++task_it) {
-      status = (*task_it)->cleanup(*this);
+      status = (*task_it)->cleanup(*static_cast<S *>(this));
       if (IS_ERROR(status)) error_cnt++;
     }
     cleanup_tasks.clear();
@@ -109,20 +87,53 @@ struct SessionTemp {
     cleanup_scopes.pop_back();
   }
 
-  LocalCleanupIface *cleanup_task_push(
-      std::unique_ptr<LocalCleanupIface> task) {
+  T *cleanup_task_push(std::unique_ptr<T> task) {
     cleanup_tasks.push_back(std::move(task));
     return cleanup_tasks.back().get();
   }
 
-  LocalCleanupIface *cleanup_task_back() {
+  T *cleanup_task_back() {
     return cleanup_tasks.back().get();
   }
 
+ protected:
+  ~SessionCleanup() { }
+
+ private:
+  std::vector<std::unique_ptr<T> > cleanup_tasks;
+  std::vector<size_t> cleanup_scopes;
+};
+
+struct LocalCleanupIface {
+  virtual ~LocalCleanupIface() { }
+
+  virtual Status cleanup(const SessionTemp &session) = 0;
+  virtual void cancel() = 0;
+};
+
+// SessionTemp is used to manage a P4Runtime WriteRequest message. All
+// operations in the message are executed as part of the same PI batch, the
+// SessionTemp destructor will block until all operations have been completed in
+// HW.
+class SessionTemp final
+    : public SessionCleanup<SessionTemp, LocalCleanupIface> {
+ public:
+  explicit SessionTemp(bool batch = false)
+      : batch(batch) {
+    pi_session_init(&sess);
+    if (batch) pi_batch_begin(sess);
+  }
+
+  ~SessionTemp() {
+    if (batch) pi_batch_end(sess, true  /* hw_sync */);
+    pi_session_cleanup(sess);
+  }
+
+  pi_session_handle_t get() const { return sess; }
+
+ private:
   pi_session_handle_t sess;
   bool batch;
-  std::vector<std::unique_ptr<LocalCleanupIface> > cleanup_tasks;
-  std::vector<size_t> cleanup_scopes;
 };
 
 Code check_proto_bytestring(const std::string &str, size_t nbits);

--- a/proto/frontend/src/digest_mgr.h
+++ b/proto/frontend/src/digest_mgr.h
@@ -41,7 +41,7 @@ namespace fe {
 namespace proto {
 
 namespace common {
-struct SessionTemp;
+class SessionTemp;
 }  // namespace common
 
 template <typename Clock> class TaskQueue;

--- a/proto/frontend/src/pre_clone_mgr.h
+++ b/proto/frontend/src/pre_clone_mgr.h
@@ -39,7 +39,7 @@ namespace fe {
 
 namespace proto {
 
-namespace common { struct SessionTemp; }  // namespace common
+namespace common { class SessionTemp; }  // namespace common
 
 // This class is used to map P4Runtime CloneSessionEntry messages to lower-level
 // PI operations. At the moment every clone session is associated to a multicast

--- a/proto/frontend/src/pre_mc_mgr.h
+++ b/proto/frontend/src/pre_mc_mgr.h
@@ -37,7 +37,7 @@ namespace fe {
 
 namespace proto {
 
-struct McSessionTemp;
+class McSessionTemp;
 
 // This class is used to map P4Runtime MulticastGroupEntry messages to
 // lower-level PI operations. It currently does not do any rollback in case of
@@ -59,7 +59,7 @@ class PreMcMgr {
       : device_id(device_id) { }
 
   Status group_create(const GroupEntry &group_entry,
-                      GroupOwner = GroupOwner::CLIENT);
+                      GroupOwner owner = GroupOwner::CLIENT);
   Status group_modify(const GroupEntry &group_entry);
   Status group_delete(const GroupEntry &group_entry);
 
@@ -83,9 +83,22 @@ class PreMcMgr {
     GroupOwner owner;
   };
 
+  // cleanup tasks
+  struct GroupCleanupTask;
+  struct NodeDetachCleanupTask;
+  struct NodeCleanupTask;
+
+  Status group_create_(McSessionTemp *session,
+                       GroupId group_id,
+                       Group *group);
+  Status group_modify_(McSessionTemp *session,
+                       GroupId group_id,
+                       Group *old_group,
+                       Group *new_group);
+
   static Status make_new_group(const GroupEntry &group_entry, Group *group);
 
-  Status create_and_attach_node(const McSessionTemp &session,
+  Status create_and_attach_node(McSessionTemp *session,
                                 pi_mc_grp_handle_t group_h,
                                 RId rid,
                                 Node *node);


### PR DESCRIPTION
 * in case of a target failure during group creation, we cleanup all
   created nodes and the group itself
 * in case of a target failure when creating & adding new nodes to an
   existing group, we cleanup the newly created nodes (and keep the
   existing ones)

We currently assume that only the following operations will fail: group
create, node create, node attach. We don't have any specific cleanup
logic for other possible failures.