### PR TITLE
Fix null pointer dereference in default idle-timeout notification

### DIFF
--- a/src/pi_tables.c
+++ b/src/pi_tables.c
@@ -467,8 +467,8 @@ pi_status_t pi_table_idle_timeout_notify(pi_dev_id_t dev_id,
   }
   const cb_data_t *default_cb_data = cb_mgr_get_default(&cb_mgr);
   if (default_cb_data->cb) {
-    ((PIIdleTimeoutCb)(default_cb_data->cb))(dev_id, table_id, match_key,
-                                             entry_handle, cb_data->cookie);
+    PIIdleTimeoutCb cb = (PIIdleTimeoutCb)default_cb_data->cb;
+    cb(dev_id, table_id, match_key, entry_handle, default_cb_data->cookie);
     pthread_mutex_unlock(&cb_mutex);
     return PI_STATUS_SUCCESS;
   }


### PR DESCRIPTION
## Description
This PR fixes a critical null pointer dereference bug in `pi_table_idle_timeout_notify` that causes a deterministic segmentation fault whenever only a default idle-timeout callback is registered.

### Problem
When a device-specific callback is not found, `cb_data` evaluates to `NULL`. The code appropriately falls back to checking for a global/default callback (`default_cb_data`). However, during the invocation of this default callback, the function mistakenly attempts to pass `cb_data->cookie` instead of `default_cb_data->cookie`. Because `cb_data` is known to be `NULL` at this point, it triggers a null pointer dereference.

### Solution
Updated the default callback invocation on line 471 to correctly reference `default_cb_data->cookie` instead of `cb_data->cookie`.

---

## Type of Change
- Bug fix (non-breaking change which fixes an issue)

