### PR TITLE
Support mutual TLS authentication for PI gRPC server

### DIFF
--- a/proto/server/PI/proto/pi_server.h
+++ b/proto/server/PI/proto/pi_server.h
@@ -27,10 +27,20 @@
 extern "C" {
 #endif
 
+// same as the ones defined by gRPC
+typedef enum {
+  PI_GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE = 0,  // default
+  PI_GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY,
+  PI_GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY,
+  PI_GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY,
+  PI_GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY,
+} PIGrpcServerSSLClientAuth_t;
+
 typedef struct {
   const char *pem_root_certs;
   const char *pem_private_key;
   const char *pem_cert_chain;
+  PIGrpcServerSSLClientAuth_t client_auth;
 } PIGrpcServerSSLOptions_t;
 
 // Initializes necessary resources. Should only be called once.

--- a/proto/server/pi_server.cpp
+++ b/proto/server/pi_server.cpp
@@ -651,6 +651,32 @@ void PIGrpcServerRunV2(const char *server_address,
     ssl_opts.pem_root_certs = (ssl_options->pem_root_certs == NULL) ?
         "" : ssl_options->pem_root_certs;
     ssl_opts.pem_key_cert_pairs.push_back(pkcp);
+    switch (ssl_options->client_auth) {
+      case PI_GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE:
+        ssl_opts.client_certificate_request =
+            GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE;
+        break;
+      case PI_GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
+        ssl_opts.client_certificate_request =
+            GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY;
+        break;
+      case PI_GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY:
+        ssl_opts.client_certificate_request =
+            GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY;
+        break;
+      case PI_GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
+        ssl_opts.client_certificate_request =
+            GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY;
+        break;
+      case PI_GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY:
+        ssl_opts.client_certificate_request =
+            GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY;
+        break;
+      default:
+        ssl_opts.client_certificate_request =
+            GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE;
+        break;
+    }
     creds = grpc::SslServerCredentials(ssl_opts);
   }
   builder.AddListeningPort(


### PR DESCRIPTION
It was already possible to provide a CA certificate for the server to
verify the client. However, by default gRPC will not request a
certificate from the client unless it is configured to do so. We had an
SSL option to configure client certificate requests.