### PR TITLE
Fix P4Runtime demo under proto/demo_grpc

### DIFF
--- a/targets/bmv2/common.h
+++ b/targets/bmv2/common.h
@@ -91,6 +91,14 @@ struct ADataSize {
   }
 };
 
+// We return a dummy value (0xff..ff) for the default handle. bmv2 currently
+// does not support direct resources (direct counter / direct meter) for default
+// entries so we will return an error if this handle is used to read / write
+// direct resource configurations.
+static inline constexpr pi_entry_handle_t get_default_handle() {
+  return static_cast<pi_entry_handle_t>(-1);
+}
+
 }  // namespace pibmv2
 
 #endif  // PI_BMV2_COMMON_H_

--- a/targets/bmv2/pi_counter_imp.cpp
+++ b/targets/bmv2/pi_counter_imp.cpp
@@ -149,6 +149,13 @@ pi_status_t _pi_counter_read_direct(pi_session_handle_t session_handle,
   (void)session_handle;
   (void)flags;
 
+  // bmv2 currently does not support direct counters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    std::cout << "bmv2 does not support direct counters for default entries"
+              << std::endl;
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
+
   pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(d_info->assigned);
   const pi_p4info_t *p4info = d_info->p4info;
@@ -177,6 +184,13 @@ pi_status_t _pi_counter_write_direct(pi_session_handle_t session_handle,
                                      pi_entry_handle_t entry_handle,
                                      const pi_counter_data_t *counter_data) {
   (void)session_handle;
+
+  // bmv2 currently does not support direct counters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    std::cout << "bmv2 does not support direct counters for default entries"
+              << std::endl;
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
 
   pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(d_info->assigned);

--- a/targets/bmv2/pi_meter_imp.cpp
+++ b/targets/bmv2/pi_meter_imp.cpp
@@ -137,6 +137,13 @@ pi_status_t _pi_meter_read_direct(pi_session_handle_t session_handle,
                                   pi_meter_spec_t *meter_spec) {
   (void)session_handle;
 
+  // bmv2 currently does not support direct meters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    std::cout << "bmv2 does not support direct meters for default entries"
+              << std::endl;
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
+
   pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(d_info->assigned);
   const pi_p4info_t *p4info = d_info->p4info;
@@ -164,6 +171,13 @@ pi_status_t _pi_meter_set_direct(pi_session_handle_t session_handle,
                                  pi_entry_handle_t entry_handle,
                                  const pi_meter_spec_t *meter_spec) {
   (void)session_handle;
+
+  // bmv2 currently does not support direct meters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    std::cout << "bmv2 does not support direct meters for default entries"
+              << std::endl;
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
 
   pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(d_info->assigned);

--- a/targets/bmv2/pi_tables_imp.cpp
+++ b/targets/bmv2/pi_tables_imp.cpp
@@ -557,8 +557,8 @@ pi_status_t _pi_table_default_action_get_handle(
   (void)session_handle;
   (void)dev_tgt;
   (void)table_id;
-  (void)entry_handle;
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  *entry_handle = pibmv2::get_default_handle();
+  return PI_STATUS_SUCCESS;
 }
 
 pi_status_t _pi_table_entry_delete(pi_session_handle_t session_handle,


### PR DESCRIPTION
The demo was broken because of some missing functionality in the
deprecated bmv2 PI implementation included in this repo. Maybe the demo
should be updated to use simple_switch_grpc instead.