### PR TITLE
Correct a bug with parsing PacketIn controller metadata

### DIFF
--- a/proto/frontend/src/packet_io_mgr.cpp
+++ b/proto/frontend/src/packet_io_mgr.cpp
@@ -182,6 +182,10 @@ class PacketInMutate {
       generic_extract(pkt, bit_offset, bitwidth, buffer.data());
       bit_offset += (bitwidth % 8);
       pkt += (bitwidth / 8);
+      if (bit_offset >= 8) {
+          pkt += (bit_offset / 8);
+          bit_offset = bit_offset % 8;
+      }
       metadata->set_value(bytestring_pi_to_p4rt(buffer.data(), buffer.size()));
     }
     return true;

--- a/proto/tests/test_proto_fe_packet_io.cpp
+++ b/proto/tests/test_proto_fe_packet_io.cpp
@@ -199,9 +199,9 @@ struct ValueIterator {
 class DeviceMgrPacketIOMetadataTest : public DeviceMgrPacketIOTest {
  public:
   static constexpr int num = 3;
-  static constexpr int bw1 = 2;
-  static constexpr int bw2 = 9;
-  static constexpr int bw3 = 5;
+  static constexpr int bw1 = 7;
+  static constexpr int bw2 = 7;
+  static constexpr int bw3 = 2;
   using VType = std::array<int, num>;
 
  protected:


### PR DESCRIPTION
The bug manifests itself if bit_offset becomes 8 or larger, which happens in some cases if there are multiple fields in the packet-in header that are not a multiple of 8 bits wide.