### PR TITLE
fix(bmv2): use grp_handle instead of mbr_handle when serializing GRP_HANDLE entries in table fetch

### DIFF
--- a/targets/bmv2/pi_tables_imp.cpp
+++ b/targets/bmv2/pi_tables_imp.cpp
@@ -794,7 +794,7 @@ pi_status_t _pi_table_entries_fetch(pi_session_handle_t session_handle,
         {
           data += emit_action_entry_type(data, PI_ACTION_ENTRY_TYPE_INDIRECT);
           auto indirect_handle =
-              static_cast<pi_indirect_handle_t>(action_entry.mbr_handle);
+              static_cast<pi_indirect_handle_t>(action_entry.grp_handle);
           indirect_handle = pibmv2::IndirectHMgr::make_grp_h(indirect_handle);
           data += emit_indirect_handle(data, indirect_handle);
         }


### PR DESCRIPTION
# Description

## Summary

`_pi_table_entries_fetch()` in `targets/bmv2/pi_tables_imp.cpp` incorrectly reads `action_entry.mbr_handle` when serializing entries whose `action_type` is `BmActionEntryType::GRP_HANDLE`. It should read `action_entry.grp_handle`.

## Problem

When bulk-fetching match-action table entries (`_pi_table_entries_fetch`), each entry's indirect handle is serialized based on its `BmActionEntryType`:

```cpp
case BmActionEntryType::MBR_HANDLE:
  {
    ...
    auto indirect_handle =
        static_cast<pi_indirect_handle_t>(action_entry.mbr_handle);
    data += emit_indirect_handle(data, indirect_handle);
  }
  break;
case BmActionEntryType::GRP_HANDLE:
  {
    ...
    auto indirect_handle =
        static_cast<pi_indirect_handle_t>(action_entry.mbr_handle);  // BUG
    indirect_handle = pibmv2::IndirectHMgr::make_grp_h(indirect_handle);
    data += emit_indirect_handle(data, indirect_handle);
  }
  break;
```

For the `GRP_HANDLE` case, the code reads `mbr_handle` instead of `grp_handle` from the `BmActionEntry` Thrift union, then wraps that (wrong) value with `make_grp_h()`. The result is a handle tagged as a group handle but carrying the wrong underlying ID.

This is inconsistent with the rest of the file - `_pi_table_default_action_get()` already handles the two cases correctly:

```cpp
case BmActionEntryType::MBR_HANDLE:
  retrieve_indirect_entry(p4info, entry.mbr_handle, false, table_entry);
  break;
case BmActionEntryType::GRP_HANDLE:
  retrieve_indirect_entry(p4info, entry.grp_handle, true, table_entry);
  break;
```

## Impact

- Affects tables that use indirect action selectors (`ActionProfile` with a selector/group), specifically the bulk `_pi_table_entries_fetch` path.
- `_pi_table_default_action_get` is unaffected.
- A control plane fetching entries that point to action-selector groups will reconstruct the wrong group binding for those entries.

## Fix

Single-field correction in the `GRP_HANDLE` branch of `_pi_table_entries_fetch`:

```diff
       case BmActionEntryType::GRP_HANDLE:
         {
           data += emit_action_entry_type(data, PI_ACTION_ENTRY_TYPE_INDIRECT);
           auto indirect_handle =
-              static_cast<pi_indirect_handle_t>(action_entry.mbr_handle);
+              static_cast<pi_indirect_handle_t>(action_entry.grp_handle);
           indirect_handle = pibmv2::IndirectHMgr::make_grp_h(indirect_handle);
           data += emit_indirect_handle(data, indirect_handle);
         }
         break;
```
