### PR TITLE
Use clang-format-6.0 for style check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All contributed code must pass the style checker, which can be run with
 `./tools/check_style.sh`. If the style checker fails because of a C file, you
 can format this C file with `./tools/clang_format_check.py -s Google -i <file>`.
 
-CI uses clang-format-3.8 to validate the formatting of C files, which means that
+CI uses clang-format-6.0 to validate the formatting of C files, which means that
 your contribution may fail CI if you use a different version locally.
 
 ### Making changes to the PI internal API

--- a/Dockerfile.bmv2
+++ b/Dockerfile.bmv2
@@ -24,8 +24,8 @@ ARG CXX=g++
 ENV PI_DEPS automake \
             build-essential \
             clang-3.8 \
-            clang-format-3.8 \
             clang-6.0 \
+            clang-format-6.0 \
             g++ \
             g++-7 \
             libboost-dev \

--- a/src/config_readers/bmv2_json_reader.c
+++ b/src/config_readers/bmv2_json_reader.c
@@ -415,8 +415,8 @@ static pi_p4info_match_type_t match_type_from_str(const char *type) {
 }
 
 static int cmp_json_object_generic(const void *e1, const void *e2) {
-  cJSON *object_1 = *(cJSON * const *)e1;
-  cJSON *object_2 = *(cJSON * const *)e2;
+  cJSON *object_1 = *(cJSON *const *)e1;
+  cJSON *object_2 = *(cJSON *const *)e2;
   const cJSON *item_1, *item_2;
   item_1 = cJSON_GetObjectItem(object_1, "name");
   item_2 = cJSON_GetObjectItem(object_2, "name");

--- a/src/device_map.h
+++ b/src/device_map.h
@@ -26,7 +26,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-typedef struct device_map_s { void *_map; } device_map_t;
+typedef struct device_map_s {
+  void *_map;
+} device_map_t;
 
 void device_map_create(device_map_t *map);
 

--- a/targets/dummy/func_counter.c
+++ b/targets/dummy/func_counter.c
@@ -24,7 +24,9 @@
 
 #include <stdio.h>
 
-typedef struct { Pvoid_t array; } func_counter_t;
+typedef struct {
+  Pvoid_t array;
+} func_counter_t;
 
 static func_counter_t func_counter;
 

--- a/targets/dummy/pi_act_prof_imp.c
+++ b/targets/dummy/pi_act_prof_imp.c
@@ -18,8 +18,8 @@
  *
  */
 
-#include "PI/pi.h"
 #include "PI/target/pi_act_prof_imp.h"
+#include "PI/pi.h"
 
 #include <stdio.h>
 

--- a/targets/dummy/pi_tables_imp.c
+++ b/targets/dummy/pi_tables_imp.c
@@ -18,8 +18,8 @@
  *
  */
 
-#include "PI/pi.h"
 #include "PI/target/pi_tables_imp.h"
+#include "PI/pi.h"
 
 #include <stdio.h>
 

--- a/tools/clang_format_check.py
+++ b/tools/clang_format_check.py
@@ -183,8 +183,7 @@ def main():
     parser.add_argument("-e", "--exe",
                         required=False,
                         help="The clang-format executable to use, by default "
-                        "we will try 'clang-format', 'clang-format-3.8' and "
-                        "'clang-format-3.6'")
+                        "we will try 'clang-format' and 'clang-format-6.0'")
 
     # Files or directory to check
     parser.add_argument("file", nargs="+", help="Paths to the files that'll "
@@ -208,7 +207,7 @@ def main():
             exit(-1)
         clang_exec = args.exe
     else:
-        for e in ["clang-format", "clang-format-3.8", "clang-format-3.6"]:
+        for e in ["clang-format", "clang-format-6.0"]:
             if check_clang_format_exec(e):
                 clang_exec = e
                 break


### PR DESCRIPTION
Instead of clang-format-3.8. This is because 3.8 is no longer easily
installable on Ubuntu 18.04.