### PR TITLE
Support canonical representation for P4Runtime bytestrings

### DIFF
--- a/proto/frontend/src/action_helpers.h
+++ b/proto/frontend/src/action_helpers.h
@@ -1,4 +1,5 @@
 /* Copyright 2013-present Barefoot Networks, Inc.
+ * Copyright 2021 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
@@ -22,6 +23,7 @@
 #define SRC_ACTION_HELPERS_H_
 
 #include <PI/pi.h>
+#include <PI/frontends/cpp/tables.h>
 
 #include "google/rpc/status.pb.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -34,8 +36,9 @@ namespace proto {
 
 using Status = ::google::rpc::Status;
 
-Status validate_action_data(const pi_p4info_t *p4info,
-                            const p4::v1::Action &action);
+Status construct_action_data(const pi_p4info_t *p4info,
+                             const p4::v1::Action &action,
+                             pi::ActionData *action_data);
 
 }  // namespace proto
 

--- a/proto/frontend/src/action_prof_mgr.h
+++ b/proto/frontend/src/action_prof_mgr.h
@@ -1,4 +1,5 @@
 /* Copyright 2013-present Barefoot Networks, Inc.
+ * Copyright 2021 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
@@ -236,7 +237,6 @@ class ActionProfAccessBase {
   bool check_p4_action_id(pi_p4_id_t p4_id) const;
 
   Status validate_action(const p4::v1::Action &action);
-  pi::ActionData construct_action_data(const p4::v1::Action &action);
 
   pi_dev_tgt_t device_tgt;
   pi_p4_id_t act_prof_id;

--- a/proto/frontend/src/common.h
+++ b/proto/frontend/src/common.h
@@ -1,4 +1,5 @@
 /* Copyright 2013-present Barefoot Networks, Inc.
+ * Copyright 2021 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
@@ -32,6 +33,7 @@
 #include "google/rpc/status.pb.h"
 
 #include "report_error.h"
+#include "statusor.h"
 
 namespace pi {
 
@@ -136,6 +138,18 @@ class SessionTemp final
   pi_session_handle_t sess;
   bool batch;
 };
+
+// bytestring_p4rt_to_pi converts any valid P4Runtime bytestring to the format
+// expected by PI. PI expects the length of the bytestring to be the same as the
+// size of the P4 type, which may require the P4Runtime bytestring to be padded
+// first.
+StatusOr<std::string> bytestring_p4rt_to_pi(const std::string &str,
+                                            size_t nbits);
+
+// bytestring_pi_to_p4rt converts the PI bytestring to a canonical P4Runtime
+// bytestring.
+std::string bytestring_pi_to_p4rt(const std::string &str);
+std::string bytestring_pi_to_p4rt(const char *, size_t n);
 
 Code check_proto_bytestring(const std::string &str, size_t nbits);
 

--- a/proto/frontend/src/digest_mgr.cpp
+++ b/proto/frontend/src/digest_mgr.cpp
@@ -71,6 +71,8 @@ using Code = ::google::rpc::Code;
 using EmptyPromise = std::promise<void>;
 using StreamMessageResponseCb = DigestMgr::StreamMessageResponseCb;
 
+using common::bytestring_pi_to_p4rt;
+
 // Fowler–Noll–Vo hash function parameters depending on desired output size
 // this ensures that things work correctly on both 32-bit and 64-bit systems
 // when using fnv_1a_hash_params<size_t>
@@ -270,7 +272,8 @@ TypeSpecConverterStruct::operator()(const Sample &s, p4v1::P4Data *p4_data) {
   auto *struct_like = p4_data->mutable_struct_();
   for (const auto &bitwidth : bitwidths) {
     bytes = (bitwidth + 7) / 8;
-    struct_like->add_members()->set_bitstring(s.data + offset, bytes);
+    struct_like->add_members()->set_bitstring(
+        bytestring_pi_to_p4rt(s.data + offset, bytes));
     offset += bytes;
   }
 }
@@ -310,7 +313,8 @@ TypeSpecConverterTuple::operator()(const Sample &s, p4v1::P4Data *p4_data) {
   auto *struct_like = p4_data->mutable_tuple();
   for (const auto &bitwidth : bitwidths) {
     bytes = (bitwidth + 7) / 8;
-    struct_like->add_members()->set_bitstring(s.data + offset, bytes);
+    struct_like->add_members()->set_bitstring(
+        bytestring_pi_to_p4rt(s.data + offset, bytes));
     offset += bytes;
   }
 }
@@ -340,8 +344,7 @@ TypeSpecConverterBitstring::operator()(const Sample &s, p4v1::P4Data *p4_data) {
         "Digest sample received from PI doesn't match expected format");
     return;
   }
-  // TODO(antonin): ensure correct formatting, use canonical representation?
-  p4_data->set_bitstring(s.data, s.size);
+  p4_data->set_bitstring(bytestring_pi_to_p4rt(s.data, s.size));
 }
 
 using Cache = std::unordered_set<Sample, SampleHash, SampleEq>;

--- a/proto/frontend/src/match_key_helpers.cpp
+++ b/proto/frontend/src/match_key_helpers.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2019-present Barefoot Networks, Inc.
+ * Copyright 2021 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
@@ -44,18 +45,26 @@ namespace proto {
 using Code = ::google::rpc::Code;
 using p4_id_t = common::p4_id_t;
 
-bool ternary_match_is_dont_care(const p4v1::FieldMatch::Ternary &mf) {
-  const auto &mask = mf.mask();
+using common::bytestring_pi_to_p4rt;
+
+bool ternary_match_is_dont_care_(const std::string &mask) {
   return std::all_of(mask.begin(), mask.end(),
                      [](std::string::value_type c) { return c == 0; });
 }
 
-bool range_match_is_dont_care(const p4v1::FieldMatch::Range &mf) {
-  const auto &low = mf.low();
-  const auto &high = mf.high();
+bool ternary_match_is_dont_care(const p4v1::FieldMatch::Ternary &mf) {
+  return ternary_match_is_dont_care_(mf.mask());
+}
+
+bool range_match_is_dont_care_(const std::string &low,
+                               const std::string &high) {
   auto bitwidth = static_cast<size_t>(low.size() * 8);
   return low == common::range_default_lo(bitwidth) &&
       high == common::range_default_hi(bitwidth);
+}
+
+bool range_match_is_dont_care(const p4v1::FieldMatch::Range &mf) {
+  return range_match_is_dont_care_(mf.low(), mf.high());
 }
 
 Status parse_match_key(const pi_p4info_t *p4info, p4_id_t table_id,
@@ -87,49 +96,66 @@ Status parse_match_key(const pi_p4info_t *p4info, p4_id_t table_id,
       case PI_P4INFO_MATCH_TYPE_EXACT:
         {
           auto exact = mf->mutable_exact();
-          match_key.get_exact(finfo->mf_id, exact->mutable_value());
+          std::string value;
+          match_key.get_exact(finfo->mf_id, &value);
+          exact->set_value(bytestring_pi_to_p4rt(value));
         }
         break;
       case PI_P4INFO_MATCH_TYPE_LPM:
         {
           auto lpm = mf->mutable_lpm();
+          std::string value;
           int pLen;
-          match_key.get_lpm(finfo->mf_id, lpm->mutable_value(), &pLen);
-          lpm->set_prefix_len(pLen);
+          match_key.get_lpm(finfo->mf_id, &value, &pLen);
           // if prefix length is 0, omit match field
-          if (pLen == 0)
+          if (pLen == 0) {
             entry->mutable_match()->RemoveLast();
+          } else {
+            lpm->set_value(bytestring_pi_to_p4rt(value));
+            lpm->set_prefix_len(pLen);
+          }
         }
         break;
       case PI_P4INFO_MATCH_TYPE_TERNARY:
         {
           auto ternary = mf->mutable_ternary();
-          match_key.get_ternary(finfo->mf_id, ternary->mutable_value(),
-                                ternary->mutable_mask());
+          std::string value, mask;
+          match_key.get_ternary(finfo->mf_id, &value, &mask);
           // if mask is 0, omit match field
-          if (ternary_match_is_dont_care(*ternary))
+          if (ternary_match_is_dont_care_(mask)) {
             entry->mutable_match()->RemoveLast();
+          } else {
+            ternary->set_value(bytestring_pi_to_p4rt(value));
+            ternary->set_mask(bytestring_pi_to_p4rt(mask));
+          }
         }
         break;
       case PI_P4INFO_MATCH_TYPE_RANGE:
         {
           auto range = mf->mutable_range();
-          match_key.get_range(finfo->mf_id, range->mutable_low(),
-                              range->mutable_high());
+          std::string low, high;
+          match_key.get_range(finfo->mf_id, &low, &high);
           // if range includes all values, omit match field
-          if (range_match_is_dont_care(*range))
+          if (range_match_is_dont_care_(low, high)) {
             entry->mutable_match()->RemoveLast();
+          } else {
+            range->set_low(bytestring_pi_to_p4rt(low));
+            range->set_high(bytestring_pi_to_p4rt(high));
+          }
         }
         break;
       case PI_P4INFO_MATCH_TYPE_OPTIONAL:
         {
           auto optional = mf->mutable_optional();
+          std::string value;
           bool is_wildcard;
-          match_key.get_optional(finfo->mf_id, optional->mutable_value(),
-                                 &is_wildcard);
+          match_key.get_optional(finfo->mf_id, &value, &is_wildcard);
           // if optional field is wildcard, omit match field
-          if (is_wildcard)
+          if (is_wildcard) {
             entry->mutable_match()->RemoveLast();
+          } else {
+            optional->set_value(bytestring_pi_to_p4rt(value));
+          }
         }
         break;
       default:

--- a/proto/tests/Makefile.am
+++ b/proto/tests/Makefile.am
@@ -22,6 +22,7 @@ endif
 TESTS = \
 test_p4info_convert \
 test_proto_fe \
+test_proto_fe_bytestrings \
 test_proto_fe_digest \
 test_proto_fe_packet_io \
 test_proto_fe_set_pipeline_config \
@@ -58,6 +59,8 @@ test_proto_fe_base.cpp \
 stream_receiver.h
 
 test_proto_fe_SOURCES = $(proto_fe_common_source) test_proto_fe.cpp
+test_proto_fe_bytestrings_SOURCES = $(proto_fe_common_source) \
+test_proto_fe_bytestrings.cpp
 test_proto_fe_digest_SOURCES = $(proto_fe_common_source) \
 test_proto_fe_digest.cpp
 test_proto_fe_packet_io_SOURCES = $(proto_fe_common_source) \
@@ -85,6 +88,7 @@ $(top_builddir)/libpiprotobuf.la \
 $(PROTOBUF_LIBS)
 
 test_proto_fe_LDADD = $(proto_fe_libs)
+test_proto_fe_bytestrings_LDADD = $(proto_fe_libs)
 test_proto_fe_digest_LDADD = $(proto_fe_libs)
 test_proto_fe_packet_io_LDADD = $(proto_fe_libs)
 test_proto_fe_set_pipeline_config_LDADD = $(proto_fe_libs)
@@ -126,6 +130,7 @@ test_server_config_LDADD = $(test_server_libs)
 check_PROGRAMS = \
 test_p4info_convert \
 test_proto_fe \
+test_proto_fe_bytestrings \
 test_proto_fe_digest \
 test_proto_fe_packet_io \
 test_proto_fe_set_pipeline_config \

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -517,7 +517,7 @@ MatchTableTest::default_mf() const {
 }
 
 TEST_P(MatchTableTest, AddAndRead) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = std::get<1>(GetParam());
   auto mk_matcher = CorrectMatchKey(t_id, mk_input.get_match_key());
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
@@ -559,7 +559,7 @@ TEST_P(MatchTableTest, AddAndRead) {
 }
 
 TEST_P(MatchTableTest, AddAndDelete) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = std::get<1>(GetParam());
   auto mk_matcher = CorrectMatchKey(t_id, mk_input.get_match_key());
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
@@ -580,7 +580,7 @@ TEST_P(MatchTableTest, AddAndDelete) {
 }
 
 TEST_P(MatchTableTest, AddAndModify) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = std::get<1>(GetParam());
   auto mk_matcher = CorrectMatchKey(t_id, mk_input.get_match_key());
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
@@ -601,7 +601,7 @@ TEST_P(MatchTableTest, AddAndModify) {
 }
 
 TEST_P(MatchTableTest, SetDefault) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
   EXPECT_CALL(*mock, table_default_action_set(t_id, entry_matcher)).Times(2);
   auto entry = generic_make(t_id, boost::none, adata);
@@ -641,7 +641,7 @@ TEST_P(MatchTableTest, GetDefault) {
   auto entry_r1 = read_entry();
   ASSERT_OK(entry_r1.status());
 
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
   auto entry = generic_make(t_id, boost::none, adata);
   entry.set_is_default_action(true);
@@ -663,7 +663,7 @@ TEST_P(MatchTableTest, GetDefault) {
 
 TEST_P(MatchTableTest, InvalidSetDefault) {
   // Invalid to set is_default_action flag to true with a non-empty match key
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = std::get<1>(GetParam());
   auto entry = generic_make(t_id, mk_input.get_proto(mf_id), adata);
   entry.set_is_default_action(true);
@@ -682,7 +682,7 @@ TEST_P(MatchTableTest, ResetDefault) {
 
 TEST_P(MatchTableTest, InvalidTableId) {
   // build valid table entry, then modify the table id
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = std::get<1>(GetParam());
   auto entry = generic_make(t_id, mk_input.get_proto(mf_id), adata);
   auto check_bad_status_write = [this, &entry](pi_p4_id_t bad_id) {
@@ -720,7 +720,7 @@ TEST_P(MatchTableTest, InvalidTableId) {
 
 TEST_P(MatchTableTest, InvalidActionId) {
   // build valid table entry, then modify the action id
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = std::get<1>(GetParam());
   auto entry = generic_make(
       t_id, mk_input.get_proto(mf_id), adata, mk_input.get_priority());
@@ -751,7 +751,7 @@ TEST_P(MatchTableTest, InvalidActionId) {
 }
 
 TEST_P(MatchTableTest, MissingMatchField) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = default_mf();
   if (mk_input.is_initialized()) {  // omitting field supported for match type
     auto mk_matcher = CorrectMatchKey(t_id, mk_input.get().get_match_key());
@@ -769,7 +769,7 @@ TEST_P(MatchTableTest, MissingMatchField) {
 }
 
 TEST_P(MatchTableTest, WriteBatchWithError) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto mk_input = std::get<1>(GetParam());
   auto mk_matcher = CorrectMatchKey(t_id, mk_input.get_match_key());
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
@@ -1012,7 +1012,7 @@ TEST_P(ActionProfTest, Member) {
 TEST_P(ActionProfTest, CreateDupMemberId) {
   DeviceMgr::Status status;
   uint32_t member_id = 123;
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(act_prof_id, _, _))
       .Times(AtLeast(1));
   auto member = make_member(member_id, adata);
@@ -1023,7 +1023,7 @@ TEST_P(ActionProfTest, CreateDupMemberId) {
 TEST_P(ActionProfTest, BadMemberId) {
   DeviceMgr::Status status;
   uint32_t member_id = 123;
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   // in this test we do not expect any call to a mock method
   auto member = make_member(member_id, adata);
   // try to modify a member id which does not exist
@@ -1038,7 +1038,7 @@ TEST_P(ActionProfTest, Group) {
   uint32_t member_id_1 = 1, member_id_2 = 2;
 
   // create 2 members
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(act_prof_id, _, _))
       .Times(2);
   auto member_1 = make_member(member_id_1, adata);
@@ -1108,7 +1108,7 @@ TEST_P(ActionProfTest, Read) {
   uint32_t member_id_1 = 1;
 
   // create 1 member
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(act_prof_id, _, _));
   auto member_1 = make_member(member_id_1, adata);
   EXPECT_OK(create_member(&member_1));
@@ -1151,7 +1151,7 @@ TEST_P(ActionProfTest, ReadOne) {
   uint32_t member_id_1 = 1;
 
   // create 1 member
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(act_prof_id, _, _));
   auto member_1 = make_member(member_id_1, adata);
   EXPECT_OK(create_member(&member_1));
@@ -1235,7 +1235,7 @@ TEST_P(ActionProfTest, InvalidMemberWeight) {
   uint32_t member_id = 1;
 
   // create 1 member
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(_, _, _));
   auto member = make_member(member_id, adata);
   EXPECT_OK(create_member(&member));
@@ -1257,7 +1257,7 @@ TEST_P(ActionProfTest, MemberWeights) {
   uint32_t member_id = 1;
 
   // create 1 member
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(_, _, _));
   auto member = make_member(member_id, adata);
   EXPECT_OK(create_member(&member));
@@ -1319,7 +1319,7 @@ TEST_P(ActionProfTest, MemberWatchPort) {
   uint32_t member_id = 1;
 
   // create 1 member
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(_, _, _));
   auto member = make_member(member_id, adata);
   EXPECT_OK(create_member(&member));
@@ -1412,7 +1412,7 @@ TEST_P(ActionProfTest, MemberWatchPortBytes) {
   uint32_t member_id = 1;
 
   // create 1 member
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(_, _, _));
   auto member = make_member(member_id, adata);
   EXPECT_OK(create_member(&member));
@@ -1501,7 +1501,7 @@ TEST_P(ActionProfTest, MemberWatchPortBytes) {
 TEST_P(ActionProfTest, InvalidActionProfId) {
   DeviceMgr::Status status;
   uint32_t member_id = 123;
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto member = make_member(member_id, adata);
   auto check_bad_status_write = [this, &member](pi_p4_id_t bad_id) {
     member.set_action_profile_id(bad_id);
@@ -1539,7 +1539,7 @@ TEST_P(ActionProfTest, InvalidActionProfId) {
 TEST_P(ActionProfTest, InvalidActionId) {
   DeviceMgr::Status status;
   uint32_t member_id = 123;
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto member = make_member(member_id, adata);
   auto check_bad_status_write = [this, &member](
       pi_p4_id_t bad_id, const char *msg = invalid_p4_id_error_str) {
@@ -1589,7 +1589,7 @@ TEST_P(ActionProfTest, InvalidMaxSize) {
 
 TEST_P(ActionProfTest, MaxSizeExceeded) {
   uint32_t group_id = 1000;
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   std::vector<uint32_t> members(max_group_size_p4info + 1);
   int n = 1;
   std::generate(members.begin(), members.end(), [&n] () { return n++; });
@@ -1608,7 +1608,7 @@ TEST_P(ActionProfTest, MaxSizeExceeded) {
 
 TEST_P(ActionProfTest, DuplicateMemberIds) {
   uint32_t group_id = 1000, member_id = 1;
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
 
   EXPECT_CALL(*mock, action_prof_member_create(act_prof_id, _, _));
   auto member = make_member(member_id, adata);
@@ -1628,7 +1628,7 @@ TEST_P(ActionProfTest, MaxSizeModify) {
   uint32_t member_id_1 = 1, member_id_2 = 2;
 
   // create 2 members
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, action_prof_member_create(act_prof_id, _, _))
       .Times(2);
   auto member_1 = make_member(member_id_1, adata);
@@ -1880,7 +1880,7 @@ class MatchTableIndirectTest
 TEST_P(MatchTableIndirectTest, Member) {
   uint32_t member_id = 123;
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   create_member(member_id, adata);
   auto mbr_h = mock->get_action_prof_handle();
   auto mk_matcher = CorrectMatchKey(t_id, mf);
@@ -1906,7 +1906,7 @@ TEST_P(MatchTableIndirectTest, Group) {
   uint32_t member_id = 123;
   uint32_t group_id = 1000;
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   create_member(member_id, adata);
   create_group(group_id, member_id);
   auto grp_h = mock->get_action_prof_handle();
@@ -1932,8 +1932,8 @@ TEST_P(MatchTableIndirectTest, Group) {
 TEST_P(MatchTableIndirectTest, OneShotInsertAndRead) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
   std::vector<std::string> params;
-  params.emplace_back(6, '\x00');
   params.emplace_back(6, '\x01');
+  params.emplace_back(6, '\x02');
   auto entry = make_indirect_entry_one_shot(mf, params.begin(), params.end());
   ASSERT_OK(add_indirect_entry_one_shot(&entry, params.begin(), params.end()));
 
@@ -1950,8 +1950,8 @@ TEST_P(MatchTableIndirectTest, OneShotInsertAndRead) {
 TEST_P(MatchTableIndirectTest, OneShotInsertAndModify) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
   std::vector<std::string> params;
-  params.emplace_back(6, '\x00');
   params.emplace_back(6, '\x01');
+  params.emplace_back(6, '\x02');
   auto entry_1 = make_indirect_entry_one_shot(mf, params.begin(), params.end());
   ASSERT_OK(add_indirect_entry_one_shot(
       &entry_1, params.begin(), params.end()));
@@ -1979,8 +1979,8 @@ TEST_P(MatchTableIndirectTest, OneShotInsertAndModify) {
 TEST_P(MatchTableIndirectTest, OneShotInsertAndDelete) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
   std::vector<std::string> params;
-  params.emplace_back(6, '\x00');
   params.emplace_back(6, '\x01');
+  params.emplace_back(6, '\x02');
   auto entry = make_indirect_entry_one_shot(mf, params.begin(), params.end());
   ASSERT_OK(add_indirect_entry_one_shot(&entry, params.begin(), params.end()));
 
@@ -1995,8 +1995,8 @@ TEST_P(MatchTableIndirectTest, OneShotInsertAndDelete) {
 TEST_P(MatchTableIndirectTest, OneShotInvalidActionWeight) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
   std::vector<std::string> params;
-  params.emplace_back(6, '\x00');
   params.emplace_back(6, '\x01');
+  params.emplace_back(6, '\x02');
   auto entry =
       make_indirect_entry_one_shot(mf, params.begin(), params.end(), 0);
   EXPECT_EQ(
@@ -2008,8 +2008,8 @@ TEST_P(MatchTableIndirectTest, OneShotInvalidActionWeight) {
 TEST_P(MatchTableIndirectTest, OneShotWeights) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
   std::vector<std::string> params;
-  params.emplace_back(6, '\x00');
   params.emplace_back(6, '\x01');
+  params.emplace_back(6, '\x02');
   auto entry =
       make_indirect_entry_one_shot(mf, params.begin(), params.end(), 2);
   ASSERT_OK(add_indirect_entry_one_shot(
@@ -2028,8 +2028,8 @@ TEST_P(MatchTableIndirectTest, OneShotWeights) {
 TEST_P(MatchTableIndirectTest, OneShotWatchPort) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
   std::vector<std::string> params;
-  params.emplace_back(6, '\x00');
   params.emplace_back(6, '\x01');
+  params.emplace_back(6, '\x02');
   int weight = 2;
   int watch_port = 7;
 
@@ -2077,8 +2077,8 @@ TEST_P(MatchTableIndirectTest, OneShotWatchPort) {
 TEST_P(MatchTableIndirectTest, OneShotWatchPortBytes) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
   std::vector<std::string> params;
-  params.emplace_back(6, '\x00');
   params.emplace_back(6, '\x01');
+  params.emplace_back(6, '\x02');
   int weight = 2;
   int watch_port = 7;
   std::string watch_port_str("\x07");
@@ -2241,7 +2241,7 @@ TEST_P(OneShotCleanupTest, MemberAddError) {
 
 TEST_P(MatchTableIndirectTest, MixedSelectorModes) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   std::vector<std::string> params({adata});
   auto entry = make_indirect_entry_one_shot(mf, params.begin(), params.end());
   ASSERT_OK(add_indirect_entry_one_shot(&entry, params.begin(), params.end()));
@@ -2340,7 +2340,7 @@ class ExactOneTest : public DeviceMgrTest {
 
 TEST_F(ExactOneTest, PriorityForNonTernaryMatch) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   int priority(789);
   auto entry = make_entry(mf, adata);
   entry.set_priority(priority);
@@ -2355,7 +2355,7 @@ TEST_F(ExactOneTest, PriorityForNonTernaryMatch) {
 // code.
 TEST_F(ExactOneTest, ZeroKeyAndDefaultEntry) {
   std::string mf(4, '\x00');
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
   EXPECT_CALL(*mock, table_default_action_set(t_id, _)).Times(2);
   {
@@ -2428,7 +2428,7 @@ class DirectMeterTest : public ExactOneTest {
 
 TEST_F(DirectMeterTest, WriteAndRead) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata);
   auto mk_matcher = CorrectMatchKey(t_id, mf);
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
@@ -2476,7 +2476,7 @@ TEST_F(DirectMeterTest, WriteAndRead) {
 
 TEST_F(DirectMeterTest, WriteInTableEntry) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata);
   auto *meter_config = entry.mutable_meter_config();
   *meter_config = make_meter_config();
@@ -2494,7 +2494,7 @@ TEST_F(DirectMeterTest, WriteInTableEntry) {
 }
 
 TEST_F(DirectMeterTest, InvalidTableEntry) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   std::string mf_1("\xaa\xbb\xcc\xdd", 4);
   auto entry_1 = make_entry(mf_1, adata);
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
@@ -2518,7 +2518,7 @@ TEST_F(DirectMeterTest, MissingTableEntry) {
 
 TEST_F(DirectMeterTest, ReadAllFromTable) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata);
   auto *meter_config = entry.mutable_meter_config();
   *meter_config = make_meter_config();
@@ -2549,7 +2549,7 @@ TEST_F(DirectMeterTest, ReadAllFromTable) {
 
 // default entry direct meter access with DirectMeterEntry message
 TEST_F(DirectMeterTest, DefaultEntry) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(boost::none, adata);
   entry.set_is_default_action(true);
   auto config = make_meter_config();
@@ -2572,7 +2572,7 @@ TEST_F(DirectMeterTest, DefaultEntry) {
 
 // default entry direct meter access with TableEntry message
 TEST_F(DirectMeterTest, WriteInTableEntryDefault) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(boost::none, adata);
   entry.set_is_default_action(true);
   auto *meter_config = entry.mutable_meter_config();
@@ -2711,7 +2711,7 @@ class DirectCounterTest : public ExactOneTest {
 
 TEST_F(DirectCounterTest, WriteAndRead) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata);
   auto mk_matcher = CorrectMatchKey(t_id, mf);
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
@@ -2762,7 +2762,7 @@ TEST_F(DirectCounterTest, WriteAndRead) {
 
 TEST_F(DirectCounterTest, InvalidTableEntry) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata);
   auto mk_matcher = CorrectMatchKey(t_id, mf);
   auto entry_matcher = CorrectTableEntryDirect(a_id, adata);
@@ -2781,7 +2781,7 @@ TEST_F(DirectCounterTest, InvalidTableEntry) {
 
 TEST_F(DirectCounterTest, ReadAllFromTable) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata);
   auto counter_data = entry.mutable_counter_data();
   counter_data->set_packet_count(3);
@@ -2827,7 +2827,7 @@ TEST_F(DirectCounterTest, ReadAll) {
 
 TEST_F(DirectCounterTest, WriteInTableEntry) {
   std::string mf("\xaa\xbb\xcc\xdd", 4);
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata);
   auto counter_data = entry.mutable_counter_data();
   counter_data->set_packet_count(3);
@@ -2845,7 +2845,7 @@ TEST_F(DirectCounterTest, WriteInTableEntry) {
 
 // default entry direct counter access with DirectCounterEntry message
 TEST_F(DirectCounterTest, DefaultEntry) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(boost::none, adata);
   entry.set_is_default_action(true);
   auto counter_entry = make_counter_entry(&entry);
@@ -2868,7 +2868,7 @@ TEST_F(DirectCounterTest, DefaultEntry) {
 
 // default entry direct counter access with TableEntry message
 TEST_F(DirectCounterTest, WriteInTableEntryDefault) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(boost::none, adata);
   entry.set_is_default_action(true);
   auto counter_data = entry.mutable_counter_data();
@@ -2998,7 +2998,7 @@ class MatchKeyFormatTest : public ExactOneTest {
     auto param = action->add_params();
     param->set_param_id(
         pi_p4info_action_param_id_from_name(p4info, a_id, "param"));
-    std::string adata(6, '\x00');
+    std::string adata(6, '\xcd');
     param->set_value(adata);
     return table_entry;
   }
@@ -3017,8 +3017,7 @@ TEST_F(MatchKeyFormatTest, Good1) {
   auto entry = make_entry_no_mk();
   std::string mf_v("\x0f\xbb", 2);
   add_one_mf(&entry, mf_v);
-  auto status = add_entry(&entry);
-  ASSERT_EQ(status.code(), Code::OK);
+  EXPECT_OK(add_entry(&entry));
 }
 
 TEST_F(MatchKeyFormatTest, Good2) {
@@ -3026,8 +3025,7 @@ TEST_F(MatchKeyFormatTest, Good2) {
   auto entry = make_entry_no_mk();
   std::string mf_v("\x00\x00", 2);
   add_one_mf(&entry, mf_v);
-  auto status = add_entry(&entry);
-  ASSERT_EQ(status.code(), Code::OK);
+  EXPECT_OK(add_entry(&entry));
 }
 
 TEST_F(MatchKeyFormatTest, MkMissingField) {
@@ -3046,11 +3044,11 @@ TEST_F(MatchKeyFormatTest, MkTooLong) {
 }
 
 TEST_F(MatchKeyFormatTest, FieldTooShort) {
+  EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
   auto entry = make_entry_no_mk();
   std::string mf_v("\x0a", 1);
   add_one_mf(&entry, mf_v);
-  auto status = add_entry(&entry);
-  EXPECT_EQ(status, OneExpectedError(Code::INVALID_ARGUMENT));
+  EXPECT_OK(add_entry(&entry));
 }
 
 TEST_F(MatchKeyFormatTest, FieldTooLong) {
@@ -3122,7 +3120,7 @@ class TernaryOneTest : public DeviceMgrTest {
 };
 
 TEST_F(TernaryOneTest, ValueEqValueAndMask) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   {  // value == value & mask
     std::string mf("\x11\x01\x01\x00", 4);
     std::string mask("\xff\xff\xff\xff", 4);
@@ -3142,7 +3140,7 @@ TEST_F(TernaryOneTest, ValueEqValueAndMask) {
 }
 
 TEST_F(TernaryOneTest, DontCare) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   {  // omitting match field: valid
     auto entry = make_entry(boost::none, boost::none, adata);
     EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
@@ -3168,7 +3166,7 @@ TEST_F(TernaryOneTest, DontCare) {
 }
 
 TEST_F(TernaryOneTest, ZeroPriority) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(boost::none, boost::none, adata, 0);
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _)).Times(0);
   auto status = add_entry(&entry);
@@ -3219,7 +3217,7 @@ class RangeOneTest : public DeviceMgrTest {
 };
 
 TEST_F(RangeOneTest, LowLeHigh) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   {  // low < high
     std::string low("\x11\x00\x11\x11", 4);
     std::string high("\x11\x00\x12\x11", 4);
@@ -3247,7 +3245,7 @@ TEST_F(RangeOneTest, LowLeHigh) {
 }
 
 TEST_F(RangeOneTest, DontCare) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   {  // omitting match field: valid
     auto entry = make_entry(boost::none, boost::none, adata);
     EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));
@@ -3315,7 +3313,7 @@ class LpmOneTest : public DeviceMgrTest {
 };
 
 TEST_F(LpmOneTest, TrailingZeros) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   int pLen(12);
   {
     std::string mf("\xff\xf0\x00\x00", 4);
@@ -3348,7 +3346,7 @@ TEST_F(LpmOneTest, TrailingZeros) {
 }
 
 TEST_F(LpmOneTest, DontCare) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   int pLen(0);
   {  // omitting match field: valid
     auto entry = make_entry(boost::none, pLen, adata);
@@ -4049,7 +4047,7 @@ TEST_F(ReadExclusiveAccess, ConcurrentReadAndWrites) {
 
     uint32_t member_id = 123;
     std::string mf("\xaa\xbb\xcc\xdd", 4);
-    std::string adata(6, '\x00');
+    std::string adata(6, '\xcd');
     auto member = make_member(member_id, adata);
     auto entry = make_indirect_entry_to_member(mf, member_id);
 
@@ -4331,8 +4329,8 @@ constexpr std::chrono::milliseconds IdleTimeoutTest::negativeTimeout;
 constexpr std::chrono::milliseconds IdleTimeoutTest::notificationMaxDelay;
 
 TEST_F(IdleTimeoutTest, EntryAgeing) {
-  std::string mf(2, '\x00');
-  std::string adata(6, '\x00');
+  std::string mf(2, '\xab');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata, defaultIdleTimeout);
 
   auto *entry_matcher_ = new TableEntryMatcher_Direct(a_id, adata);
@@ -4357,7 +4355,7 @@ TEST_F(IdleTimeoutTest, EntryAgeing) {
 // load). By default the DeviceMgr implementation delays notifications by at
 // most 100ms.
 TEST_F(IdleTimeoutTest, Buffering) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   constexpr size_t num_entries = 3;
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _)).Times(num_entries);
   for (size_t i = 0; i < num_entries; i++) {
@@ -4376,7 +4374,7 @@ TEST_F(IdleTimeoutTest, Buffering) {
 
 // Checks that notifications are not buffered for too long.
 TEST_F(IdleTimeoutTest, MaxBuffering) {
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   constexpr size_t num_entries = 3;
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _)).Times(num_entries);
   for (size_t i = 0; i < num_entries; i++) {
@@ -4394,7 +4392,7 @@ TEST_F(IdleTimeoutTest, MaxBuffering) {
 
 TEST_F(IdleTimeoutTest, ModifyTTL) {
   std::string mf(2, '\x00');
-  std::string adata(6, '\x00');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata, defaultIdleTimeout);
 
   auto *entry_matcher_ = new TableEntryMatcher_Direct(a_id, adata);
@@ -4419,8 +4417,8 @@ TEST_F(IdleTimeoutTest, ModifyTTL) {
 }
 
 TEST_F(IdleTimeoutTest, ReadEntry) {
-  std::string mf(2, '\x00');
-  std::string adata(6, '\x00');
+  std::string mf(2, '\xab');
+  std::string adata(6, '\xcd');
   auto entry = make_entry(mf, adata, defaultIdleTimeout);
 
   EXPECT_CALL(*mock, table_entry_add(t_id, _, _, _));

--- a/proto/tests/test_proto_fe_bytestrings.cpp
+++ b/proto/tests/test_proto_fe_bytestrings.cpp
@@ -1,0 +1,112 @@
+/* Copyright 2021 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+
+#include "src/common.h"
+
+namespace pi {
+namespace proto {
+namespace testing {
+namespace {
+
+using ::testing::TestWithParam;
+using ::testing::Values;
+
+using ::pi::fe::proto::common::bytestring_p4rt_to_pi;
+using ::pi::fe::proto::common::bytestring_pi_to_p4rt;
+
+class TestBytestringConversionP4RtToPi
+    : public TestWithParam<std::tuple<int, std::string, std::string> > { };
+
+TEST_P(TestBytestringConversionP4RtToPi, convert) {
+  auto nbits = std::get<0>(GetParam());
+  auto input = std::get<1>(GetParam());
+  auto expected_output = std::get<2>(GetParam());
+  auto output = bytestring_p4rt_to_pi(input, nbits);
+  ASSERT_TRUE(output.ok());
+  EXPECT_EQ(output.ValueOrDie(), expected_output);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BytestringConversionsP4RtToPi, TestBytestringConversionP4RtToPi,
+    Values(std::make_tuple(
+               16, std::string("\x30\x64", 2), std::string("\x30\x64", 2)),
+           std::make_tuple(
+               16, std::string("\x64", 1), std::string("\x00\x64", 2)),
+           std::make_tuple(
+               16, std::string("\x00\x64", 2), std::string("\x00\x64", 2)),
+           std::make_tuple(
+               16, std::string("\x00\x30\x64", 3), std::string("\x30\x64", 2)),
+           std::make_tuple(
+               12, std::string("\x00\x0f\x64", 3), std::string("\x0f\x64", 2)),
+           std::make_tuple(
+               12, std::string("\x64", 1), std::string("\x00\x64", 2)),
+           std::make_tuple(
+               12, std::string("\x0f\x64", 2), std::string("\x0f\x64", 2)))
+);
+
+class TestBytestringConversionP4RtToPiErrors
+    : public TestWithParam<std::tuple<int, std::string> > { };
+
+TEST_P(TestBytestringConversionP4RtToPiErrors, convert) {
+  auto nbits = std::get<0>(GetParam());
+  auto input = std::get<1>(GetParam());
+  auto output = bytestring_p4rt_to_pi(input, nbits);
+  ASSERT_FALSE(output.ok());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BytestringConversionsP4RtToPiErrors, TestBytestringConversionP4RtToPiErrors,
+    Values(std::make_tuple(16, std::string("\xab\x30\x64", 3)),
+           std::make_tuple(12, std::string("\xff\x30", 2)))
+);
+
+class TestBytestringConversionPiToP4Rt
+    : public TestWithParam<std::tuple<std::string, std::string> > { };
+
+TEST_P(TestBytestringConversionPiToP4Rt, convert) {
+  auto input = std::get<0>(GetParam());
+  auto expected_output = std::get<1>(GetParam());
+  auto output = bytestring_pi_to_p4rt(input);
+  EXPECT_EQ(output, expected_output);
+}
+
+TEST_P(TestBytestringConversionPiToP4Rt, convert_cstr) {
+  auto input = std::get<0>(GetParam());
+  auto expected_output = std::get<1>(GetParam());
+  auto output = bytestring_pi_to_p4rt(input.data(), input.size());
+  EXPECT_EQ(output, expected_output);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BytestringConversionsPiToP4Rt, TestBytestringConversionPiToP4Rt,
+    Values(std::make_tuple(
+               std::string("\x30\x64", 2), std::string("\x30\x64", 2)),
+           std::make_tuple(
+               std::string("\x00\x64", 2), std::string("\x64", 1)))
+);
+
+}  // namespace
+}  // namespace testing
+}  // namespace proto
+}  // namespace pi


### PR DESCRIPTION
* All bytestrings which are valid according to the P4Runtime
  specification are now accepted for Write RPCs
* All bytestrings sent by the P4Runtime server to the P4Runtime client
  now use the canonical representation

If read-write symmetry is desired, the clients should only send
bytestrings in the canonical format, as per the P4Runtime specification.

Fixes #454