### PR TITLE
Temporarily pin Bazel build in CI to Ubuntu 22.04

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BAZEL: bazelisk-linux-amd64
     steps:


### PR DESCRIPTION
A similar change was made in the p4runtime repo recently, when ubuntu-latest changed from 22.04 to 24.04: https://github.com/p4lang/p4runtime/commit/a41e728e14682d3e3c651057a526edfed7b27a6f

until the Bazel build files could be updated to work for Ubuntu 24.04: https://github.com/p4lang/p4runtime/commit/da2e3441e1774112ecf44905ba8ef57d1b33c3e0