### PR TITLE
[bazel] Modify `includes` for `piserver`

### DIFF
--- a/proto/server/BUILD
+++ b/proto/server/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "gnmi.h",
         "pi_server_testing.h",
     ],
+    includes = ["."],
     deps = [
         "//proto:gnmi_cc_grpc",
         "//proto:p4serverconfig_cc_grpc",


### PR DESCRIPTION
BMv2 has following use case:

https://github.com/p4lang/behavioral-model/blob/044fccf9d40b04849f9f0d9b314f63678738ec25/targets/simple_switch_grpc/switch_runner.cpp#L31

We need this patch to expose the piserver's header files so that BMv2 can successfully build with Bazel without missing header/include errors.