### PR TITLE
Fix vector remove element index

### DIFF
--- a/lib/vector.c
+++ b/lib/vector.c
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -94,7 +94,9 @@ void vector_remove(vector_t *v, size_t index) {
 
 void vector_remove_e(vector_t *v, void *e) {
   assert(e >= v->data);
-  size_t index = (char *)e - (char *)v->data;
+  size_t offset = (char *)e - (char *)v->data;
+  assert(offset % v->e_size == 0);
+  size_t index = offset / v->e_size;
   vector_remove(v, index);
 }
 


### PR DESCRIPTION
## Description
This PR addresses a severe bug in `vector_remove_e` where a byte offset is incorrectly passed as an element index to `vector_remove`, breaking element removal routines.

### Problem
In `lib/vector.c`, the `vector_remove_e` function calculates the position of an element pointer by subtracting `v->data` from `e`. This calculates a raw **byte offset**, not an element index. Passing this byte offset directly to `vector_remove` causes out-of-bounds asserts or memory corruption for any index greater than 0. This directly impacts core system behaviors such as device removal sequences (`src/pi.c:266`).

### Solution
- Divided the computed byte distance by `v->e_size` to calculate the actual item index.
- Added an explicit alignment assertion (`assert(offset % v->e_size == 0)`) to ensure the pointer target maps properly onto a clean element boundary.

---

## Type of Change
- Bug fix (non-breaking change which fixes an issue)
