### PR TITLE
Adopt more inclusive terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,20 @@ send us an email (p4-dev@lists.p4.org).
 
 ### Apache CLA
 
-All developers must sign the [P4.org](http://p4.org) CLA and return it to
-(membership@p4.org) before making contributions. The CLA is available
-[here](https://p4.org/assets/P4_Language_Consortium_Membership_Agreement.pdf).
+All developers must sign the [Open Networking Foundation (ONF)
+CLA](https://cla.opennetworking.org) before making contributions.
+
+### Inclusive Naming
+
+For symbol names and documentation, do not introduce new usage of harmful
+language such as 'master / slave' (or 'slave' independent of 'master') and
+'blacklist / whitelist'. For more information about what constitutes harmful
+language and for a reference word replacement list, please refer to the
+[Inclusive Naming Initiative](https://inclusivenaming.org/).
+
+We are committed to removing all harmful language from the project. If you
+detect existing usage of harmful language in code or documentation, please
+report the issue to us or open a Pull Request to address it directly. Thanks!
 
 ### Building locally
 


### PR DESCRIPTION
Remove harmful language from the project as much as possible, in
particular references to "master" and "slave". The source still includes
some references to "master":

* in third-party software
* references to the "master" branch of other software projects
* references to the "master" branch of this project (the branch will be
  renamed to "main" in the near future)
* for backward-compatibility reasons, P4Runtime still uses the
  "MasterArbitrationUpdate" Protobuf message

CONTRIBUTING.md is also updated to ask contributors not to use harmful
language.

See #526