### PR TITLE
Support reads for PRE entries

### DIFF
--- a/proto/frontend/src/pre_mc_mgr.h
+++ b/proto/frontend/src/pre_mc_mgr.h
@@ -62,9 +62,12 @@ class PreMcMgr {
                       GroupOwner owner = GroupOwner::CLIENT);
   Status group_modify(const GroupEntry &group_entry);
   Status group_delete(const GroupEntry &group_entry);
+  Status group_read(const GroupEntry &group_entry,
+                    ::p4::v1::ReadResponse *response) const;
+  Status group_read_one(GroupId group_id, GroupEntry *group_entry) const;
 
   // user-defined multicast group ids must be in the range
-  // [0,first_reserved_group[; ideally this should be configurable based on the
+  // ]0,first_reserved_group[; ideally this should be configurable based on the
   // target.
   static constexpr GroupId first_reserved_group_id() { return 1 << 15; }
 
@@ -97,6 +100,9 @@ class PreMcMgr {
                        Group *new_group);
 
   static Status make_new_group(const GroupEntry &group_entry, Group *group);
+
+  static void read_group(
+      GroupId group_id, const Group &group, GroupEntry *group_entry);
 
   Status create_and_attach_node(McSessionTemp *session,
                                 pi_mc_grp_handle_t group_h,

--- a/proto/tests/matchers.cpp
+++ b/proto/tests/matchers.cpp
@@ -80,6 +80,42 @@ ProtoEqMatcher::DescribeNegationTo(std::ostream *os) const {
   *os << "is not equal to:\n" << expected.DebugString();
 }
 
+ProtoEqAsSetMatcher::ProtoEqAsSetMatcher(
+    const ::google::protobuf::Message &expected)
+    : expected(expected) { }
+
+bool
+ProtoEqAsSetMatcher::MatchAndExplain(const ::google::protobuf::Message &actual,
+                                     MatchResultListener *listener) const {
+  using ::google::protobuf::util::MessageDifferencer;
+  MessageDifferencer differencer;
+  std::string diff;
+  differencer.ReportDifferencesToString(&diff);
+
+  auto *descriptor = expected.GetDescriptor();
+  for (int i = 0; i < descriptor->field_count(); i++) {
+    auto *f_descriptor = descriptor->field(i);
+    if (f_descriptor->is_repeated()) {
+      differencer.TreatAsSet(f_descriptor);
+    }
+  }
+
+  auto eq = differencer.Compare(actual, expected);
+  *listener << actual.DebugString();
+  *listener << diff;
+  return eq;
+}
+
+void
+ProtoEqAsSetMatcher::DescribeTo(std::ostream *os) const {
+  *os << "is equal to:\n" << expected.DebugString();
+}
+
+void
+ProtoEqAsSetMatcher::DescribeNegationTo(std::ostream *os) const {
+  *os << "is not equal to:\n" << expected.DebugString();
+}
+
 MatchKeyMatcher::MatchKeyMatcher(pi_p4_id_t t_id, const std::string &v)
     : t_id(t_id), v(v) { }
 

--- a/proto/tests/matchers.h
+++ b/proto/tests/matchers.h
@@ -89,6 +89,30 @@ inline Matcher<const ::google::protobuf::Message &> ProtoEq(
 #define EXPECT_PROTO_EQ(actual, expected) \
   EXPECT_THAT(actual, ProtoEq(expected));
 
+class ProtoEqAsSetMatcher
+    : public MatcherInterface<const ::google::protobuf::Message &> {
+ public:
+  explicit ProtoEqAsSetMatcher(const ::google::protobuf::Message &expected);
+
+ private:
+  bool MatchAndExplain(const ::google::protobuf::Message &actual,
+                       MatchResultListener *listener) const override;
+
+  void DescribeTo(std::ostream *os) const override;
+
+  void DescribeNegationTo(std::ostream *os) const override;
+
+  const ::google::protobuf::Message &expected;
+};
+
+inline Matcher<const ::google::protobuf::Message &> ProtoEqAsSet(
+    const ::google::protobuf::Message &expected) {
+  return MakeMatcher(new ProtoEqAsSetMatcher(expected));
+}
+
+#define EXPECT_PROTO_EQ_AS_SET(actual, expected) \
+  EXPECT_THAT(actual, ProtoEqAsSet(expected));
+
 
 // This is a very verbose matcher but it has the advantage to print convenient
 // error messages. Not sure I could achieve such a nice result by only using


### PR DESCRIPTION
We support reads for both multicast groups and clone sessions. We
"cheat" and take a slightly different approach than usual: instead of
calling into PI, we instead rely entirely on local state stored in the
DeviceMgr to reply to the ReadRequests. The P4Runtime spec does not
mandate anything in this regard and does not require Read RPCs to read
state from HW or lower-level drivers. It is up to the implementation,
and while we usually choose to read the state from PI, here we chose not
to, in order to reduce the amount of work required to implement the
feature.

Note that the current implementation does not return the "replicas" list
in the same order as in the corresponding WriteRequest, which is allowed
by the P4Runtime spec.

Fixes #492