### PR TITLE
Fix build status badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PI LIBRARY REPOSITORY
 
-![Build Status](https://github.com/p4lang/PI/workflows/Test/badge.svg?branch=main)
+![Build Status](https://github.com/p4lang/PI/actions/workflows/test.yml/badge.svg?branch=main)
 
 **This repository has submodules; after cloning it you should run `git submodule
   update --init --recursive`.**


### PR DESCRIPTION
Same rationale as https://github.com/p4lang/behavioral-model/pull/1393.