### PR TITLE
Memset table_entry to 0 in pi_table_default_action_get

### DIFF
--- a/src/pi_tables.c
+++ b/src/pi_tables.c
@@ -137,6 +137,12 @@ pi_status_t pi_table_default_action_get(pi_session_handle_t session_handle,
                                         pi_dev_tgt_t dev_tgt,
                                         pi_p4_id_t table_id,
                                         pi_table_entry_t *table_entry) {
+  // This should not be required for a correct target implementation that
+  // sets all the fields correctly in table_entry, but it does not really hurt
+  // to be safe, e.g. if the target does not set direct_res_config to NULL in
+  // the absence of direct resources.
+  memset(table_entry, 0, sizeof(*table_entry));
+
   pi_status_t status;
   status = _pi_table_default_action_get(session_handle, dev_tgt, table_id,
                                         table_entry);

--- a/targets/bmv2/pi_tables_imp.cpp
+++ b/targets/bmv2/pi_tables_imp.cpp
@@ -515,6 +515,10 @@ pi_status_t _pi_table_default_action_get(pi_session_handle_t session_handle,
     return static_cast<pi_status_t>(PI_STATUS_TARGET_ERROR + ito.code);
   }
 
+  // Not supported by this target implementation
+  table_entry->entry_properties = nullptr;
+  table_entry->direct_res_config = nullptr;
+
   switch (entry.action_type) {
     case BmActionEntryType::NONE:
       table_entry->entry_type = PI_ACTION_ENTRY_TYPE_NONE;


### PR DESCRIPTION
This is probably a bit redundant because PI target implementations
should make sure that all fields are initialized to the correct values,
but it may avoid bugs and does not cost much.

Fixes #507