### PR TITLE
Remove ppa:ubuntu-toolchain-r/test from Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,10 @@ matrix:
   include:
     - name: gcc
       env: CXX=g++ CC=gcc
-    - name: gcc-7
-      env: CXX=g++-7 CC=gcc-7
     - name: clang-3.8
       env: CXX=clang++-3.8 CC=clang-3.8
-    - name: clang-6.0
-      env: CXX=clang++-6.0 CC=clang-6.0
+    - name: clang-8
+      env: CXX=clang++-8 CC=clang-8
 
 install:
   - docker build -t pi --build-arg IMAGE_TYPE=test --build-arg CC=$CC --build-arg CXX=$CXX -f Dockerfile.bmv2 .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ All contributed code must pass the style checker, which can be run with
 `./tools/check_style.sh`. If the style checker fails because of a C file, you
 can format this C file with `./tools/clang_format_check.py -s Google -i <file>`.
 
-CI uses clang-format-6.0 to validate the formatting of C files, which means that
+CI uses clang-format-8 to validate the formatting of C files, which means that
 your contribution may fail CI if you use a different version locally.
 
 ### Making changes to the PI internal API

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,6 @@ ENV PI_RUNTIME_DEPS libboost-system1.58.0 \
 COPY . /PI/
 WORKDIR /PI/
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get update && \
     apt-get install -y --no-install-recommends $PI_DEPS $PI_RUNTIME_DEPS && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     ln -sf /usr/bin/pip3 /usr/bin/pip && \

--- a/Dockerfile.bmv2
+++ b/Dockerfile.bmv2
@@ -16,18 +16,16 @@ ARG MAKEFLAGS=-j2
 ARG IMAGE_TYPE=build
 
 # Select the compiler to use.
-# We install the default version of GCC (GCC 5), as well as GCC 7, clang 3.8 and
-# clang 6.0.
+# We install the default version of GCC (GCC 5), as well as clang 3.8 and clang 8.
 ARG CC=gcc
 ARG CXX=g++
 
 ENV PI_DEPS automake \
             build-essential \
             clang-3.8 \
-            clang-6.0 \
-            clang-format-6.0 \
+            clang-8 \
+            clang-format-8 \
             g++ \
-            g++-7 \
             libboost-dev \
             libboost-system-dev \
             libboost-thread-dev \
@@ -50,9 +48,6 @@ COPY proto/sysrepo/docker_entry_point.sh /docker_entry_point.sh
 COPY . /PI/
 WORKDIR /PI/
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get update && \
     apt-get install -y --no-install-recommends $PI_DEPS $PI_RUNTIME_DEPS && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     ln -sf /usr/bin/pip3 /usr/bin/pip && \

--- a/tools/clang_format_check.py
+++ b/tools/clang_format_check.py
@@ -184,7 +184,7 @@ def main():
     parser.add_argument("-e", "--exe",
                         required=False,
                         help="The clang-format executable to use, by default "
-                        "we will try 'clang-format' and 'clang-format-6.0'")
+                        "we will try 'clang-format' and 'clang-format-8'")
 
     # Files or directory to check
     parser.add_argument("file", nargs="+", help="Paths to the files that'll "
@@ -208,7 +208,7 @@ def main():
             exit(-1)
         clang_exec = args.exe
     else:
-        for e in ["clang-format", "clang-format-6.0"]:
+        for e in ["clang-format", "clang-format-8"]:
             if check_clang_format_exec(e):
                 clang_exec = e
                 break


### PR DESCRIPTION
For some reason, having this PPA makes it impossible to install clang,
it creates a "dependency hell". This is recent a issue and wasn't
present a couple weeks ago. To avoid the issue altogether, rather than
waste a lot of time debugging it, we remove the PPA, which means we no
longer run a CI job with a "recent" version of gcc (gcc 7). We still
test with the default version of gcc for Ubuntu 16.04, along with
clang-3.8 and clang-8 (updated from clang-6.0).

The long-term solution should really be to update the base image from
Ubuntu 16.04 to 20.04 (https://github.com/p4lang/third-party/issues/25).