### PR TITLE
Unsafe proto release cleanup

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -3,14 +3,15 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//bazel:workspace_rule.bzl", "remote_workspace")
 
-GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a";
-GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108";
+GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a"
+GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108"
+
 # P4RUNTIME_TAG = "1.3.0"
 # We cannot use the latest release (v1.3.0) as we need to include a recent fix
 # to support Bazel 4.0. More precisely, this fix updates the Bazel build
 # dependencies to more recent versions compatible with Bazel 4.0.
-P4RUNTIME_COMMIT = "0d40261b67283999bf0f03bd6b40b5374c7aebd0"
-P4RUNTIME_SHA="d1b31378f58fa7c6039edac06299acfe77ec130e4dffb4704b4e5a30293bd2a5"
+P4RUNTIME_COMMIT = "e9c0d196c4c2acd6f1bd3439f5b30b423ef90c95"
+P4RUNTIME_SHA = "039fb488af8b5ae8f2a5dd05ca4385b1ab33099165c4d61405fb50eedf0c6324"
 
 def PI_deps():
     """Loads dependencies needed to compile PI."""
@@ -50,7 +51,7 @@ def PI_deps():
             build_file = "@//bazel:external/gnmi.BUILD",
             patch_cmds = [
                 "sed -i.bak 's#github.com/openconfig/gnmi/proto/##g' gnmi/gnmi.proto",
-                "rm gnmi/gnmi.proto.bak"
+                "rm gnmi/gnmi.proto.bak",
             ],
         )
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -3,15 +3,15 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//bazel:workspace_rule.bzl", "remote_workspace")
 
-GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a"
-GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108"
+GNMI_COMMIT="39cb2fffed5c9a84970bde47b3d39c8c716dc17a";
+GNMI_SHA="3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108";
 
 # P4RUNTIME_TAG = "1.3.0"
 # We cannot use the latest release (v1.3.0) as we need to include a recent fix
 # to support Bazel 4.0. More precisely, this fix updates the Bazel build
 # dependencies to more recent versions compatible with Bazel 4.0.
-P4RUNTIME_COMMIT = "e9c0d196c4c2acd6f1bd3439f5b30b423ef90c95"
-P4RUNTIME_SHA = "039fb488af8b5ae8f2a5dd05ca4385b1ab33099165c4d61405fb50eedf0c6324"
+P4RUNTIME_COMMIT="e9c0d196c4c2acd6f1bd3439f5b30b423ef90c95"
+P4RUNTIME_SHA="c83ab6b7f89e5d1a0faedb04d6a0e3c2969a810f98d732bca40c8d774851aedb"
 
 def PI_deps():
     """Loads dependencies needed to compile PI."""
@@ -51,7 +51,7 @@ def PI_deps():
             build_file = "@//bazel:external/gnmi.BUILD",
             patch_cmds = [
                 "sed -i.bak 's#github.com/openconfig/gnmi/proto/##g' gnmi/gnmi.proto",
-                "rm gnmi/gnmi.proto.bak",
+                "rm gnmi/gnmi.proto.bak"
             ],
         )
 

--- a/proto/frontend/src/device_mgr.cpp
+++ b/proto/frontend/src/device_mgr.cpp
@@ -602,11 +602,11 @@ class DeviceMgrImp {
       for (auto &entity : *forwarding_state.mutable_entities()) {
         auto *update = write_request.add_updates();
         update->set_type(p4v1::Update::INSERT);
-        update->set_allocated_entity(&entity);
+        update->unsafe_arena_set_allocated_entity(&entity);
       }
       auto status = write_(write_request);
       for (auto &update : *write_request.mutable_updates())
-        update.release_entity();
+        update.unsafe_arena_release_entity();
       if (IS_ERROR(status))
         RETURN_ERROR_STATUS(Code::UNKNOWN, "Error when reconciling config")
     }
@@ -1598,9 +1598,9 @@ class DeviceMgrImp {
     if (stream_error.canonical_code() == Code::OK || !cb_) return status;
 
     p4v1::StreamMessageResponse msg;
-    msg.set_allocated_error(&stream_error);
+    msg.unsafe_arena_set_allocated_error(&stream_error);
     cb_(device_id, &msg, cookie_);
-    msg.release_error();
+    msg.unsafe_arena_release_error();
     return status;
   }
 

--- a/proto/frontend/src/digest_mgr.cpp
+++ b/proto/frontend/src/digest_mgr.cpp
@@ -515,13 +515,15 @@ class DigestData {
     digest.set_timestamp(
         std::chrono::duration_cast<std::chrono::nanoseconds>(
             Clock::now().time_since_epoch()).count());
-    response.set_allocated_digest(&digest);
     // the test for a callback is probably not strictly required based on our
     // usage. However, in theory it is possible for the callback to be
     // unregistered and then have the timeout sweep task try to generate a
     // digest message.
-    if (cb) cb(device_id, &response, cookie);
-    response.release_digest();
+    if (cb) {
+        response.unsafe_arena_set_allocated_digest(&digest);
+        cb(device_id, &response, cookie);
+        response.unsafe_arena_release_digest();
+    }
     timeout_bit = false;
     // for the case where ack_timeout_ns is 0 and no caching is done
     if (!current_list_data.cache_pointers.empty())

--- a/proto/frontend/src/idle_timeout_buffer.cpp
+++ b/proto/frontend/src/idle_timeout_buffer.cpp
@@ -79,9 +79,9 @@ class IdleTimeoutBuffer::TaskSendNotifications : public Task {
         std::chrono::duration_cast<std::chrono::nanoseconds>(
             Clock::now().time_since_epoch()).count());
     p4v1::StreamMessageResponse msg;
-    msg.set_allocated_idle_timeout_notification(&notifications);
+    msg.unsafe_arena_set_allocated_idle_timeout_notification(&notifications);
     buffer->cb(buffer->device_id, &msg, buffer->cookie);
-    msg.release_idle_timeout_notification();
+    msg.unsafe_arena_release_idle_timeout_notification();
     notifications.Clear();
   }
 };

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -598,9 +598,9 @@ namespace testing {
 
 void send_packet_in(DeviceMgr::device_id_t device_id, p4v1::PacketIn *packet) {
   p4v1::StreamMessageResponse msg;
-  msg.set_allocated_packet(packet);
+  msg.unsafe_arena_set_allocated_packet(packet);
   Devices::get(device_id)->send_stream_message(&msg);
-  msg.release_packet();
+  msg.unsafe_arena_release_packet();
 }
 
 size_t max_connections() { return DeviceState::max_connections; }

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -890,9 +890,9 @@ class ActionProfTest
     auto update = request.add_updates();
     update->set_type(type);
     auto entity = update->mutable_entity();
-    entity->set_allocated_action_profile_member(member);
+    entity->unsafe_arena_set_allocated_action_profile_member(member);
     auto status = mgr.write(request);
-    entity->release_action_profile_member();
+    entity->unsafe_arena_release_action_profile_member();
     return status;
   }
 
@@ -953,9 +953,9 @@ class ActionProfTest
     auto update = request.add_updates();
     update->set_type(type);
     auto entity = update->mutable_entity();
-    entity->set_allocated_action_profile_group(group);
+    entity->unsafe_arena_set_allocated_action_profile_group(group);
     auto status = mgr.write(request);
-    entity->release_action_profile_group();
+    entity->unsafe_arena_release_action_profile_group();
     return status;
   }
 
@@ -1703,9 +1703,9 @@ class MatchTableIndirectTest
     auto update = request.add_updates();
     update->set_type(p4v1::Update::INSERT);
     auto entity = update->mutable_entity();
-    entity->set_allocated_action_profile_member(&member);
+    entity->unsafe_arena_set_allocated_action_profile_member(&member);
     auto status = mgr.write(request);
-    entity->release_action_profile_member();
+    entity->unsafe_arena_release_action_profile_member();
     EXPECT_EQ(status.code(), Code::OK);
   }
 
@@ -1739,9 +1739,9 @@ class MatchTableIndirectTest
     auto update = request.add_updates();
     update->set_type(p4v1::Update::INSERT);
     auto entity = update->mutable_entity();
-    entity->set_allocated_action_profile_group(&group);
+    entity->unsafe_arena_set_allocated_action_profile_group(&group);
     auto status = mgr.write(request);
-    entity->release_action_profile_group();
+    entity->unsafe_arena_release_action_profile_group();
     EXPECT_OK(status);
   }
 
@@ -2390,9 +2390,9 @@ class DirectMeterTest : public ExactOneTest {
     auto update = request.add_updates();
     update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
-    entity->set_allocated_direct_meter_entry(direct_meter_entry);
+    entity->unsafe_arena_set_allocated_direct_meter_entry(direct_meter_entry);
     auto status = mgr.write(request);
-    entity->release_direct_meter_entry();
+    entity->unsafe_arena_release_direct_meter_entry();
     return status;
   }
 
@@ -2417,9 +2417,9 @@ class DirectMeterTest : public ExactOneTest {
                                p4v1::ReadResponse *response) {
     p4v1::ReadRequest request;
     auto entity = request.add_entities();
-    entity->set_allocated_direct_meter_entry(direct_meter_entry);
+    entity->unsafe_arena_set_allocated_direct_meter_entry(direct_meter_entry);
     auto status = mgr.read(request, response);
-    entity->release_direct_meter_entry();
+    entity->unsafe_arena_release_direct_meter_entry();
     return status;
   }
 
@@ -2607,9 +2607,9 @@ class IndirectMeterTest : public DeviceMgrTest  {
                                p4v1::ReadResponse *response) {
     p4v1::ReadRequest request;
     auto entity = request.add_entities();
-    entity->set_allocated_meter_entry(meter_entry);
+    entity->unsafe_arena_set_allocated_meter_entry(meter_entry);
     auto status = mgr.read(request, response);
-    entity->release_meter_entry();
+    entity->unsafe_arena_release_meter_entry();
     return status;
   }
 
@@ -2618,9 +2618,9 @@ class IndirectMeterTest : public DeviceMgrTest  {
     auto update = request.add_updates();
     update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
-    entity->set_allocated_meter_entry(meter_entry);
+    entity->unsafe_arena_set_allocated_meter_entry(meter_entry);
     auto status = mgr.write(request);
-    entity->release_meter_entry();
+    entity->unsafe_arena_release_meter_entry();
     return status;
   }
 
@@ -2682,9 +2682,9 @@ class DirectCounterTest : public ExactOneTest {
                                  p4v1::ReadResponse *response) {
     p4v1::ReadRequest request;
     auto entity = request.add_entities();
-    entity->set_allocated_direct_counter_entry(direct_counter_entry);
+    entity->unsafe_arena_set_allocated_direct_counter_entry(direct_counter_entry);
     auto status = mgr.read(request, response);
-    entity->release_direct_counter_entry();
+    entity->unsafe_arena_release_direct_counter_entry();
     return status;
   }
 
@@ -2694,9 +2694,9 @@ class DirectCounterTest : public ExactOneTest {
     auto update = request.add_updates();
     update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
-    entity->set_allocated_direct_counter_entry(direct_counter_entry);
+    entity->unsafe_arena_set_allocated_direct_counter_entry(direct_counter_entry);
     auto status = mgr.write(request);
-    entity->release_direct_counter_entry();
+    entity->unsafe_arena_release_direct_counter_entry();
     return status;
   }
 
@@ -2902,9 +2902,9 @@ class IndirectCounterTest : public DeviceMgrTest  {
                                  p4v1::ReadResponse *response) {
     p4v1::ReadRequest request;
     auto entity = request.add_entities();
-    entity->set_allocated_counter_entry(counter_entry);
+    entity->unsafe_arena_set_allocated_counter_entry(counter_entry);
     auto status = mgr.read(request, response);
-    entity->release_counter_entry();
+    entity->unsafe_arena_release_counter_entry();
     return status;
   }
 
@@ -2913,9 +2913,9 @@ class IndirectCounterTest : public DeviceMgrTest  {
     auto update = request.add_updates();
     update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
-    entity->set_allocated_counter_entry(counter_entry);
+    entity->unsafe_arena_set_allocated_counter_entry(counter_entry);
     auto status = mgr.write(request);
-    entity->release_counter_entry();
+    entity->unsafe_arena_release_counter_entry();
     return status;
   }
 

--- a/proto/tests/test_proto_fe.cpp
+++ b/proto/tests/test_proto_fe.cpp
@@ -2682,7 +2682,8 @@ class DirectCounterTest : public ExactOneTest {
                                  p4v1::ReadResponse *response) {
     p4v1::ReadRequest request;
     auto entity = request.add_entities();
-    entity->unsafe_arena_set_allocated_direct_counter_entry(direct_counter_entry);
+    entity->unsafe_arena_set_allocated_direct_counter_entry(
+        direct_counter_entry);
     auto status = mgr.read(request, response);
     entity->unsafe_arena_release_direct_counter_entry();
     return status;
@@ -2694,7 +2695,8 @@ class DirectCounterTest : public ExactOneTest {
     auto update = request.add_updates();
     update->set_type(p4v1::Update::MODIFY);
     auto entity = update->mutable_entity();
-    entity->unsafe_arena_set_allocated_direct_counter_entry(direct_counter_entry);
+    entity->unsafe_arena_set_allocated_direct_counter_entry(
+        direct_counter_entry);
     auto status = mgr.write(request);
     entity->unsafe_arena_release_direct_counter_entry();
     return status;

--- a/proto/tests/test_proto_fe_base.h
+++ b/proto/tests/test_proto_fe_base.h
@@ -85,12 +85,12 @@ class DeviceMgrBaseTest : public ProtoFrontendBaseTest {
         .Times(::testing::AnyNumber());
 
     p4v1::ForwardingPipelineConfig config;
-    config.set_allocated_p4info(p4info_proto);
+    config.unsafe_arena_set_allocated_p4info(p4info_proto);
     config.mutable_cookie()->set_cookie(cookie);
     config.set_p4_device_config(device_config);
     auto status = mgr.pipeline_config_set(
         p4v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT, config);
-    config.release_p4info();
+    config.unsafe_arena_release_p4info();
     return status;
   }
 
@@ -100,9 +100,9 @@ class DeviceMgrBaseTest : public ProtoFrontendBaseTest {
     auto update = request.add_updates();
     update->set_type(type);
     auto entity = update->mutable_entity();
-    entity->set_allocated_table_entry(entry);
+    entity->unsafe_arena_set_allocated_table_entry(entry);
     auto status = mgr.write(request);
-    entity->release_table_entry();
+    entity->unsafe_arena_release_table_entry();
     return status;
   }
 
@@ -129,9 +129,9 @@ class DeviceMgrBaseTest : public ProtoFrontendBaseTest {
   DeviceMgr::Status read_table_entry(p4v1::TableEntry *table_entry,
                                      p4v1::ReadResponse *response) {
     p4v1::Entity entity;
-    entity.set_allocated_table_entry(table_entry);
+    entity.unsafe_arena_set_allocated_table_entry(table_entry);
     auto status = mgr.read_one(entity, response);
-    entity.release_table_entry();
+    entity.unsafe_arena_release_table_entry();
     return status;
   }
 

--- a/proto/tests/test_proto_fe_set_pipeline_config.cpp
+++ b/proto/tests/test_proto_fe_set_pipeline_config.cpp
@@ -72,9 +72,9 @@ class DeviceMgrSetPipelineConfigTest : public DeviceMgrBaseTest {
         .Times(AnyNumber());
 
     p4v1::ForwardingPipelineConfig config;
-    config.set_allocated_p4info(p4info_proto);
+    config.unsafe_arena_set_allocated_p4info(p4info_proto);
     auto status = mgr.pipeline_config_set(action, config);
-    config.release_p4info();
+    config.unsafe_arena_release_p4info();
     return status;
   }
 };


### PR DESCRIPTION
MUST_USE_RESULT is being added to these release methods, which will break this code as it's currently written.  This change is part of an internal google effort to fix these instances before enabling PROTOBUF_MUST_USE_RESULT.

The unsafe arena variants of set_allocated_* and release_* will not require the result to be checked, and will also avoid unwanted copies or memory leaks if the protos are owned by an arena.