### PR TITLE
Add SPDX license id lines to those .m4 files that mention a license

### DIFF
--- a/frontends_extra/cpp/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/frontends_extra/cpp/m4/ax_cxx_compile_stdcxx_11.m4
@@ -27,6 +27,7 @@
 #   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
 #   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
 #   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/frontends_extra/cpp/m4/ax_pthread.m4
+++ b/frontends_extra/cpp/m4/ax_pthread.m4
@@ -55,6 +55,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -27,6 +27,7 @@
 #   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
 #   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
 #   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/m4/ax_prog_doxygen.m4
+++ b/m4/ax_prog_doxygen.m4
@@ -91,6 +91,7 @@
 #
 #   Copyright (c) 2009 Oren Ben-Kiki <oren@ben-kiki.org>
 #   Copyright (c) 2015 Olaf Mandel <olaf@mandel.name>
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -55,6 +55,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the

--- a/proto/m4/ax_boost_base.m4
+++ b/proto/m4/ax_boost_base.m4
@@ -27,6 +27,7 @@
 #
 #   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
 #   Copyright (c) 2009 Peter Adolphs
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/proto/m4/ax_boost_system.m4
+++ b/proto/m4/ax_boost_system.m4
@@ -25,6 +25,7 @@
 #   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
 #   Copyright (c) 2008 Michael Tindal
 #   Copyright (c) 2008 Daniel Casimiro <dan.casimiro@gmail.com>
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/proto/m4/ax_boost_thread.m4
+++ b/proto/m4/ax_boost_thread.m4
@@ -24,6 +24,7 @@
 #
 #   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
 #   Copyright (c) 2009 Michael Tindal
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/proto/m4/ax_compare_version.m4
+++ b/proto/m4/ax_compare_version.m4
@@ -73,6 +73,7 @@
 # LICENSE
 #
 #   Copyright (c) 2008 Tim Toolan <toolan@ele.uri.edu>
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/proto/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/proto/m4/ax_cxx_compile_stdcxx_11.m4
@@ -27,6 +27,7 @@
 #   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
 #   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
 #   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/proto/m4/ax_pthread.m4
+++ b/proto/m4/ax_pthread.m4
@@ -55,6 +55,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the

--- a/proto/m4/pkg.m4
+++ b/proto/m4/pkg.m4
@@ -3,6 +3,7 @@ dnl serial 11 (pkg-config-0.29.1)
 dnl
 dnl Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
 dnl Copyright © 2012-2015 Dan Nicholson <dbn.lists@gmail.com>
+dnl SPDX-License-Identifier: GPL-2.0-or-later
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by

--- a/targets/bmv2/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/targets/bmv2/m4/ax_cxx_compile_stdcxx_11.m4
@@ -27,6 +27,7 @@
 #   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
 #   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
 #   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   SPDX-License-Identifier: FSFAP
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/targets/bmv2/m4/ax_prefix_config_h.m4
+++ b/targets/bmv2/m4/ax_prefix_config_h.m4
@@ -87,6 +87,7 @@
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2008 Marten Svantesson
 #   Copyright (c) 2008 Gerald Point <Gerald.Point@labri.fr>
+#   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   This program is free software; you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the

--- a/targets/bmv2/m4/ax_pthread.m4
+++ b/targets/bmv2/m4/ax_pthread.m4
@@ -55,6 +55,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the


### PR DESCRIPTION
This does not change any licenses of any files -- it only adds their SPDX license id names to files that already have them.