### PR TITLE
Use Github workflow to update p4lang/PI Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build and push latest image
+
+on:
+  push:
+    branches:
+      - main
+      - stable
+
+jobs:
+  build:
+    if: ${{ github.repository == 'p4lang/PI' && github.event_name == 'push' }}
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Determine Docker image tag
+      id: get-tag
+      shell: bash
+      run: |
+        TAG=""
+        if [[ "$GITHUB_REF" =~ "main" ]]; then
+            TAG="latest"
+        elif [[ "$GITHUB_REF" =~ "stable" ]]; then
+            TAG="stable"
+        else
+            echo "Invalid Github ref $GITHUB_REF"
+            exit 1
+        fi
+        echo "Tag is $TAG"
+        echo "::set-output name=tag::$TAG"
+    - name: Build and push Docker image to registry
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        docker build -t p4lang/PI:${{ steps.get-tag.outputs.tag }} .
+        docker push p4lang/PI:${{ steps.get-tag.outputs.tag }}


### PR DESCRIPTION
Now that Docker has disabled automatic builds for free accounts, we need
to find a different solution.
This is temporary: ideally I'd like to migrate everything from Travis to
Github workflows. The Docker image should also be updated every time the
base image (p4lang/third-party) is updated, not just for push events.