### PR TITLE
Increase the max value for the clone session ID

### DIFF
--- a/proto/frontend/src/pre_clone_mgr.h
+++ b/proto/frontend/src/pre_clone_mgr.h
@@ -29,6 +29,7 @@
 
 #include "google/rpc/status.pb.h"
 #include "p4/v1/p4runtime.pb.h"
+
 #include "pre_mc_mgr.h"
 
 namespace pi {
@@ -37,76 +38,74 @@ namespace fe {
 
 namespace proto {
 
-namespace common {
-class SessionTemp;
-}  // namespace common
+namespace common { class SessionTemp; }  // namespace common
 
 // This class is used to map P4Runtime CloneSessionEntry messages to lower-level
 // PI operations. At the moment every clone session is associated to a multicast
 // group.
 class PreCloneMgr {
  public:
-    using Status = ::google::rpc::Status;
-    using CloneSession = ::p4::v1::CloneSessionEntry;
-    using CloneSessionId = uint32_t;
-    using SessionTemp = common::SessionTemp;
+  using Status = ::google::rpc::Status;
+  using CloneSession = ::p4::v1::CloneSessionEntry;
+  using CloneSessionId = uint32_t;
+  using SessionTemp = common::SessionTemp;
 
-    PreCloneMgr(pi_dev_tgt_t device_tgt, PreMcMgr *mc_mgr);
+  PreCloneMgr(pi_dev_tgt_t device_tgt, PreMcMgr* mc_mgr);
 
-    Status session_create(const CloneSession &clone_session,
-                          const SessionTemp &session);
-    Status session_modify(const CloneSession &clone_session,
-                          const SessionTemp &session);
-    Status session_delete(const CloneSession &clone_session,
-                          const SessionTemp &session);
-    Status session_read(const CloneSession &clone_session,
-                        const SessionTemp &session,
-                        ::p4::v1::ReadResponse *response) const;
+  Status session_create(const CloneSession &clone_session,
+                        const SessionTemp &session);
+  Status session_modify(const CloneSession &clone_session,
+                        const SessionTemp &session);
+  Status session_delete(const CloneSession &clone_session,
+                        const SessionTemp &session);
+  Status session_read(const CloneSession &clone_session,
+                      const SessionTemp &session,
+                      ::p4::v1::ReadResponse *response) const;
 
  private:
-    using Mutex = std::mutex;
-    using Lock = std::lock_guard<Mutex>;
+  using Mutex = std::mutex;
+  using Lock = std::lock_guard<Mutex>;
 
-    struct CloneSessionConfig {
-        uint32_t class_of_service;
-        int32_t packet_length_bytes;
+  struct CloneSessionConfig {
+    uint32_t class_of_service;
+    int32_t packet_length_bytes;
 
-        bool operator==(const CloneSessionConfig &other) const {
-            return class_of_service == other.class_of_service &&
-                   packet_length_bytes == other.packet_length_bytes;
-        }
+    bool operator==(const CloneSessionConfig &other) const {
+      return class_of_service == other.class_of_service &&
+          packet_length_bytes == other.packet_length_bytes;
+    }
 
-        bool operator!=(const CloneSessionConfig &other) const {
-            return !(*this == other);
-        }
-    };
+    bool operator!=(const CloneSessionConfig &other) const {
+      return !(*this == other);
+    }
+  };
 
-    // We set the max session ID value to 32768.
-    // This is the the max value supported by simple_switch,
-    // which reserves the left-most bit
-    // https://github.com/p4lang/behavioral-model/blob/
-    // e9fa7dc687f334e5cf327e0c993fc1a351d224c0/targets/simple_switch/register_access.h#L46
-    // Additionally, for clone sessions to more than 1 port, PI will program a
-    // multicast group. There may only be 32768 mgids available for this usage
-    // (with another 32768 reserved for user-defined multicast groups).
-    // TODO(antonin): Ideally, these values should be configurable based on the
-    // target. Other targets may support a different number of clone sessions.
-    static constexpr CloneSessionId kMinCloneSessionId = 1;
-    static constexpr CloneSessionId kMaxCloneSessionId = 32768;
+  // We set the max session ID value to 32768.
+  // This is the the max value supported by simple_switch, which reserves the
+  // left-most bit
+  // https://github.com/p4lang/behavioral-model/blob/
+  // e9fa7dc687f334e5cf327e0c993fc1a351d224c0/targets/simple_switch/register_access.h#L46
+  // Additionally, for clone sessions to more than 1 port, PI will program a
+  // multicast group. There may only be 32768 mgids available for this usage
+  // (with another 32768 reserved for user-defined multicast groups).
+  // TODO(antonin): Ideally, these values should be configurable based on the
+  // target. Other targets may support a different number of clone sessions.
+  static constexpr CloneSessionId kMinCloneSessionId = 1;
+  static constexpr CloneSessionId kMaxCloneSessionId = 32768;
 
-    Status session_set(const CloneSession &clone_session,
-                       PreMcMgr::GroupId mc_group_id,
-                       const SessionTemp &session);
+  Status session_set(const CloneSession &clone_session,
+                     PreMcMgr::GroupId mc_group_id,
+                     const SessionTemp &session);
 
-    static Status validate_session_id(CloneSessionId session_id);
+  static Status validate_session_id(CloneSessionId session_id);
 
-    static CloneSessionConfig make_clone_session_config(
-        const CloneSession &clone_session);
+  static CloneSessionConfig make_clone_session_config(
+      const CloneSession &clone_session);
 
-    pi_dev_tgt_t device_tgt;
-    PreMcMgr *mc_mgr;  // non-owning pointer
-    std::unordered_map<CloneSessionId, CloneSessionConfig> sessions{};
-    mutable Mutex mutex{};
+  pi_dev_tgt_t device_tgt;
+  PreMcMgr* mc_mgr;  // non-owning pointer
+  std::unordered_map<CloneSessionId, CloneSessionConfig> sessions{};
+  mutable Mutex mutex{};
 };
 
 }  // namespace proto

--- a/proto/frontend/src/pre_clone_mgr.h
+++ b/proto/frontend/src/pre_clone_mgr.h
@@ -80,10 +80,16 @@ class PreCloneMgr {
     }
   };
 
-  // TODO(antonin): this should ideally be configurable based on te target but
-  // these seem like a reasonnable place to start with.
+  // We set the max session ID value to 32768.
+  // This is the the max value supported by simple_switch, which reserves the left-most bit
+  // (https://github.com/p4lang/behavioral-model/blob/e9fa7dc687f334e5cf327e0c993fc1a351d224c0/targets/simple_switch/register_access.h#L46).
+  // Additionally, for clone sessions to more than 1 port, PI will program a multicast group.
+  // There may only be 32768 mgids available for this usage (with another 32768 reserved for
+  // user-defined multicast groups).
+  // TODO(antonin): Ideally, these values should be configurable based on the target.
+  // Other targets may support a different number of clone sessions.
   static constexpr CloneSessionId kMinCloneSessionId = 1;
-  static constexpr CloneSessionId kMaxCloneSessionId = 65536;
+  static constexpr CloneSessionId kMaxCloneSessionId = 32768;
 
   Status session_set(const CloneSession &clone_session,
                      PreMcMgr::GroupId mc_group_id,

--- a/proto/frontend/src/pre_clone_mgr.h
+++ b/proto/frontend/src/pre_clone_mgr.h
@@ -29,7 +29,6 @@
 
 #include "google/rpc/status.pb.h"
 #include "p4/v1/p4runtime.pb.h"
-
 #include "pre_mc_mgr.h"
 
 namespace pi {
@@ -38,72 +37,76 @@ namespace fe {
 
 namespace proto {
 
-namespace common { class SessionTemp; }  // namespace common
+namespace common {
+class SessionTemp;
+}  // namespace common
 
 // This class is used to map P4Runtime CloneSessionEntry messages to lower-level
 // PI operations. At the moment every clone session is associated to a multicast
 // group.
 class PreCloneMgr {
  public:
-  using Status = ::google::rpc::Status;
-  using CloneSession = ::p4::v1::CloneSessionEntry;
-  using CloneSessionId = uint32_t;
-  using SessionTemp = common::SessionTemp;
+    using Status = ::google::rpc::Status;
+    using CloneSession = ::p4::v1::CloneSessionEntry;
+    using CloneSessionId = uint32_t;
+    using SessionTemp = common::SessionTemp;
 
-  PreCloneMgr(pi_dev_tgt_t device_tgt, PreMcMgr* mc_mgr);
+    PreCloneMgr(pi_dev_tgt_t device_tgt, PreMcMgr *mc_mgr);
 
-  Status session_create(const CloneSession &clone_session,
-                        const SessionTemp &session);
-  Status session_modify(const CloneSession &clone_session,
-                        const SessionTemp &session);
-  Status session_delete(const CloneSession &clone_session,
-                        const SessionTemp &session);
-  Status session_read(const CloneSession &clone_session,
-                      const SessionTemp &session,
-                      ::p4::v1::ReadResponse *response) const;
+    Status session_create(const CloneSession &clone_session,
+                          const SessionTemp &session);
+    Status session_modify(const CloneSession &clone_session,
+                          const SessionTemp &session);
+    Status session_delete(const CloneSession &clone_session,
+                          const SessionTemp &session);
+    Status session_read(const CloneSession &clone_session,
+                        const SessionTemp &session,
+                        ::p4::v1::ReadResponse *response) const;
 
  private:
-  using Mutex = std::mutex;
-  using Lock = std::lock_guard<Mutex>;
+    using Mutex = std::mutex;
+    using Lock = std::lock_guard<Mutex>;
 
-  struct CloneSessionConfig {
-    uint32_t class_of_service;
-    int32_t packet_length_bytes;
+    struct CloneSessionConfig {
+        uint32_t class_of_service;
+        int32_t packet_length_bytes;
 
-    bool operator==(const CloneSessionConfig &other) const {
-      return class_of_service == other.class_of_service &&
-          packet_length_bytes == other.packet_length_bytes;
-    }
+        bool operator==(const CloneSessionConfig &other) const {
+            return class_of_service == other.class_of_service &&
+                   packet_length_bytes == other.packet_length_bytes;
+        }
 
-    bool operator!=(const CloneSessionConfig &other) const {
-      return !(*this == other);
-    }
-  };
+        bool operator!=(const CloneSessionConfig &other) const {
+            return !(*this == other);
+        }
+    };
 
-  // We set the max session ID value to 32768.
-  // This is the the max value supported by simple_switch, which reserves the left-most bit
-  // (https://github.com/p4lang/behavioral-model/blob/e9fa7dc687f334e5cf327e0c993fc1a351d224c0/targets/simple_switch/register_access.h#L46).
-  // Additionally, for clone sessions to more than 1 port, PI will program a multicast group.
-  // There may only be 32768 mgids available for this usage (with another 32768 reserved for
-  // user-defined multicast groups).
-  // TODO(antonin): Ideally, these values should be configurable based on the target.
-  // Other targets may support a different number of clone sessions.
-  static constexpr CloneSessionId kMinCloneSessionId = 1;
-  static constexpr CloneSessionId kMaxCloneSessionId = 32768;
+    // We set the max session ID value to 32768.
+    // This is the the max value supported by simple_switch,
+    // which reserves the left-most bit
+    // https://github.com/p4lang/behavioral-model/blob/
+    // e9fa7dc687f334e5cf327e0c993fc1a351d224c0/targets/simple_switch/register_access.h#L46
+    // Additionally, for clone sessions to more than 1 port, PI will program a
+    // multicast group. There may only be 32768 mgids available for this usage
+    // (with another 32768 reserved for user-defined multicast groups).
+    // TODO(antonin): Ideally, these values should be configurable based on the
+    // target. Other targets may support a different number of clone sessions.
+    static constexpr CloneSessionId kMinCloneSessionId = 1;
+    static constexpr CloneSessionId kMaxCloneSessionId = 32768;
 
-  Status session_set(const CloneSession &clone_session,
-                     PreMcMgr::GroupId mc_group_id,
-                     const SessionTemp &session);
+    Status session_set(const CloneSession &clone_session,
+                       PreMcMgr::GroupId mc_group_id,
+                       const SessionTemp &session);
 
-  static Status validate_session_id(CloneSessionId session_id);
+    static Status validate_session_id(CloneSessionId session_id);
 
-  static CloneSessionConfig make_clone_session_config(
-      const CloneSession &clone_session);
+    static CloneSessionConfig make_clone_session_config(
+        const CloneSession &clone_session);
 
-  pi_dev_tgt_t device_tgt;
-  PreMcMgr* mc_mgr;  // non-owning pointer
-  std::unordered_map<CloneSessionId, CloneSessionConfig> sessions{};
-  mutable Mutex mutex{};
+    pi_dev_tgt_t device_tgt;
+    PreMcMgr *mc_mgr;  // non-owning pointer
+    std::unordered_map<CloneSessionId, CloneSessionConfig> sessions{};
+    mutable Mutex mutex{};
 };
 
 }  // namespace proto

--- a/proto/frontend/src/pre_clone_mgr.h
+++ b/proto/frontend/src/pre_clone_mgr.h
@@ -83,7 +83,7 @@ class PreCloneMgr {
   // TODO(antonin): this should ideally be configurable based on te target but
   // these seem like a reasonnable place to start with.
   static constexpr CloneSessionId kMinCloneSessionId = 1;
-  static constexpr CloneSessionId kMaxCloneSessionId = 512;
+  static constexpr CloneSessionId kMaxCloneSessionId = 65536;
 
   Status session_set(const CloneSession &clone_session,
                      PreMcMgr::GroupId mc_group_id,


### PR DESCRIPTION
PI restricts the maximum clone session ID to 512, but this is a rather conservative number. Some P4 programs may use the full range of the `pi_clone_session_id_t` (which appears to be uint16_t) for the behavioral model. Increase the upper bound to 65535.