### PR TITLE
Fix Bazel build for Bazel 4.0

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -21,8 +21,13 @@ jobs:
     - name: Mount bazel cache
       uses: actions/cache@v2
       with:
-        path: "~/.cache/bazel"  # See https://docs.bazel.build/versions/master/output_directories.html
-        key: bazel
+        # See https://docs.bazel.build/versions/master/output_directories.html
+        path: "~/.cache/bazel"
+        # Create a new cache entry whenever Bazel files change.
+        # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
+        key: ${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
 
     - name: Install bazelisk
       run: |

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -5,8 +5,12 @@ load("//bazel:workspace_rule.bzl", "remote_workspace")
 
 GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a";
 GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108";
-P4RUNTIME_TAG = "1.3.0"
-P4RUNTIME_SHA="20b187a965fab78df9b8253da14166b8666938a82a2aeea16c6f9abaa934bdcb"
+# P4RUNTIME_TAG = "1.3.0"
+# We cannot use the latest release (v1.3.0) as we need to include a recent fix
+# to support Bazel 4.0. More precisely, this fix updates the Bazel build
+# dependencies to more recent versions compatible with Bazel 4.0.
+P4RUNTIME_COMMIT = "0d40261b67283999bf0f03bd6b40b5374c7aebd0"
+P4RUNTIME_SHA="d1b31378f58fa7c6039edac06299acfe77ec130e4dffb4704b4e5a30293bd2a5"
 
 def PI_deps():
     """Loads dependencies needed to compile PI."""
@@ -14,9 +18,11 @@ def PI_deps():
     if "com_github_p4lang_p4runtime" not in native.existing_rules():
         http_archive(
             name = "com_github_p4lang_p4runtime",
-            urls = ["https://github.com/p4lang/p4runtime/archive/v%s.zip" % P4RUNTIME_TAG],
+            # urls = ["https://github.com/p4lang/p4runtime/archive/v%s.zip" % P4RUNTIME_TAG],
+            urls = ["https://github.com/p4lang/p4runtime/archive/%s.zip" % P4RUNTIME_COMMIT],
             sha256 = P4RUNTIME_SHA,
-            strip_prefix = "p4runtime-%s/proto" % P4RUNTIME_TAG,
+            # strip_prefix = "p4runtime-%s/proto" % P4RUNTIME_TAG,
+            strip_prefix = "p4runtime-%s/proto" % P4RUNTIME_COMMIT,
         )
 
     if "judy" not in native.existing_rules():
@@ -32,7 +38,7 @@ def PI_deps():
         remote_workspace(
             name = "com_google_absl",
             remote = "https://github.com/abseil/abseil-cpp",
-            branch = "lts_2019_08_08",
+            branch = "lts_2020_09_23",
         )
 
     if "com_github_openconfig_gnmi" not in native.existing_rules():
@@ -59,7 +65,7 @@ def PI_deps():
         remote_workspace(
             name = "com_google_googleapis",
             remote = "https://github.com/googleapis/googleapis",
-            commit = "1079c999f0683196d857795ae6951ced9e15ce72",
+            commit = "8fa381b7138f1d72966ff20563efae1b2194d359",
         )
 
     if "com_github_nelhage_rules_boost" not in native.existing_rules():


### PR DESCRIPTION
Dependencies - most notably p4lang/p4runtime - need to be updated in
order to support Bazel 4.0.

We also include a caching improvement, borrowed from @smolkaj, which
should speed up the CI Bazel build.