### PR TITLE
Add Bazel build to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,19 @@ services:
 
 matrix:
   include:
-    - env: CXX=g++ CC=gcc
-    - env: CXX=g++-7 CC=gcc-7
-    - env: CXX=clang++-3.8 CC=clang-3.8
-    - env: CXX=clang++-6.0 CC=clang-6.0
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-xenial-6.0
+    - name: gcc
+      env: CXX=g++ CC=gcc
+    - name: gcc-7
+      env: CXX=g++-7 CC=gcc-7
+    - name: clang-3.8
+      env: CXX=clang++-3.8 CC=clang-3.8
+    - name: clang-6.0
+      env: CXX=clang++-6.0 CC=clang-6.0
+    - name: Bazel 0.23.2
+      install:
+        - docker pull l.gcr.io/google/bazel:0.23.2
+      script:
+        - docker run -v `pwd`:/PI -w /PI l.gcr.io/google/bazel:0.23.2 test //proto/tests:pi_proto_tests //proto/tests:pi_proto_server_tests
 
 install:
   - docker build -t pi --build-arg IMAGE_TYPE=test --build-arg CC=$CC --build-arg CXX=$CXX -f Dockerfile.bmv2 .

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ system. This should enable other Bazel projects to easily import this
 repository. For the great majority of users who wish to build and install PI, we
 recommend using the autotools-based build system.
 
-The Bazel version we have tested is 0.23.2.
+The Bazel version we have tested is 0.23.2. This is the version used to run CI.
 
 To build the P4Runtime PI frontend and run the tests:
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,3 +48,6 @@ pip_import(
 load("@grpc_py_deps//:requirements.bzl", grpc_pip_install = "pip_install")
 
 grpc_pip_install()
+
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+boost_deps()

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -32,7 +32,7 @@ def PI_deps():
         remote_workspace(
             name = "com_google_absl",
             remote = "https://github.com/abseil/abseil-cpp",
-            branch = "master",
+            branch = "lts_2019_08_08",
         )
 
     if "com_github_openconfig_gnmi" not in native.existing_rules():
@@ -67,4 +67,11 @@ def PI_deps():
             name = "build_stack_rules_proto",
             remote = "https://github.com/stackb/rules_proto",
             commit = "2f4e4f62a3d7a43654d69533faa0652e1c4f5082",
+        )
+
+    if "com_github_nelhage_rules_boost" not in native.existing_rules():
+        remote_workspace(
+            name = "com_github_nelhage_rules_boost",
+            remote = "https://github.com/nelhage/rules_boost",
+            commit = "a3b25bf1a854ca7245d5786fda4821df77c57827",
         )

--- a/bazel/external/judy.BUILD
+++ b/bazel/external/judy.BUILD
@@ -27,7 +27,8 @@ filegroup(
 
 cc_binary(
     name = "Judy1TablesGen",
-    srcs = ["src/JudyCommon/JudyTables.c", ":Judy1_int_hdrs"],
+    srcs = ["src/JudyCommon/JudyTables.c", ":Judy1_int_hdrs", "src/Judy.h"],
+    includes = ["src"],
     copts = DEFAULT_COPTS + ["-DJUDY1", "-Iexternal/judy/src/Judy1"],
 )
 
@@ -42,6 +43,7 @@ cc_library(
     name = "Judy1Prev",
     srcs = ["src/JudyCommon/JudyPrevNext.c",
             "src/JudyCommon/JudyPrevNextEmpty.c",
+            "src/Judy.h",
             ":Judy1_int_hdrs"],
     includes = ["src"],
     copts = DEFAULT_COPTS + ["-DJUDY1", "-DJUDYNEXT", "-Iexternal/judy/src/Judy1"],
@@ -51,6 +53,7 @@ cc_library(
     name = "Judy1Next",
     srcs = ["src/JudyCommon/JudyPrevNext.c",
             "src/JudyCommon/JudyPrevNextEmpty.c",
+            "src/Judy.h",
             ":Judy1_int_hdrs"],
     includes = ["src"],
     copts = DEFAULT_COPTS + ["-DJUDY1", "-DJUDYPREV", "-Iexternal/judy/src/Judy1"],
@@ -76,7 +79,8 @@ filegroup(
 
 cc_binary(
     name = "JudyLTablesGen",
-    srcs = ["src/JudyCommon/JudyTables.c", ":JudyL_int_hdrs"],
+    srcs = ["src/JudyCommon/JudyTables.c", ":JudyL_int_hdrs", "src/Judy.h"],
+    includes = ["src"],
     copts = DEFAULT_COPTS + ["-DJUDYL", "-Iexternal/judy/src/JudyL"],
 )
 
@@ -91,6 +95,7 @@ cc_library(
     name = "JudyLPrev",
     srcs = ["src/JudyCommon/JudyPrevNext.c",
             "src/JudyCommon/JudyPrevNextEmpty.c",
+            "src/Judy.h",
             ":JudyL_int_hdrs"],
     includes = ["src"],
     copts = DEFAULT_COPTS + ["-DJUDYL", "-DJUDYNEXT", "-Iexternal/judy/src/JudyL"],
@@ -100,6 +105,7 @@ cc_library(
     name = "JudyLNext",
     srcs = ["src/JudyCommon/JudyPrevNext.c",
             "src/JudyCommon/JudyPrevNextEmpty.c",
+            "src/Judy.h",
             ":JudyL_int_hdrs"],
     includes = ["src"],
     copts = DEFAULT_COPTS + ["-DJUDYL", "-DJUDYPREV", "-Iexternal/judy/src/JudyL"],

--- a/proto/tests/BUILD
+++ b/proto/tests/BUILD
@@ -9,7 +9,9 @@ cc_library(
             "mock_switch.cpp"],
     hdrs = ["matchers.h", "mock_switch.h"],
     deps = ["@com_google_googletest//:gtest",
-            "//proto/frontend:pifeproto"],
+            "//proto/frontend:pifeproto",
+            "@boost//:optional",
+            "@boost//:functional"],
     testonly = True,
 )
 
@@ -21,7 +23,8 @@ cc_test(
         + glob(["test_proto_fe*.cpp"]),
     deps = ["@com_google_googletest//:gtest",
             "//proto/frontend:pifeproto",
-            ":testutils"],
+            ":testutils",
+            "@boost//:optional"],
     data = ["//tests:exported_testdata"],
     copts = ['-DTESTDATADIR=\\"tests/testdata\\"'],
 )
@@ -31,7 +34,8 @@ cc_test(
     srcs = glob(["server/*.cpp", "server/*.h"]),
     deps = ["@com_google_googletest//:gtest",
             "//proto/server:piserver",
-            ":testutils"],
+            ":testutils",
+            "@boost//:optional"],
     data = ["//tests:exported_testdata"],
     copts = ['-DTESTDATADIR=\\"tests/testdata\\"',
              "-Iproto/server", "-Iproto/tests"],

--- a/proto/tests/test_proto_fe_packet_io.cpp
+++ b/proto/tests/test_proto_fe_packet_io.cpp
@@ -31,6 +31,7 @@
 
 #include "matchers.h"
 #include "mock_switch.h"
+#include "test_proto_fe_base.h"
 
 namespace p4v1 = ::p4::v1;
 namespace p4configv1 = ::p4::config::v1;
@@ -48,39 +49,16 @@ using ::testing::AllArgs;
 using ::testing::StrEq;
 using ::testing::Truly;
 
-class DeviceMgrPacketIOTest : public ::testing::Test {
+class DeviceMgrPacketIOTest : public DeviceMgrBaseTest {
  public:
-  DeviceMgrPacketIOTest()
-      : mock(wrapper.sw()), device_id(wrapper.device_id()), mgr(device_id) { }
-
-  static void SetUpTestCase() {
-    DeviceMgr::init(256);
-  }
-
-  static void TearDownTestCase() {
-    DeviceMgr::destroy();
-  }
+  DeviceMgrPacketIOTest() { }
 
   void SetUp() override {
-    p4v1::ForwardingPipelineConfig config;
-    config.set_allocated_p4info(&p4info_proto);
-    auto status = mgr.pipeline_config_set(
-        p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT,
-        config);
-    // releasing resource before the assert to avoid double free in case the
-    // assert is false
-    config.release_p4info();
+    auto status = set_pipeline_config(&p4info_proto);
     ASSERT_OK(status);
   }
 
-  void TearDown() override { }
-
   p4configv1::P4Info p4info_proto;
-
-  DummySwitchWrapper wrapper{};
-  DummySwitchMock *mock;
-  device_id_t device_id;
-  DeviceMgr mgr;
 };
 
 // Base case for packet-in / packet-out: no special metadata fields


### PR DESCRIPTION
This revealed some issues with the Bazel build that we address in this
commit: missing dependencies (boost) and incorrect Judy build file.

Running the gtests in the Bazel docker container also caused a segfault
that had to be fixed.

Fixes #493