### PR TITLE
Cjson memory delete to use correct API

### DIFF
--- a/bin/gen_pi_json.c
+++ b/bin/gen_pi_json.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
   printf("%s\n", native_json);
 
   pi_destroy_config(p4info);
-  free(native_json);
+  pi_free_serialized_config(native_json);
 
   return 0;
 }

--- a/include/PI/p4info.h
+++ b/include/PI/p4info.h
@@ -53,6 +53,9 @@ pi_status_t pi_add_config_from_file(const char *config_path,
 //! Release the memory for a given \p p4info object.
 pi_status_t pi_destroy_config(pi_p4info_t *p4info);
 
+//! Release the memory for a serialized \p p4info object.
+void pi_free_serialized_config(char *config);
+
 //! Serialize p4info in native PI JSON format. If \p fmt is 0, non-formatted,
 //! else formatted.
 char *pi_serialize_config(const pi_p4info_t *p4info, int fmt);

--- a/proto/p4info/convert_p4info.cpp
+++ b/proto/p4info/convert_p4info.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
     char *native_json = pi_serialize_config(p4info, 1);
     std::cout << native_json << "\n";
     os << native_json << "\n";
-    free(native_json);
+    pi_free_serialized_config(native_json);
   } else if (to_str == "proto") {
     const auto p4info_proto = pi::p4info::p4info_serialize_to_proto(p4info);
     std::cout << p4info_proto.DebugString();

--- a/src/p4info/p4info.c
+++ b/src/p4info/p4info.c
@@ -106,11 +106,15 @@ char *pi_serialize_config(const pi_p4info_t *p4info, int fmt) {
   return str;
 }
 
+void pi_free_serialized_config(char * config) {
+  cJSON_free(config);
+}
+
 int pi_serialize_config_to_fd(const pi_p4info_t *p4info, int fd, int fmt) {
   char *config = pi_serialize_config(p4info, fmt);
   if (!config) return -1;
   int bytes = dprintf(fd, "%s", config);
-  free(config);
+  pi_free_serialized_config(config);
   return bytes;
 }
 
@@ -120,7 +124,7 @@ int pi_serialize_config_to_file(const pi_p4info_t *p4info, const char *path,
   FILE *f = fopen(path, "w");
   if (!f) return -1;
   int bytes = fprintf(f, "%s", config);
-  free(config);
+  pi_free_serialized_config(config);
   fclose(f);
   return bytes;
 }

--- a/src/p4info/p4info.c
+++ b/src/p4info/p4info.c
@@ -106,9 +106,7 @@ char *pi_serialize_config(const pi_p4info_t *p4info, int fmt) {
   return str;
 }
 
-void pi_free_serialized_config(char * config) {
-  cJSON_Delete_char(config);
-}
+void pi_free_serialized_config(char *config) { cJSON_Delete_char(config); }
 
 int pi_serialize_config_to_fd(const pi_p4info_t *p4info, int fd, int fmt) {
   char *config = pi_serialize_config(p4info, fmt);

--- a/src/p4info/p4info.c
+++ b/src/p4info/p4info.c
@@ -107,7 +107,7 @@ char *pi_serialize_config(const pi_p4info_t *p4info, int fmt) {
 }
 
 void pi_free_serialized_config(char * config) {
-  cJSON_free(config);
+  cJSON_Delete_char(config);
 }
 
 int pi_serialize_config_to_fd(const pi_p4info_t *p4info, int fd, int fmt) {

--- a/targets/rpc/pi_imp.c
+++ b/targets/rpc/pi_imp.c
@@ -147,7 +147,11 @@ pi_status_t _pi_assign_device(pi_dev_id_t dev_id, const pi_p4info_t *p4info,
   req_ += emit_dev_id(req_, dev_id);
   memcpy(req_, p4info_json, p4info_size);
   req_ += p4info_size;
-  free(p4info_json);
+  if (p4info) {
+    pi_free_serialized_config(p4info_json);
+  } else {
+    free(p4info_json);
+  }
   req_ += emit_uint32(req_, num_extras);
   extra_ = extra;
   for (; !extra_->end_of_extras; extra_++) {

--- a/tests/test_bmv2_json_reader.c
+++ b/tests/test_bmv2_json_reader.c
@@ -84,8 +84,8 @@ static void read_and_serialize(const char *path) {
 
   TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info));
   TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info_new));
-  free(dump);
-  free(dump_new);
+  pi_free_serialized_config(dump);
+  pi_free_serialized_config(dump_new);
   free(config);
 }
 

--- a/tests/test_p4info.c
+++ b/tests/test_p4info.c
@@ -425,8 +425,8 @@ TEST(P4Info, Serialize) {
 
   TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info));
   TEST_ASSERT_EQUAL(PI_STATUS_SUCCESS, pi_destroy_config(p4info_new));
-  free(dump);
-  free(dump_new);
+  pi_free_serialized_config(dump);
+  pi_free_serialized_config(dump_new);
   free(config);
 }
 

--- a/third_party/cJSON/include/cJSON/cJSON.h
+++ b/third_party/cJSON/include/cJSON/cJSON.h
@@ -64,8 +64,6 @@ typedef struct cJSON_Hooks {
 /* Supply malloc, realloc and free functions to cJSON */
 extern void cJSON_InitHooks(cJSON_Hooks* hooks);
 
-extern void *(*cJSON_malloc)(size_t sz);
-extern void (*cJSON_free)(void *ptr);
 
 /* Supply a block of JSON, and this returns a cJSON object you can interrogate. Call cJSON_Delete when finished. */
 extern cJSON *cJSON_Parse(const char *value);
@@ -77,6 +75,8 @@ extern char  *cJSON_PrintUnformatted(cJSON *item);
 extern char *cJSON_PrintBuffered(cJSON *item,int prebuffer,int fmt);
 /* Delete a cJSON entity and all subentities. */
 extern void   cJSON_Delete(cJSON *c);
+/* Delete entities allocated by cJSON_Print, cJSON_PrintUnformatted, or cJSON_PrintBuffered. */
+extern void   cJSON_Delete_char(char* c);
 
 /* Returns the number of items in an array (or object). */
 extern int	  cJSON_GetArraySize(cJSON *array);

--- a/third_party/cJSON/include/cJSON/cJSON.h
+++ b/third_party/cJSON/include/cJSON/cJSON.h
@@ -64,6 +64,8 @@ typedef struct cJSON_Hooks {
 /* Supply malloc, realloc and free functions to cJSON */
 extern void cJSON_InitHooks(cJSON_Hooks* hooks);
 
+extern void *(*cJSON_malloc)(size_t sz);
+extern void (*cJSON_free)(void *ptr);
 
 /* Supply a block of JSON, and this returns a cJSON object you can interrogate. Call cJSON_Delete when finished. */
 extern cJSON *cJSON_Parse(const char *value);

--- a/third_party/cJSON/src/cJSON.c
+++ b/third_party/cJSON/src/cJSON.c
@@ -43,8 +43,8 @@ static int cJSON_strcasecmp(const char *s1,const char *s2)
 	return tolower(*(const unsigned char *)s1) - tolower(*(const unsigned char *)s2);
 }
 
-void *(*cJSON_malloc)(size_t sz) = malloc;
-void (*cJSON_free)(void *ptr) = free;
+static void *(*cJSON_malloc)(size_t sz) = malloc;
+static void (*cJSON_free)(void *ptr) = free;
 
 static char* cJSON_strdup(const char* str)
 {
@@ -90,6 +90,11 @@ void cJSON_Delete(cJSON *c)
 		cJSON_free(c);
 		c=next;
 	}
+}
+
+/* Delete entities allocated by cJSON_Print, cJSON_PrintUnformatted, or cJSON_PrintBuffered*/
+void cJSON_Delete_char(char *c) {
+  cJSON_free(c);
 }
 
 /* Parse the input text to generate a number, and populate the result into item. */

--- a/third_party/cJSON/src/cJSON.c
+++ b/third_party/cJSON/src/cJSON.c
@@ -43,8 +43,8 @@ static int cJSON_strcasecmp(const char *s1,const char *s2)
 	return tolower(*(const unsigned char *)s1) - tolower(*(const unsigned char *)s2);
 }
 
-static void *(*cJSON_malloc)(size_t sz) = malloc;
-static void (*cJSON_free)(void *ptr) = free;
+void *(*cJSON_malloc)(size_t sz) = malloc;
+void (*cJSON_free)(void *ptr) = free;
 
 static char* cJSON_strdup(const char* str)
 {


### PR DESCRIPTION
* Making cJSON_free and cJSON_malloc in third_party/cJSON as public APIs
* For objects allocated with cJSON_Print or cJSON_PrintUnformatted,
use cJSON_free to deallocate them instead of using free directly