### PR TITLE
Do not include multicast groups created internally in reads

### DIFF
--- a/proto/frontend/src/pre_mc_mgr.cpp
+++ b/proto/frontend/src/pre_mc_mgr.cpp
@@ -386,6 +386,11 @@ PreMcMgr::group_read(const GroupEntry &group_entry,
   Lock lock(mutex);
   if (group_id == 0) {  // wildcard read
     for (const auto &p_group : groups) {
+      // Do not include groups created internally (for clone sessions).
+      // If groups was a map (ordered), we could break and stop the iteration
+      // here. However, given that we also do a lot of single-value lookups in
+      // groups, it is not clear which data structure is better.
+      if (p_group.first >= first_reserved_group_id()) continue;
       add_group_to_response(p_group.first, p_group.second);
     }
   } else {


### PR DESCRIPTION
Multicast groups created by DeviceMgr to implement clone sessions should
not be included in P4Runtime reads. For wildcard reads, we simply omit
them; for single reads, we return OUT_OF_RANGE (and not NOT_FOUND, for
consistency with the write RPC).