### PR TITLE
Upadate the README with instructions for installing  gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,16 @@ make
 git clone --depth=1 -b v1.43.2 https://github.com/google/grpc.git
 cd grpc/
 git submodule update --init --recursive
-make
-[sudo] make install
-[sudo] ldconfig
+mkdir -p "cmake/build"
+pushd "cmake/build"
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DgRPC_INSTALL=ON \
+  -DgRPC_BUILD_TESTS=OFF \
+  -DgRPC_SSL_PROVIDER=package \
+  ../..
+make -j4 install
+popd
 ```
 - [sysrepo](https://github.com/sysrepo/sysrepo) and all its dependencies: see
   instructions in [proto/README.md](proto/README.md)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ cmake \
   -DgRPC_BUILD_TESTS=OFF \
   -DgRPC_SSL_PROVIDER=package \
   ../..
-make -j4 install
+make
+[sudo] make install
 popd
 ```
 - [sysrepo](https://github.com/sysrepo/sysrepo) and all its dependencies: see


### PR DESCRIPTION
I recently attempted to install PI and found that the gRPC installation instructions in the README were outdated. gRPC can now only be installed via Bazel or CMake. The set of commands provided [here](https://github.com/grpc/grpc/blob/v1.43.2/test/distrib/cpp/run_distrib_test_cmake_module_install.sh#L29C3-L29C36) allowed me to successfully install gRPC and PI with the `./configure --with-proto`.

