### PR TITLE
Update P4Runtime version to 1.1.0-rc.1 and implement Capabilities RPC

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -5,7 +5,7 @@ load("//bazel:workspace_rule.bzl", "remote_workspace")
 
 GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a";
 GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108";
-P4RUNTIME_COMMIT = "09a02842321aecd224cfdbbcea95b1dbc6255266";
+P4RUNTIME_TAG = "1.1.0-rc.1"
 
 def PI_deps():
     """Loads dependencies needed to compile PI."""
@@ -14,7 +14,7 @@ def PI_deps():
         remote_workspace(
             name = "com_github_p4lang_p4runtime",
             remote = "https://github.com/p4lang/p4runtime",
-            commit = P4RUNTIME_COMMIT,
+            tag = P4RUNTIME_TAG,
         )
 
     if "judy" not in native.existing_rules():

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -60,6 +60,8 @@ namespace server {
 
 namespace {
 
+constexpr char p4runtime_api_version[] = "1.1.0-rc.1";
+
 // Copied from
 // https://github.com/grpc/grpc/blob/master/src/cpp/util/error_details.cc
 // Cannot use libgrpc++_error_details, as the library includes
@@ -521,6 +523,14 @@ class P4RuntimeServiceImpl : public p4v1::P4Runtime::Service {
           break;
       }
     }
+    return Status::OK;
+  }
+
+  Status Capabilities(ServerContext* context,
+                      const p4v1::CapabilitiesRequest *request,
+                      p4v1::CapabilitiesResponse *rep) override {
+    (void) request;
+    rep->set_p4runtime_api_version(p4runtime_api_version);
     return Status::OK;
   }
 


### PR DESCRIPTION
As of this version of P4Runtime, the Capabilities RPC only returns the
version of the API implemented by the server.

The RPC is handled entirely by the server, and DeviceMgr is not
involved. This means that if the DeviceMgr implementation
(libpifecpp.so) is updated separately from the server, the version
number returned by the server may not be meaningful anymore. However,
moving the implementation of Capabilities to DeviceMgr does not really
resolve the issue either, since some parts of P4Runtime (such as
master-arbitration) are the responsibility of the server. The current
solution is consistent with Stratum, which takes care of implementing
Capabilities in the target-independent server code.