### PR TITLE
Remove occurrence of word 'confidential' from a comment in docs

### DIFF
--- a/docs/bfn_latex.sty
+++ b/docs/bfn_latex.sty
@@ -24,6 +24,5 @@
 \fancyhead[R]{\sl\sffamily\footnotesize\textbf{\chaptermark}}
 \fancyfoot[L]{\sffamily\footnotesize\textbf{Barefoot Networks}}
 %\fancyfoot[C]{\sffamily\footnotesize\thepage}
-%\fancyfoot[R]{\sffamily\scriptsize\textbf{Company Confidential}}
 \fancyfoot[R]{\sffamily\footnotesize\thepage}
 \renewcommand\footrulewidth{.4pt}


### PR DESCRIPTION
I know this is only in a comment, and only for documentation, but one less occurrence of the word 'confidential' in p4lang repos makes it quicker to scan for occurrences of this in the future.