### PR TITLE
Simplify dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ is not the right one.
 - [nanomsg 1.0.0](https://github.com/nanomsg/nanomsg/releases/tag/1.0.0)
 - [Protobuf v3.6.1](https://github.com/google/protobuf/releases/tag/v3.6.1):
 ```
-git clone https://github.com/google/protobuf.git
+git clone --depth=1 -b v3.6.1 https://github.com/google/protobuf.git
 cd protobuf/
-git checkout tags/v3.6.1
 ./autogen.sh
 ./configure
 make
@@ -65,9 +64,8 @@ make
 ```
 - [gRPC v1.17.2](https://github.com/grpc/grpc/releases/tag/v1.17.2):
 ```
-git clone https://github.com/google/grpc.git
+git clone --depth=1 -b v1.17.2 https://github.com/google/grpc.git
 cd grpc/
-git checkout tags/v1.17.2
 git submodule update --init --recursive
 make
 [sudo] make install

--- a/proto/README.md
+++ b/proto/README.md
@@ -21,9 +21,8 @@ packages:
 
 Then install libyang:
 
-    git clone https://github.com/CESNET/libyang.git
+    git clone --depth=1 -b v0.16-r1 https://github.com/CESNET/libyang.git
     cd libyang
-    git checkout v0.16-r1
     mkdir build
     cd build
     cmake ..
@@ -32,9 +31,8 @@ Then install libyang:
 
 Finally, install sysrepo
 
-    git clone https://github.com/sysrepo/sysrepo.git
+    git clone --depth=1 -b v0.7.5 https://github.com/sysrepo/sysrepo.git
     cd sysrepo
-    git checkout v0.7.5
     mkdir build
     cd build
     cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=Off -DCALL_TARGET_BINS_DIRECTLY=Off ..


### PR DESCRIPTION
This pull request updates the dependency installation instructions to use the `--depth` option for `git clone` to create a shallow clone and point to the exact branch needed with `-b`. This can save a lot of space and time.