### PR TITLE
Add test P4 program / P4Info message with custom ids

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,12 +69,15 @@ testdata/ecmp.json \
 testdata/stats.json \
 testdata/l2_switch.json \
 testdata/pragmas.json \
+testdata/unittest.p4 \
 testdata/unittest.p4info.txt \
 testdata/id_collision.json \
 testdata/act_prof.json \
 testdata/reconcile_1.p4info.txt \
 testdata/reconcile_2.p4info.txt \
-testdata/reconcile_3.p4info.txt
+testdata/reconcile_3.p4info.txt \
+testdata/customids.p4 \
+testdata/customids.p4info.txt
 
 # cleaning up the file created by the dummy target (function call counters)
 clean-local:

--- a/tests/testdata/customids.p4
+++ b/tests/testdata/customids.p4
@@ -1,0 +1,108 @@
+// Copyright 2020 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// To re-generate the P4Info (customids.p4info.txt), run:
+// p4test customids.p4 --std p4-16 --p4runtime-files customids.p4info.txt
+
+#include <v1model.p4>
+
+header header_test_t {
+    bit<8> field8;
+    bit<16> field16;
+    bit<20> field20;
+    bit<24> field24;
+    bit<32> field32;
+    bit<48> field48;
+    bit<64> field64;
+    bit<12> field12;
+    bit<4> field4;
+}
+
+@controller_header("packet_in")
+header cpu_header_t { bit<32> f1; @id(1) bit<32> f2; }
+
+struct headers_t {
+    header_test_t header_test;
+    cpu_header_t cpu_header;
+}
+
+struct metadata_t { }
+
+struct test_digest_t {
+    @id(101) bit<48> f48;
+    bit<12> f12;
+}
+
+parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract(hdr.cpu_header);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    test_digest_t test_digest;
+
+    @name(".actionA")
+    @id(1)
+    action actionA(@id(101) bit<48> p1, bit<32> p2) {
+        hdr.header_test.field48 = p1;
+        hdr.header_test.field32 = p2;
+    }
+
+    @name(".actionB")
+    @id(2)
+    action actionB(bit<8> param) {
+        hdr.header_test.field8 = param;
+    }
+    @name(".actionC")
+    @id(3)
+    action actionC() { }
+
+    @name(".ExactOne")
+    @id(1)
+    table ExactOne {
+        key = {
+            hdr.header_test.field64 : exact @id(101);
+            hdr.header_test.field12 : exact;
+        }
+        actions = { actionA; actionB; }
+        size = 512;
+    }
+
+    apply {
+        ExactOne.apply();
+
+        test_digest = {hdr.header_test.field48, hdr.header_test.field12};
+        digest(1, test_digest);
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control DeparserImpl(packet_out packet, in headers_t hdr) {
+    apply { }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control computeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/tests/testdata/customids.p4info.txt
+++ b/tests/testdata/customids.p4info.txt
@@ -1,0 +1,128 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33554433
+    name: "ExactOne"
+    alias: "ExactOne"
+  }
+  match_fields {
+    id: 101
+    name: "hdr.header_test.field64"
+    bitwidth: 64
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.header_test.field12"
+    bitwidth: 12
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16777217
+  }
+  action_refs {
+    id: 16777218
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 512
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 16777217
+    name: "actionA"
+    alias: "actionA"
+  }
+  params {
+    id: 101
+    name: "p1"
+    bitwidth: 48
+  }
+  params {
+    id: 2
+    name: "p2"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 16777218
+    name: "actionB"
+    alias: "actionB"
+  }
+  params {
+    id: 1
+    name: "param"
+    bitwidth: 8
+  }
+}
+controller_packet_metadata {
+  preamble {
+    id: 77503259
+    name: "packet_in"
+    alias: "packet_in"
+    annotations: "@controller_header(\"packet_in\")"
+  }
+  metadata {
+    id: 2
+    name: "f1"
+    bitwidth: 32
+  }
+  metadata {
+    id: 1
+    name: "f2"
+    bitwidth: 32
+  }
+}
+digests {
+  preamble {
+    id: 387015589
+    name: "test_digest_t"
+    alias: "test_digest_t"
+  }
+  type_spec {
+    struct {
+      name: "test_digest_t"
+    }
+  }
+}
+type_info {
+  structs {
+    key: "test_digest_t"
+    value {
+      members {
+        name: "f48"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 48
+            }
+          }
+        }
+      }
+      members {
+        name: "f12"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 12
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We recently added support for choosing custom ids for non top-level P4
objects (match fields, action parameters, controller header metadata
fields, digst fields).

This test helps ensure that when using custom ids, the P4Info message
can be correctly imported by PI without error. The goals is to make sure
that the PI code does not make assumptions (e.g. ids are sequential and
start at 0 or 1).

Ideally we would run more comprehensive tests (e.g. try to insert
P4Runtime entries), but that would require a more significant effort.