### PR TITLE
configure: Update AM_PATH_PYTHON to Python 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,9 +23,7 @@ AC_PROG_CXX
 # std=c++11, configure will not fail
 AX_CXX_COMPILE_STDCXX_11([noext],[optional])
 
-# TODO: this can be removed when the Python scripts are updated to work with
-# python3.
-m4_define_default([_AM_PYTHON_INTERPRETER_LIST], [python python3 python2.7])
+m4_define_default([_AM_PYTHON_INTERPRETER_LIST], [python3 python])
 AM_CONDITIONAL([HAVE_python], [test "$PYTHON" != :])
 
 DX_DOT_FEATURE([ON])

--- a/proto/configure.ac
+++ b/proto/configure.ac
@@ -18,7 +18,7 @@ AC_LANG_PUSH(C++)
 
 AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 
-AM_PATH_PYTHON([2.7],, [:])
+AM_PATH_PYTHON([3.5],, [:])
 AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != :])
 
 PKG_CHECK_MODULES([PROTOBUF], [protobuf >= 3.0.0])

--- a/proto/demo_grpc/1sw_demo.py
+++ b/proto/demo_grpc/1sw_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/proto/demo_grpc/README.md
+++ b/proto/demo_grpc/README.md
@@ -28,7 +28,7 @@ the switch. The gRPC server translates the protobuf messages into PI library
 calls (using the PI C++ frontend).
 
 To run the demo, you will need 3 terminal instances:
-- `sudo python 1sw_demo.py --cpu-port veth250`
+- `sudo python3 1sw_demo.py --cpu-port veth250`
 - `sudo ./pi_grpc_server`
 - `sudo ./controller -c simple_router.json -p simple_router.p4info.txt`
 

--- a/proto/p4info/xform/xform_anno.py
+++ b/proto/p4info/xform/xform_anno.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python3
 #
 # xform_anno.py - Utility to transform p4info annotations into first-class Message elements
 #

--- a/proto/ptf/README.md
+++ b/proto/ptf/README.md
@@ -46,7 +46,7 @@ inject and receive test packets.
 
 3. Running the PTF tests (in a second terminal)
 
-    sudo python ptf_runner.py \
+    sudo python3 ptf_runner.py \
         --device-config config.bin --p4info p4info.proto.txt \
         --ptfdir l3_host_fwd/test/ --port-map bmv2/port_map.json
 

--- a/proto/ptf/bmv2/gen_bmv2_config.py
+++ b/proto/ptf/bmv2/gen_bmv2_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/proto/ptf/bmv2/gen_bmv2_config.sh
+++ b/proto/ptf/bmv2/gen_bmv2_config.sh
@@ -8,5 +8,5 @@ fi
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-python $THIS_DIR/gen_bmv2_config.py $1 \
+python3 $THIS_DIR/gen_bmv2_config.py $1 \
   --out-bin $2/device_config.bin --out-p4info $2/p4info.proto.txt

--- a/proto/ptf/l3_host_fwd/test/l3_host_fwd.py
+++ b/proto/ptf/l3_host_fwd/test/l3_host_fwd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/proto/ptf/ptf_runner.py
+++ b/proto/ptf/ptf_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tests/CLI/run_one_test.py.in
+++ b/tests/CLI/run_one_test.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tools/clang_format_check.py
+++ b/tools/clang_format_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Modified from https://github.com/cloderic/clang_format_check

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #

--- a/tools/update_test_bmv2_jsons.py
+++ b/tools/update_test_bmv2_jsons.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import fnmatch


### PR DESCRIPTION
This pull request updates the `AM_PATH_PYTHON` macro to search for a Python 3 interpreter on the system. The first argument of this macro is the minimum version of Python required. Usually, when `AM_PATH_PYTHON` is invoked with an argument of the form `3.X`, it means that only a Python 3 interpreter should be used. However, [the `python` command may invoke a Python 2 interpreter](http://www.python.org/dev/peps/pep-0394/) on some systems. Thus, if we try `python` first we may get a Python 2 interpreter.

Fixes https://github.com/p4lang/PI/issues/582