### PR TITLE
Add license annotations for files already containing explicit copyright notice

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/proto/frontend/src/status_macros.h
+++ b/proto/frontend/src/status_macros.h
@@ -1,32 +1,9 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
 // https://developers.google.com/protocol-buffers/
+// SPDX-FileCopyrightText: 2008 Google Inc.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// SPDX-License-Identifier: BSD-3-Clause
 
 // Adpated from:
 // https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/stubs/status_macros.h

--- a/proto/yang/iana-if-type.yang.license
+++ b/proto/yang/iana-if-type.yang.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014 IETF Trust and the persons identified as authors of the code
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/proto/yang/ietf-inet-types@2013-07-15.yang.license
+++ b/proto/yang/ietf-inet-types@2013-07-15.yang.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 IETF Trust and the persons identified as authors of the code
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/proto/yang/ietf-interfaces@2014-05-08.yang.license
+++ b/proto/yang/ietf-interfaces@2014-05-08.yang.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014 IETF Trust and the persons identified as authors of the code
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/proto/yang/ietf-netconf-acm@2012-02-22.yang.license
+++ b/proto/yang/ietf-netconf-acm@2012-02-22.yang.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2012 IETF Trust and the persons identified as authors of the code
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/proto/yang/ietf-netconf-notifications.yang.license
+++ b/proto/yang/ietf-netconf-notifications.yang.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2012 IETF Trust and the persons identified as authors of the code
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/proto/yang/ietf-netconf@2011-06-01.yang.license
+++ b/proto/yang/ietf-netconf@2011-06-01.yang.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2011 IETF Trust and the persons identified as authors of the code
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/proto/yang/ietf-yang-types@2013-07-15.yang.license
+++ b/proto/yang/ietf-yang-types@2013-07-15.yang.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 IETF Trust and the persons identified as authors of the code
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/CLI/run_one_test.py.in
+++ b/tests/CLI/run_one_test.py.in
@@ -1,19 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2013 Barefoot Networks, Inc.
 # Copyright 2013-present Barefoot Networks, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# SPDX-License-Identifier: Apache-2.0
 
 #
 # Antonin Bas (antonin@barefootnetworks.com)

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -1,32 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2009 Google Inc.
+# Copyright (C) 2009 Google Inc. All rights reserved.
 #
-# Copyright (c) 2009 Google Inc. All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-#    * Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#    * Redistributions in binary form must reproduce the above
-# copyright notice, this list of conditions and the following disclaimer
-# in the documentation and/or other materials provided with the
-# distribution.
-#    * Neither the name of Google Inc. nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Does google-lint on c++ files.
 


### PR DESCRIPTION
I tracked down the license they used either from comments in the file itself, or from searching for the name of the YANG files on the Internet and finding out where they were originally published.  The IETF Trust is the copyright holder, and allows others to use them under a BSD-3-Clause license.